### PR TITLE
fix: exclude all .env.* variants from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,8 @@ build
 .git
 .gitignore
 .env
+.env.*
+!.env.example
 npm-debug.log
 .DS_Store
 backend


### PR DESCRIPTION
## Summary

- `.dockerignore` previously only excluded `.env`, leaving `.env.production`, `.env.local`, `.env.development`, etc. exposed to the Docker build context
- CRA reads these files at `npm run build` time, so any local env file with `REACT_APP_GRAPHQL_URL=http://localhost:4000/graphql` would get baked into the JS bundle
- This was the root cause of ISS-75 (app fetching localhost instead of the deployed domain for GraphQL)

## Changes

- Added `.env.*` to `.dockerignore` to exclude all CRA env file variants
- Added `!.env.example` to keep the example file accessible in the build context

## Test plan

- [ ] Verify Docker build succeeds without baking a localhost URL into the JS bundle
- [ ] Confirm `/graphql` is the URL in the built JS (`grep "/graphql" static/js/main.*.js`)
- [ ] Confirm GraphQL queries work on the deployed app

🤖 Generated with [Claude Code](https://claude.com/claude-code)