### PR TITLE
feat: add footer with copyright and git build info

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            REACT_APP_GIT_BRANCH=${{ github.ref_name }}
+            REACT_APP_GIT_HASH=${{ github.sha }}
 
       - name: Image digest
         run: echo ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,12 @@ RUN npm ci --ignore-scripts
 # Copy application source
 COPY . .
 
+# Git info baked into the bundle at build time
+ARG REACT_APP_GIT_BRANCH=unknown
+ARG REACT_APP_GIT_HASH=unknown
+ENV REACT_APP_GIT_BRANCH=$REACT_APP_GIT_BRANCH
+ENV REACT_APP_GIT_HASH=$REACT_APP_GIT_HASH
+
 # Build the application (creates /app/build directory)
 RUN npm run build
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import HomePage from "./components/home/Homepage";
 import { Login } from "./components/auth/Login";
 import { UserManagement } from "./components/admin/UserManagement";
 import { Navbar } from "./components/common/Navbar";
+import { Footer } from "./components/common/Footer";
 import { useAuth } from "./contexts/AuthContext";
 
 const App = () => {
@@ -24,7 +25,7 @@ const App = () => {
   }
 
   return (
-    <Box>
+    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
       <Navbar
         showUserManagement={showUserManagement}
         onShowMovies={() => setShowUserManagement(false)}
@@ -39,6 +40,8 @@ const App = () => {
       ) : (
         <HomePage />
       )}
+
+      <Footer />
     </Box>
   );
 };

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Box, Typography } from "@mui/joy";
+
+const GIT_BRANCH = process.env.REACT_APP_GIT_BRANCH;
+const GIT_HASH = process.env.REACT_APP_GIT_HASH;
+
+export const Footer: React.FC = () => {
+  const year = new Date().getFullYear();
+
+  return (
+    <Box
+      component="footer"
+      sx={{
+        mt: "auto",
+        py: 2,
+        textAlign: "center",
+        borderTop: "1px solid",
+        borderColor: "divider",
+      }}
+    >
+      <Typography level="body-xs">
+        &copy; {year} MovieNight. All rights reserved.
+      </Typography>
+      {(GIT_BRANCH || GIT_HASH) && (
+        <Typography level="body-xs" sx={{ color: "neutral.400", mt: 0.5 }}>
+          {GIT_BRANCH && <>branch: {GIT_BRANCH}</>}
+          {GIT_BRANCH && GIT_HASH && " · "}
+          {GIT_HASH && <>commit: {GIT_HASH.slice(0, 7)}</>}
+        </Typography>
+      )}
+    </Box>
+  );
+};


### PR DESCRIPTION
## Summary

- Adds a `Footer` component displaying copyright and muted git branch/commit info
- Git details (`REACT_APP_GIT_BRANCH`, `REACT_APP_GIT_HASH`) are baked into the bundle at Docker build time
- Deploy workflow passes `github.ref_name` and `github.sha` as build-args automatically
- Footer is hidden gracefully in local dev (vars not set)

## Test plan

- [ ] Local dev: footer shows copyright only (no git info block)
- [ ] Docker build with `--build-arg REACT_APP_GIT_BRANCH=master --build-arg REACT_APP_GIT_HASH=<sha>`: footer shows both lines
- [ ] Deploy via CI: footer shows correct branch and 7-char commit hash in muted text

🤖 Generated with [Claude Code](https://claude.com/claude-code)