### PR TITLE
ci: only run test deploy for non-draft PRs

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -1,9 +1,8 @@
 name: Deploy Test Branch
 
 on:
-  push:
-    branches-ignore:
-      - master
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 env:
@@ -15,6 +14,7 @@ jobs:
   build-and-push:
     name: Build and Push Test Images
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary
- Replace `push` trigger with `pull_request` trigger (types: opened, synchronize, reopened, ready_for_review)
- Add `if: github.event.pull_request.draft == false` guard to prevent deploys on draft PRs
- `workflow_dispatch` still bypasses the draft check for manual triggers

## Test plan
- [ ] Push to a branch with no PR open — workflow should not trigger
- [ ] Open a draft PR — workflow should not trigger
- [ ] Mark draft PR as ready for review — workflow should trigger
- [ ] Push to a branch with an open non-draft PR — workflow should trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)