### PR TITLE
fix: remove duplicate expressMiddleware call causing TS build error

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -30,7 +30,6 @@ async function startServer() {
         return { user };
       },
     })
-    expressMiddleware(server)
   );
 
   await initializeDatabase();


### PR DESCRIPTION
Line 33 had a duplicate bare expressMiddleware(server) after the one with the auth context, with a missing comma between them, causing TS1005 (',' expected) at compile time.