### PR TITLE
ci: force-recreate containers on deploy to fix stale overlay2 state

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,8 +95,8 @@ jobs:
             # Pull new images
             docker compose -f "$COMPOSE_FILE" pull movienight-frontend movienight-backend
 
-            # Restart all services with new images
-            docker compose -f "$COMPOSE_FILE" up -d
+            # Restart all services with new images; --force-recreate avoids stale container state
+            docker compose -f "$COMPOSE_FILE" up -d --force-recreate
 
             # Clean up dangling images
             docker image prune -f


### PR DESCRIPTION
## Summary
- Master deploy was failing because `movienight-db` had a corrupted overlay2 filesystem layer on the remote host
- Docker could not mount the postgres volume into the stale container, causing every deploy to fail at startup
- Added `--force-recreate` to `docker compose up -d` so all containers are torn down and recreated cleanly on each deploy

## Test plan
- [ ] Manually remove the broken container on the host: `docker rm -f movienight-db`
- [ ] Retrigger the master deploy workflow and confirm all containers come up
- [ ] Verify subsequent deploys succeed without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)