### PR TITLE
Auto-connect requester to logged-in user

### DIFF
--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -55,7 +55,14 @@ export const resolvers = {
     },
   },
   Mutation: {
-    addMovie: async (_: any, { title, requester }: { title: string; requester: string }) => {
+    addMovie: async (_: any, { title }: { title: string }, context: any) => {
+      if (!context.user) {
+        throw new GraphQLError('Not authenticated', {
+          extensions: { code: 'UNAUTHENTICATED' },
+        });
+      }
+      const requester = context.user.username;
+
       // Get the current max rank and add 1 to place new movie at the bottom
       const maxRankResult = await pool.query(
         'SELECT COALESCE(MAX(rank), 0) as max_rank FROM movies'

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -30,7 +30,7 @@ export const typeDefs = `#graphql
   }
 
   type Mutation {
-    addMovie(title: String!, requester: String!): Movie!
+    addMovie(title: String!): Movie!
     deleteMovie(id: ID!): Boolean!
     login(username: String!, password: String!): AuthPayload!
     createUser(username: String!, email: String!, password: String!, is_admin: Boolean): User!

--- a/src/components/home/Homepage.tsx
+++ b/src/components/home/Homepage.tsx
@@ -17,7 +17,6 @@ const StyledApp = styled.body`
 const HomePage: React.FC = () => {
   const { isAuthenticated } = useAuth();
   const [title, setTitle] = useState("");
-  const [requester, setRequester] = useState("");
   const [successMessage, setSuccessMessage] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
 
@@ -33,14 +32,13 @@ const HomePage: React.FC = () => {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (title && requester) {
+    if (title) {
       try {
         await addMovie({
-          variables: { title, requester },
+          variables: { title },
         });
         setSuccessMessage("Movie suggestion added successfully!");
         setTitle("");
-        setRequester("");
         setTimeout(() => {
           setSuccessMessage("");
         }, 3000);
@@ -68,12 +66,6 @@ const HomePage: React.FC = () => {
                   placeholder="Title"
                   value={title}
                   onChange={(e) => setTitle(e.target.value)}
-                />
-                <Input
-                  type="text"
-                  placeholder="Requester"
-                  value={requester}
-                  onChange={(e) => setRequester(e.target.value)}
                 />
                 <Button type="submit">Submit</Button>
               </Stack>

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -25,8 +25,8 @@ export const GET_MOVIE = gql`
 `;
 
 export const ADD_MOVIE = gql`
-  mutation AddMovie($title: String!, $requester: String!) {
-    addMovie(title: $title, requester: $requester) {
+  mutation AddMovie($title: String!) {
+    addMovie(title: $title) {
       id
       title
       requester


### PR DESCRIPTION
## Summary
- Removed the manual `Requester` text input from the Add Movie form
- `addMovie` mutation no longer accepts a `requester` argument
- Backend resolver now derives the requester from the authenticated user's JWT token (`context.user.username`)
- Added authentication check in the resolver — unauthenticated requests are rejected with `UNAUTHENTICATED` error

## Test plan
- [ ] Log in and submit a movie — verify the requester column shows your username automatically
- [ ] Confirm the Requester input field is gone from the form
- [ ] Verify that the movie list still displays the requester column correctly
- [ ] (Optional) Try calling `addMovie` without a token via GraphQL playground — should get UNAUTHENTICATED error

🤖 Generated with [Claude Code](https://claude.com/claude-code)