### PR TITLE
fix: use collection_order: release in Kometa export

### DIFF
--- a/src/components/admin/KometaExport.tsx
+++ b/src/components/admin/KometaExport.tsx
@@ -26,7 +26,6 @@ function generateKometaYaml(movies: Movie[], collectionName: string): string {
     `  ${collectionName}:\n` +
     `    tmdb_movie:\n` +
     `${idLines}\n` +
-    `    collection_order: release\n` +
     `    sync_mode: sync\n` +
     `    radarr_add_missing: true\n` +
     `    radarr_search: true\n` +

--- a/src/components/admin/KometaExport.tsx
+++ b/src/components/admin/KometaExport.tsx
@@ -26,7 +26,7 @@ function generateKometaYaml(movies: Movie[], collectionName: string): string {
     `  ${collectionName}:\n` +
     `    tmdb_movie:\n` +
     `${idLines}\n` +
-    `    collection_order: custom\n` +
+    `    collection_order: release\n` +
     `    sync_mode: sync\n` +
     `    radarr_add_missing: true\n` +
     `    radarr_search: true\n` +
@@ -98,8 +98,8 @@ export const KometaExport: React.FC = () => {
 
       <Typography level="body-sm" sx={{ color: 'text.tertiary', mb: 2 }}>
         Generates a Kometa collection file using{' '}
-        <code>tmdb_movie</code> + <code>collection_order: custom</code> to
-        preserve the current ranked order in Plex.{' '}
+        <code>tmdb_movie</code> + <code>collection_order: release</code> sorted
+        by release date.{' '}
         <strong>Write to Kometa</strong> writes directly to the configured{' '}
         <code>KOMETA_COLLECTIONS_PATH</code> on the server.
       </Typography>


### PR DESCRIPTION
## Summary
- `collection_order: custom` is only valid with `plex_search`, not `tmdb_movie` — caused a Kometa collection error on every run
- Changed to `collection_order: release` in `KometaExport.tsx` generator and updated the description text
- Also syncs branch to origin/master (TMDB matching, ranked watchlist, Kometa export, Letterboxd import, audit logs, login history, and related features)

## Test plan
- [ ] Verify Kometa no longer errors on the MovieNight collection
- [ ] Download/copy Kometa export from admin panel and confirm `collection_order: release` is present
- [ ] Confirm "Write to Kometa" button writes valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)