### PR TITLE
Route GraphQL through nginx proxy instead of hardcoded localhost URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,9 +12,8 @@ DB_PASSWORD=movienight_pass
 BACKEND_PORT=4000
 
 # Frontend Configuration
-# Backend port — hostname is derived dynamically from the browser's current URL.
-# For dev this defaults to 4000. Set REACT_APP_GRAPHQL_URL to override the full URL.
-REACT_APP_BACKEND_PORT=4000
+# GraphQL requests go to /graphql (proxied by nginx to the backend).
+# Override only if the backend is on a different origin.
 # REACT_APP_GRAPHQL_URL=https://api.example.com/graphql
 
 # Port Mappings (host:container)

--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,10 @@ DB_PASSWORD=movienight_pass
 BACKEND_PORT=4000
 
 # Frontend Configuration
-REACT_APP_GRAPHQL_URL=http://localhost:4000/graphql
+# Backend port — hostname is derived dynamically from the browser's current URL.
+# For dev this defaults to 4000. Set REACT_APP_GRAPHQL_URL to override the full URL.
+REACT_APP_BACKEND_PORT=4000
+# REACT_APP_GRAPHQL_URL=https://api.example.com/graphql
 
 # Port Mappings (host:container)
 DB_EXTERNAL_PORT=5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,8 @@ services:
     container_name: movienight-frontend
     working_dir: /app
     environment:
-      REACT_APP_GRAPHQL_URL: ${REACT_APP_GRAPHQL_URL}
+      REACT_APP_BACKEND_PORT: ${REACT_APP_BACKEND_PORT:-4000}
+      REACT_APP_GRAPHQL_URL: ${REACT_APP_GRAPHQL_URL:-}
     ports:
       - "${FRONTEND_EXTERNAL_PORT}:3000"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,6 @@ services:
     container_name: movienight-frontend
     working_dir: /app
     environment:
-      REACT_APP_BACKEND_PORT: ${REACT_APP_BACKEND_PORT:-4000}
       REACT_APP_GRAPHQL_URL: ${REACT_APP_GRAPHQL_URL:-}
     ports:
       - "${FRONTEND_EXTERNAL_PORT}:3000"
@@ -77,6 +76,8 @@ services:
       - "8080:80"
     environment:
       - TZ=America/New_York
+    networks:
+      - frontend
     labels:
       - "com.movienight.app=true"
       - "com.movienight.version=1.0"

--- a/nginx.conf
+++ b/nginx.conf
@@ -34,6 +34,16 @@ server {
         }
     }
 
+    # Proxy GraphQL API to backend
+    location /graphql {
+        proxy_pass http://movienight-backend:4000/graphql;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Redirect root to /movienight/
     location = / {
         return 301 /movienight/;

--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -1,7 +1,14 @@
 import { ApolloClient, InMemoryCache, HttpLink, ApolloLink } from '@apollo/client';
 
+function getGraphQLUri(): string {
+  if (process.env.REACT_APP_GRAPHQL_URL) return process.env.REACT_APP_GRAPHQL_URL;
+  const { protocol, hostname } = window.location;
+  const port = process.env.REACT_APP_BACKEND_PORT || '4000';
+  return `${protocol}//${hostname}:${port}/graphql`;
+}
+
 const httpLink = new HttpLink({
-  uri: process.env.REACT_APP_GRAPHQL_URL || 'http://localhost:4000/graphql',
+  uri: getGraphQLUri(),
 });
 
 const authLink = new ApolloLink((operation, forward) => {

--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -1,14 +1,7 @@
 import { ApolloClient, InMemoryCache, HttpLink, ApolloLink } from '@apollo/client';
 
-function getGraphQLUri(): string {
-  if (process.env.REACT_APP_GRAPHQL_URL) return process.env.REACT_APP_GRAPHQL_URL;
-  const { protocol, hostname } = window.location;
-  const port = process.env.REACT_APP_BACKEND_PORT || '4000';
-  return `${protocol}//${hostname}:${port}/graphql`;
-}
-
 const httpLink = new HttpLink({
-  uri: getGraphQLUri(),
+  uri: process.env.REACT_APP_GRAPHQL_URL || '/graphql',
 });
 
 const authLink = new ApolloLink((operation, forward) => {


### PR DESCRIPTION
## Problem

The Apollo Client was hardcoded to `http://localhost:4000/graphql` as its fallback URL. In production, the app is served at a public domain via Traefik/nginx, but the browser was sending GraphQL requests to `localhost:4000` on the *client's machine* — which doesn't exist there.

Even `REACT_APP_GRAPHQL_URL` was set to a localhost URL in `.env.example`, meaning anyone setting up from that template would have the same broken behaviour in a remote/proxied deployment.

## Changes

### `src/graphql/client.ts`
Replace hardcoded `http://localhost:4000/graphql` fallback with `/graphql` — a relative, same-origin URL. The browser will send requests to whatever host/port the frontend is accessed on, and nginx proxies them internally to the backend.

### `nginx.conf`
Add a `/graphql` location block that proxies to `movienight-backend:4000`. This is the single place the backend address is configured — inside the server, not in the client bundle.

### `docker-compose.yml`
- Add the production `movienight` nginx service to the `frontend` Docker network so it can reach the `movienight-backend` container by name.
- Default `REACT_APP_GRAPHQL_URL` to empty string (`:-`) in the dev frontend service to avoid passing an unset variable as a literal.

### `.env.example`
Remove `REACT_APP_GRAPHQL_URL=http://localhost:4000/graphql`. No URL configuration is needed for standard deployments — only document it as an optional override for non-standard setups.

## Result

- GraphQL URL is configured in exactly one place: `nginx.conf`
- Works on any hostname without any environment variable changes
- `REACT_APP_GRAPHQL_URL` remains as an escape hatch for split-origin deployments