### PR TITLE
Add CLAUDE.md Context Files for Agent Navigation (Vibe Kanban)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,104 @@
+# MovieNight — Agent Context
+
+A full-stack movie suggestion app: React + TypeScript frontend, Apollo GraphQL backend, PostgreSQL database. Containerized with Docker Compose.
+
+## Quick orientation
+
+| Layer | Location | Key files |
+|---|---|---|
+| Frontend | `src/` | `App.tsx`, `src/components/`, `src/graphql/queries.ts`, `src/contexts/AuthContext.tsx` |
+| Backend | `backend/src/` | `index.ts`, `schema.ts`, `resolvers.ts`, `db.ts`, `auth.ts` |
+| DB migrations | `backend/migrations/` | numbered JS files run by node-pg-migrate |
+| Docker | root | `docker-compose.yml`, `Dockerfile`, `nginx.conf` |
+| Backend Docker | `backend/` | `backend/Dockerfile` |
+
+## Running the project
+
+```bash
+# Start everything (recommended)
+docker-compose up -d
+# Frontend → http://localhost:3000
+# GraphQL  → http://localhost:4000/graphql
+# Postgres → localhost:5432
+
+# Local dev without Docker
+npm install && npm start            # frontend
+cd backend && npm install && npm run dev  # backend (needs Postgres separately)
+
+# Build
+npm run build                       # frontend (CRA)
+cd backend && npm run build         # backend (tsc)
+
+# Migrations (run automatically on backend startup)
+cd backend && npm run migrate:up
+cd backend && npm run migrate:down
+cd backend && npm run migrate:create <name>
+```
+
+## Architecture
+
+- **Frontend**: React 18 + TypeScript, Apollo Client 3, MUI Joy, Styled Components
+- **Backend**: Node 18/20, Apollo Server 4 + Express, pg (no ORM), bcrypt + JWT
+- **Database**: PostgreSQL 15
+- **Auth**: JWT (7-day expiry) stored in localStorage, sent as `Authorization: Bearer <token>`. Context injected per-request in `backend/src/index.ts`.
+- **Ranking**: Movies ordered by `rank NUMERIC(20,10)` using fractional indexing; new movies appended at `MAX(rank) + 1`.
+- **Polling**: `GET_MOVIES` query polls every 5 s (`pollInterval: 5000`).
+
+## GraphQL schema (brief)
+
+```graphql
+# Queries
+movies: [Movie!]!         # all movies ordered by rank
+movie(id: ID!): Movie
+me: User                  # requires auth
+users: [User!]!           # admin only
+user(id: ID!): User       # admin only
+
+# Mutations
+addMovie(title, requester): Movie!    # requires auth
+deleteMovie(id): Boolean!             # requires auth
+login(username, password): AuthPayload!
+createUser / updateUser / deleteUser  # admin only
+```
+
+All GraphQL operations are defined in `src/graphql/queries.ts`.
+
+## Key conventions
+
+- **No ORM** — raw SQL via `pg` pool (`backend/src/db.ts`). Use parameterised queries (`$1, $2, …`).
+- **Authorization** — check `context.user` (authenticated) or `context.user?.isAdmin` (admin) in resolvers; throw `GraphQLError` with appropriate `extensions.code`.
+- **Field resolvers** — timestamps returned from Postgres are converted to ISO 8601 in `Movie.date_submitted`, `User.created_at/updated_at` field resolvers in `resolvers.ts`.
+- **Frontend state** — auth state lives in `AuthContext`; movie/user data comes from Apollo cache.
+- **Component structure** — feature folders under `src/components/` (auth, home, admin, common).
+- **Env vars** — frontend uses `REACT_APP_*`; backend uses bare names. See `.env.example` / `backend/.env.example`.
+
+## Known bugs (as of inspection)
+
+| File | Line | Issue |
+|---|---|---|
+| `backend/src/schema.ts` | 30–33 | Duplicate `type Query { … }` block — inner block shadows some fields |
+| `backend/src/index.ts` | 33 | Duplicate `expressMiddleware(server)` call (missing comma / copy-paste) |
+| `src/index.tsx` | ~19 | `<App />` rendered twice in the provider tree |
+
+## Environment variables
+
+**Frontend** (`.env`):
+- `REACT_APP_GRAPHQL_URL` — defaults to `http://localhost:4000/graphql`
+
+**Backend** (`backend/.env`):
+- `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`
+- `PORT` (default 4000)
+- `JWT_SECRET` — **change in production**
+- `ADMIN_PASSWORD` — seeds the default admin user (default `admin123`, **change in production**)
+
+## CI/CD
+
+- `dev` branch push → `.github/workflows/test-build.yml` (build only, no push)
+- `master` branch push → `.github/workflows/deploy.yml` (build → push GHCR → SSH deploy to remote host on port 8080 at `/movienight/`)
+
+## Existing docs
+
+- `README.md` — quick-start and API examples
+- `AUTHENTICATION.md` — JWT flow, default credentials, user management
+- `DEPLOYMENT.md` — CI/CD setup, SSH keys, GHCR config
+- `backend/MIGRATIONS.md` — migration conventions

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,0 +1,63 @@
+# Backend — Agent Context
+
+Apollo Server 4 + Express + PostgreSQL. TypeScript, no ORM, raw `pg` queries.
+
+## Entry point & startup sequence
+
+`src/index.ts`:
+1. Create Express app + ApolloServer
+2. Mount `/graphql` with CORS, JSON body parser, `expressMiddleware` (JWT context)
+3. Call `initializeDatabase()` (runs migrations, seeds admin user)
+4. Listen on `PORT` (default 4000)
+
+> **Bug**: line 33 has a duplicate `expressMiddleware(server)` call without a comma — this is a syntax error that prevents compilation. Remove the duplicate line.
+
+## Source files
+
+| File | Purpose |
+|---|---|
+| `src/index.ts` | Server bootstrap, Express setup, JWT context injection |
+| `src/schema.ts` | GraphQL SDL (`typeDefs`). **Bug**: duplicate `type Query` block at lines 30–33 — remove it. |
+| `src/resolvers.ts` | All Query/Mutation resolvers + field resolvers for timestamp conversion |
+| `src/db.ts` | `pg.Pool` setup + `initializeDatabase()` (runs migrations, creates admin user) |
+| `src/auth.ts` | `hashPassword`, `comparePassword` (bcrypt), `generateToken`, `verifyToken` (JWT), `getTokenFromHeader` |
+| `src/models/User.ts` | TypeScript interfaces: `User`, `CreateUserInput`, `UpdateUserInput` |
+
+## Database
+
+- **Driver**: `pg` pool — import `pool` from `./db`, use `pool.query(sql, params)`.
+- **Parameterised queries only** — never interpolate user input into SQL strings.
+- **Tables**: `movies` (id, title, requester, date_submitted, rank), `users` (id, username, email, password_hash, is_admin, created_at, updated_at).
+- **Migrations**: `migrations/` directory, run via `node-pg-migrate`. File naming: `<timestamp>_<description>.js`.
+- New migration: `npm run migrate:create <name>` → edit the generated file → `npm run migrate:up`.
+
+## Auth pattern in resolvers
+
+```ts
+// Authenticated only
+if (!context.user) throw new GraphQLError('Not authenticated', { extensions: { code: 'UNAUTHENTICATED' } });
+
+// Admin only
+if (!context.user?.isAdmin) throw new GraphQLError('Not authorized', { extensions: { code: 'FORBIDDEN' } });
+```
+
+`context.user` shape (from `verifyToken`): `{ userId: number, isAdmin: boolean }`.
+
+## Ranking system
+
+Movies have a `rank NUMERIC(20,10)` column. Ordering: `ORDER BY rank ASC`. New movies: `MAX(rank) + 1`. For re-ordering between two items use a midpoint value (fractional indexing).
+
+## Scripts
+
+```bash
+npm run dev          # ts-node-dev with --respawn (hot reload)
+npm run build        # tsc → dist/
+npm start            # node dist/index.js
+npm run migrate:up
+npm run migrate:down
+npm run migrate:create <name>
+```
+
+## Docker
+
+`backend/Dockerfile` — Node 18 (build) + Node 20 Alpine (production). Runs migrations on container start via `CMD`.


### PR DESCRIPTION
## What changed

Added two `CLAUDE.md` files to give AI agents (and developers) fast, reliable orientation in the codebase:

- **`CLAUDE.md`** (root) — project-wide context: layer/file map, how to run/build/test, architecture summary, full GraphQL schema overview, key conventions (no ORM, parameterised queries, auth checks, field resolvers, env vars), known bugs table, and CI/CD pipeline summary.
- **`backend/CLAUDE.md`** — backend-specific context: startup sequence, source file purposes, database usage patterns, copy-pasteable auth resolver patterns, ranking system explanation, scripts, and Docker details.

## Why

Without these files, an agent exploring this repo must spend several tool-call rounds reading package.json, source files, and config to understand the stack and conventions. The CLAUDE.md files make that context immediately available at the start of every session, reducing wasted exploration and preventing agents from repeating known mistakes.

## Implementation details

- Content is scoped to what agents actually trip over: auth patterns, parameterised SQL requirement, timestamp field resolver behaviour, env var naming conventions, and the three existing known bugs (duplicate schema block, duplicate middleware call, double App render).
- Files are intentionally concise to fit within a context window.
- Root file links to existing docs (`AUTHENTICATION.md`, `DEPLOYMENT.md`, `backend/MIGRATIONS.md`) rather than duplicating them.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)