### PR TITLE
fix: improve login error messages for network and auth failures

### DIFF
--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -24,7 +24,25 @@ export const Login: React.FC = () => {
       setError('');
     },
     onError: (err) => {
-      setError(err.message || 'Login failed. Please check your credentials.');
+      if (err.networkError) {
+        const status = (err.networkError as any)?.statusCode;
+        if (status === 502 || status === 503 || status === 504) {
+          setError('Server is temporarily unavailable. Please try again in a moment.');
+        } else {
+          setError('Cannot connect to the server. Please check your connection and try again.');
+        }
+      } else if (err.graphQLErrors?.length) {
+        const code = err.graphQLErrors[0]?.extensions?.code;
+        if (code === 'UNAUTHENTICATED') {
+          setError('Incorrect username or password.');
+        } else if (code === 'FORBIDDEN') {
+          setError('Your account has been disabled. Please contact an administrator.');
+        } else {
+          setError('Login failed. Please try again.');
+        }
+      } else {
+        setError('Login failed. Please try again.');
+      }
     },
   });
 


### PR DESCRIPTION
## Summary
- Maps raw Apollo/HTTP errors to user-friendly messages on the login screen
- 502/503/504 responses show "Server is temporarily unavailable" instead of the raw HTTP error
- Wrong credentials show "Incorrect username or password" instead of `Invalid credentials`
- Disabled accounts show a message to contact an administrator
- Network failures show a connection hint

## Context
Diagnosed alongside a login 502 issue caused by `movienight-db` container being in `Created` (never-started) state, making the backend crash-loop. Credentials are unchanged — DB just needs to be started from the host.

## Test plan
- [ ] Verify wrong credentials shows friendly message
- [ ] Verify server-down scenario shows "temporarily unavailable" (stop backend, attempt login)
- [ ] Verify disabled account shows admin-contact message
- [ ] Verify successful login still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)