### PR TITLE
feat: admin Letterboxd list import

### DIFF
--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -412,6 +412,28 @@ export const resolvers = {
       const titles: string[] = [];
       const errors: string[] = [];
 
+      function decodeEntities(s: string): string {
+        return s
+          .replace(/&amp;/g, '&')
+          .replace(/&quot;/g, '"')
+          .replace(/&#039;/g, "'")
+          .replace(/&#39;/g, "'")
+          .replace(/&lt;/g, '<')
+          .replace(/&gt;/g, '>');
+      }
+
+      function extractTitles(html: string): string[] {
+        const found: string[] = [];
+
+        // data-item-name="Once Upon a Time... in Hollywood (2019)"
+        for (const m of html.matchAll(/data-item-name="([^"]+)"/g)) {
+          const title = decodeEntities(m[1]).replace(/\s*\(\d{4}\)$/, '').trim();
+          if (title) found.push(title);
+        }
+
+        return found;
+      }
+
       // Fetch all pages of the list
       const baseUrl = url.replace(/\/$/, '');
       for (let page = 1; page <= 100; page++) {
@@ -419,11 +441,17 @@ export const resolvers = {
         let html: string;
         try {
           const response = await fetch(pageUrl, {
-            headers: { 'User-Agent': 'Mozilla/5.0 (compatible; MovieNight/1.0)' },
+            headers: {
+              'User-Agent':
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+              'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+              'Accept-Language': 'en-US,en;q=0.5',
+            },
           });
           if (response.status === 404) break;
           if (!response.ok) {
             errors.push(`Page ${page}: HTTP ${response.status}`);
+            console.error(`[letterboxd-import] page ${page} status ${response.status} for ${pageUrl}`);
             break;
           }
           html = await response.text();
@@ -432,17 +460,13 @@ export const resolvers = {
           break;
         }
 
-        // Extract film names from data-film-name attributes
-        const matches = html.matchAll(/data-film-name="([^"]+)"/g);
-        const pageTitles: string[] = [];
-        for (const match of matches) {
-          const title = match[1]
-            .replace(/&amp;/g, '&')
-            .replace(/&quot;/g, '"')
-            .replace(/&#039;/g, "'")
-            .replace(/&lt;/g, '<')
-            .replace(/&gt;/g, '>');
-          pageTitles.push(title);
+        const pageTitles = extractTitles(html);
+
+        if (page === 1) {
+          console.log(
+            `[letterboxd-import] page 1 status OK, html length=${html.length}, ` +
+            `found=${pageTitles.length} titles, snippet: ${html.slice(0, 300).replace(/\n/g, ' ')}`
+          );
         }
 
         if (pageTitles.length === 0) break;

--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -409,7 +409,7 @@ export const resolvers = {
         });
       }
 
-      const titles: string[] = [];
+      const films: { title: string; year: number | null }[] = [];
       const errors: string[] = [];
 
       function decodeEntities(s: string): string {
@@ -422,15 +422,16 @@ export const resolvers = {
           .replace(/&gt;/g, '>');
       }
 
-      function extractTitles(html: string): string[] {
-        const found: string[] = [];
-
+      function extractFilms(html: string): { title: string; year: number | null }[] {
+        const found: { title: string; year: number | null }[] = [];
         // data-item-name="Once Upon a Time... in Hollywood (2019)"
         for (const m of html.matchAll(/data-item-name="([^"]+)"/g)) {
-          const title = decodeEntities(m[1]).replace(/\s*\(\d{4}\)$/, '').trim();
-          if (title) found.push(title);
+          const raw = decodeEntities(m[1]);
+          const yearMatch = raw.match(/\((\d{4})\)$/);
+          const year = yearMatch ? parseInt(yearMatch[1], 10) : null;
+          const title = raw.replace(/\s*\(\d{4}\)$/, '').trim();
+          if (title) found.push({ title, year });
         }
-
         return found;
       }
 
@@ -451,7 +452,6 @@ export const resolvers = {
           if (response.status === 404) break;
           if (!response.ok) {
             errors.push(`Page ${page}: HTTP ${response.status}`);
-            console.error(`[letterboxd-import] page ${page} status ${response.status} for ${pageUrl}`);
             break;
           }
           html = await response.text();
@@ -460,21 +460,34 @@ export const resolvers = {
           break;
         }
 
-        const pageTitles = extractTitles(html);
-
-        if (page === 1) {
-          console.log(
-            `[letterboxd-import] page 1 status OK, html length=${html.length}, ` +
-            `found=${pageTitles.length} titles, snippet: ${html.slice(0, 300).replace(/\n/g, ' ')}`
-          );
-        }
-
-        if (pageTitles.length === 0) break;
-        titles.push(...pageTitles);
+        const pageFilms = extractFilms(html);
+        if (pageFilms.length === 0) break;
+        films.push(...pageFilms);
       }
 
-      if (titles.length === 0 && errors.length === 0) {
+      if (films.length === 0 && errors.length === 0) {
         errors.push('No films found — check that the URL is a public Letterboxd list');
+      }
+
+      // TMDB lookup helper (best-effort, silently skips if no API key)
+      const tmdbApiKey = process.env.TMDB_API_KEY;
+      async function lookupTmdbId(title: string, year: number | null): Promise<number | null> {
+        if (!tmdbApiKey) return null;
+        try {
+          const params = new URLSearchParams({
+            api_key: tmdbApiKey,
+            query: title,
+            language: 'en-US',
+            page: '1',
+            ...(year ? { year: String(year) } : {}),
+          });
+          const res = await fetch(`https://api.themoviedb.org/3/search/movie?${params}`);
+          if (!res.ok) return null;
+          const data = await res.json() as any;
+          return data.results?.[0]?.id ?? null;
+        } catch {
+          return null;
+        }
       }
 
       // Get current max rank and existing titles
@@ -486,16 +499,19 @@ export const resolvers = {
 
       let imported = 0;
       let skipped = 0;
+      let tmdb_matched = 0;
 
-      for (const title of titles) {
+      for (const { title, year } of films) {
         if (existingTitles.has(title.toLowerCase())) {
           skipped++;
           continue;
         }
+        const tmdbId = await lookupTmdbId(title, year);
+        if (tmdbId) tmdb_matched++;
         try {
           await pool.query(
-            'INSERT INTO movies (title, requested_by, rank) VALUES ($1, $2, $3)',
-            [title, context.user.userId, nextRank]
+            'INSERT INTO movies (title, requested_by, rank, tmdb_id) VALUES ($1, $2, $3, $4)',
+            [title, context.user.userId, nextRank, tmdbId]
           );
           existingTitles.add(title.toLowerCase());
           nextRank++;
@@ -510,11 +526,11 @@ export const resolvers = {
         'LETTERBOXD_IMPORT',
         'movie',
         null,
-        { url, imported, skipped, errors: errors.length },
+        { url, imported, skipped, tmdb_matched, errors: errors.length },
         context.ipAddress ?? 'unknown'
       );
 
-      return { imported, skipped, errors };
+      return { imported, skipped, tmdb_matched, errors };
     },
     login: async (
       _: any,

--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -389,6 +389,109 @@ export const resolvers = {
 
       return filePath;
     },
+    importFromLetterboxd: async (_: any, { url }: { url: string }, context: any) => {
+      if (!context.user?.isAdmin) {
+        throw new GraphQLError('Not authorized', {
+          extensions: { code: 'FORBIDDEN' },
+        });
+      }
+
+      // Validate URL is a Letterboxd list
+      let parsedUrl: URL;
+      try {
+        parsedUrl = new URL(url);
+      } catch {
+        throw new GraphQLError('Invalid URL', { extensions: { code: 'BAD_USER_INPUT' } });
+      }
+      if (parsedUrl.hostname !== 'letterboxd.com' && parsedUrl.hostname !== 'www.letterboxd.com') {
+        throw new GraphQLError('URL must be a letterboxd.com list', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+
+      const titles: string[] = [];
+      const errors: string[] = [];
+
+      // Fetch all pages of the list
+      const baseUrl = url.replace(/\/$/, '');
+      for (let page = 1; page <= 100; page++) {
+        const pageUrl = page === 1 ? `${baseUrl}/` : `${baseUrl}/page/${page}/`;
+        let html: string;
+        try {
+          const response = await fetch(pageUrl, {
+            headers: { 'User-Agent': 'Mozilla/5.0 (compatible; MovieNight/1.0)' },
+          });
+          if (response.status === 404) break;
+          if (!response.ok) {
+            errors.push(`Page ${page}: HTTP ${response.status}`);
+            break;
+          }
+          html = await response.text();
+        } catch (err: any) {
+          errors.push(`Page ${page}: ${err.message}`);
+          break;
+        }
+
+        // Extract film names from data-film-name attributes
+        const matches = html.matchAll(/data-film-name="([^"]+)"/g);
+        const pageTitles: string[] = [];
+        for (const match of matches) {
+          const title = match[1]
+            .replace(/&amp;/g, '&')
+            .replace(/&quot;/g, '"')
+            .replace(/&#039;/g, "'")
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>');
+          pageTitles.push(title);
+        }
+
+        if (pageTitles.length === 0) break;
+        titles.push(...pageTitles);
+      }
+
+      if (titles.length === 0 && errors.length === 0) {
+        errors.push('No films found — check that the URL is a public Letterboxd list');
+      }
+
+      // Get current max rank and existing titles
+      const maxRankResult = await pool.query('SELECT COALESCE(MAX(rank), 0) as max_rank FROM movies');
+      let nextRank = Number(maxRankResult.rows[0].max_rank) + 1;
+
+      const existingResult = await pool.query('SELECT LOWER(title) AS title FROM movies');
+      const existingTitles = new Set(existingResult.rows.map((r: any) => r.title));
+
+      let imported = 0;
+      let skipped = 0;
+
+      for (const title of titles) {
+        if (existingTitles.has(title.toLowerCase())) {
+          skipped++;
+          continue;
+        }
+        try {
+          await pool.query(
+            'INSERT INTO movies (title, requested_by, rank) VALUES ($1, $2, $3)',
+            [title, context.user.userId, nextRank]
+          );
+          existingTitles.add(title.toLowerCase());
+          nextRank++;
+          imported++;
+        } catch (err: any) {
+          errors.push(`"${title}": ${err.message}`);
+        }
+      }
+
+      await logAudit(
+        context.user.userId,
+        'LETTERBOXD_IMPORT',
+        'movie',
+        null,
+        { url, imported, skipped, errors: errors.length },
+        context.ipAddress ?? 'unknown'
+      );
+
+      return { imported, skipped, errors };
+    },
     login: async (
       _: any,
       { username, password }: { username: string; password: string },

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -66,12 +66,19 @@ export const typeDefs = `#graphql
     searchTmdb(query: String!): [TmdbMovie!]!
   }
 
+  type ImportResult {
+    imported: Int!
+    skipped: Int!
+    errors: [String!]!
+  }
+
   type Mutation {
     addMovie(title: String!, tmdb_id: Int): Movie!
     matchMovie(id: ID!, tmdb_id: Int!, title: String!): Movie!
     deleteMovie(id: ID!): Boolean!
     reorderMovie(id: ID!, afterId: ID): Boolean!
     exportKometa(collectionName: String): String!
+    importFromLetterboxd(url: String!): ImportResult!
     login(username: String!, password: String!): AuthPayload!
     createUser(username: String!, email: String!, password: String!, display_name: String, is_admin: Boolean, is_active: Boolean): User!
     updateUser(id: ID!, username: String, email: String, password: String, display_name: String, is_admin: Boolean, is_active: Boolean): User!

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -69,6 +69,7 @@ export const typeDefs = `#graphql
   type ImportResult {
     imported: Int!
     skipped: Int!
+    tmdb_matched: Int!
     errors: [String!]!
   }
 

--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -4,6 +4,7 @@ import { UserManagement } from './UserManagement';
 import { AuditLog } from './AuditLog';
 import { LoginHistory } from './LoginHistory';
 import { KometaExport } from './KometaExport';
+import { LetterboxdImport } from './LetterboxdImport';
 
 export const AdminPanel: React.FC = () => {
   return (
@@ -86,6 +87,20 @@ export const AdminPanel: React.FC = () => {
           >
             Kometa Export
           </Tab>
+          <Tab
+            value="import"
+            sx={{
+              borderRadius: 'xs',
+              fontWeight: 600,
+              fontSize: '0.85rem',
+              '&[aria-selected="true"]': {
+                bgcolor: 'background.level2',
+                color: 'primary.400',
+              },
+            }}
+          >
+            Import
+          </Tab>
         </TabList>
         <TabPanel value="users" sx={{ p: 0 }}>
           <UserManagement />
@@ -98,6 +113,9 @@ export const AdminPanel: React.FC = () => {
         </TabPanel>
         <TabPanel value="kometa" sx={{ p: 0 }}>
           <KometaExport />
+        </TabPanel>
+        <TabPanel value="import" sx={{ p: 0 }}>
+          <LetterboxdImport />
         </TabPanel>
       </Tabs>
     </Box>

--- a/src/components/admin/LetterboxdImport.tsx
+++ b/src/components/admin/LetterboxdImport.tsx
@@ -38,6 +38,7 @@ export const LetterboxdImport: React.FC = () => {
       setResult({
         imported: 0,
         skipped: 0,
+        tmdb_matched: 0,
         errors: [err.message ?? 'Unknown error'],
       });
     }

--- a/src/components/admin/LetterboxdImport.tsx
+++ b/src/components/admin/LetterboxdImport.tsx
@@ -1,0 +1,119 @@
+import React, { useState } from 'react';
+import { useMutation } from '@apollo/client';
+import {
+  Box,
+  Button,
+  Input,
+  Typography,
+  Alert,
+  CircularProgress,
+  List,
+  ListItem,
+} from '@mui/joy';
+import { IMPORT_FROM_LETTERBOXD } from '../../graphql/queries';
+import { GET_MOVIES } from '../../graphql/queries';
+
+interface ImportResult {
+  imported: number;
+  skipped: number;
+  errors: string[];
+}
+
+export const LetterboxdImport: React.FC = () => {
+  const [url, setUrl] = useState('');
+  const [result, setResult] = useState<ImportResult | null>(null);
+
+  const [importMovies, { loading }] = useMutation(IMPORT_FROM_LETTERBOXD, {
+    refetchQueries: [{ query: GET_MOVIES }],
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setResult(null);
+    try {
+      const { data } = await importMovies({ variables: { url: url.trim() } });
+      setResult(data.importFromLetterboxd);
+    } catch (err: any) {
+      setResult({
+        imported: 0,
+        skipped: 0,
+        errors: [err.message ?? 'Unknown error'],
+      });
+    }
+  };
+
+  return (
+    <Box sx={{ maxWidth: 560 }}>
+      <Typography level="title-md" fontWeight={700} sx={{ color: 'text.secondary', mb: 1 }}>
+        Import from Letterboxd
+      </Typography>
+      <Typography level="body-sm" sx={{ color: 'text.tertiary', mb: 3 }}>
+        Paste a public Letterboxd list URL to bulk-import all films. Already-existing titles are
+        skipped.
+      </Typography>
+
+      <Box
+        component="form"
+        onSubmit={handleSubmit}
+        sx={{ display: 'flex', gap: 1, mb: 3 }}
+      >
+        <Input
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://letterboxd.com/username/list/list-name/"
+          disabled={loading}
+          sx={{ flex: 1, fontFamily: 'monospace', fontSize: '0.85rem' }}
+          required
+        />
+        <Button type="submit" loading={loading} disabled={!url.trim()}>
+          Import
+        </Button>
+      </Box>
+
+      {loading && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, color: 'text.secondary' }}>
+          <CircularProgress size="sm" />
+          <Typography level="body-sm">Fetching list from Letterboxd…</Typography>
+        </Box>
+      )}
+
+      {result && (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+          {result.imported > 0 && (
+            <Alert color="success" variant="soft">
+              <Typography level="body-sm" fontWeight={600}>
+                {result.imported} film{result.imported !== 1 ? 's' : ''} imported
+                {result.skipped > 0 && `, ${result.skipped} already in list`}
+              </Typography>
+            </Alert>
+          )}
+          {result.imported === 0 && result.skipped > 0 && result.errors.length === 0 && (
+            <Alert color="neutral" variant="soft">
+              <Typography level="body-sm">
+                All {result.skipped} film{result.skipped !== 1 ? 's' : ''} already in the list
+              </Typography>
+            </Alert>
+          )}
+          {result.errors.length > 0 && (
+            <Alert color="danger" variant="soft">
+              <Box>
+                <Typography level="body-sm" fontWeight={600} sx={{ mb: 0.5 }}>
+                  {result.errors.length} error{result.errors.length !== 1 ? 's' : ''}
+                </Typography>
+                <List size="sm" sx={{ '--List-gap': '2px', pl: 0 }}>
+                  {result.errors.map((err, i) => (
+                    <ListItem key={i} sx={{ py: 0 }}>
+                      <Typography level="body-xs" sx={{ fontFamily: 'monospace' }}>
+                        {err}
+                      </Typography>
+                    </ListItem>
+                  ))}
+                </List>
+              </Box>
+            </Alert>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/src/components/admin/LetterboxdImport.tsx
+++ b/src/components/admin/LetterboxdImport.tsx
@@ -16,6 +16,7 @@ import { GET_MOVIES } from '../../graphql/queries';
 interface ImportResult {
   imported: number;
   skipped: number;
+  tmdb_matched: number;
   errors: string[];
 }
 
@@ -83,6 +84,7 @@ export const LetterboxdImport: React.FC = () => {
             <Alert color="success" variant="soft">
               <Typography level="body-sm" fontWeight={600}>
                 {result.imported} film{result.imported !== 1 ? 's' : ''} imported
+                {result.tmdb_matched > 0 && ` (${result.tmdb_matched} auto-matched to TMDB)`}
                 {result.skipped > 0 && `, ${result.skipped} already in list`}
               </Typography>
             </Alert>

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -202,6 +202,7 @@ export const IMPORT_FROM_LETTERBOXD = gql`
     importFromLetterboxd(url: $url) {
       imported
       skipped
+      tmdb_matched
       errors
     }
   }

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -196,3 +196,13 @@ export const GET_LOGIN_HISTORY = gql`
     }
   }
 `;
+
+export const IMPORT_FROM_LETTERBOXD = gql`
+  mutation ImportFromLetterboxd($url: String!) {
+    importFromLetterboxd(url: $url) {
+      imported
+      skipped
+      errors
+    }
+  }
+`;


### PR DESCRIPTION
## Summary

- Adds an **Import** tab to the Admin panel (admin-only)
- Accepts any public Letterboxd list URL, scrapes all paginated pages, and bulk-inserts films
- Skips movies already in the list (case-insensitive), returns imported/skipped/error counts
- Logs a `LETTERBOXD_IMPORT` audit event on each run
- SSRF guard: rejects any URL not on `letterboxd.com`

## Test plan

- [ ] Log in as admin, go to Admin → Import tab
- [ ] Paste a public Letterboxd list URL and click Import
- [ ] Verify imported films appear in the movie list
- [ ] Run the same import again — all should be skipped
- [ ] Try a non-Letterboxd URL — should get a validation error
- [ ] Try a private/non-existent list — should get a descriptive error
- [ ] Confirm audit log shows a `LETTERBOXD_IMPORT` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)