### PR TITLE
feat: trigger Kometa run via webhook after collection export

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,16 @@ TMDB_API_KEY=your_tmdb_api_key_here
 # Override only if the backend is on a different origin.
 # REACT_APP_GRAPHQL_URL=https://api.example.com/graphql
 
+# Kometa Integration (optional)
+# Directory where Kometa reads its collection YAML files.
+# The backend writes movienight.yml here on export.
+# KOMETA_COLLECTIONS_PATH=/path/to/kometa/collections
+#
+# HTTP webhook URL to trigger a Kometa run after each export.
+# Kometa has no built-in API; use a sidecar like adnanh/webhook that runs:
+#   docker exec kometa python kometa.py --run --collections-only --run-collections "MovieNight Watchlist"
+# KOMETA_TRIGGER_URL=http://webhook:9000/hooks/kometa-run
+
 # Port Mappings (host:container)
 DB_EXTERNAL_PORT=5432
 BACKEND_EXTERNAL_PORT=4000

--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -398,16 +398,33 @@ export const resolvers = {
       const filePath = path.join(collectionsPath, 'movienight.yml');
       await fs.promises.writeFile(filePath, yaml, 'utf8');
 
+      let triggered = false;
+      let triggerError: string | undefined;
+      const triggerUrl = process.env.KOMETA_TRIGGER_URL;
+      if (triggerUrl) {
+        try {
+          await fetch(triggerUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ action: 'run', collection: name }),
+            signal: AbortSignal.timeout(10000),
+          });
+          triggered = true;
+        } catch (err: any) {
+          triggerError = err.message;
+        }
+      }
+
       await logAudit(
         context.user.userId,
         'KOMETA_EXPORT',
         'kometa',
         filePath,
-        { count: matched.length, skipped: movies.length - matched.length },
+        { count: matched.length, skipped: movies.length - matched.length, triggered, triggerError },
         context.ipAddress ?? 'unknown'
       );
 
-      return filePath;
+      return { filePath, triggered, triggerError: triggerError ?? null };
     },
     updateKometaSchedule: async (
       _: any,

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -82,12 +82,18 @@ export const typeDefs = `#graphql
     errors: [String!]!
   }
 
+  type KometaExportResult {
+    filePath: String!
+    triggered: Boolean!
+    triggerError: String
+  }
+
   type Mutation {
     addMovie(title: String!, tmdb_id: Int): Movie!
     matchMovie(id: ID!, tmdb_id: Int!, title: String!): Movie!
     deleteMovie(id: ID!): Boolean!
     reorderMovie(id: ID!, afterId: ID): Boolean!
-    exportKometa(collectionName: String): String!
+    exportKometa(collectionName: String): KometaExportResult!
     updateKometaSchedule(enabled: Boolean, frequency: String, dailyTime: String, collectionName: String): KometaSchedule!
     importFromLetterboxd(url: String!): ImportResult!
     login(username: String!, password: String!): AuthPayload!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       DB_PASSWORD: ${DB_PASSWORD}
       PORT: ${BACKEND_PORT}
       TMDB_API_KEY: ${TMDB_API_KEY:-}
+      KOMETA_COLLECTIONS_PATH: ${KOMETA_COLLECTIONS_PATH:-}
+      KOMETA_TRIGGER_URL: ${KOMETA_TRIGGER_URL:-}
     ports:
       - "${BACKEND_EXTERNAL_PORT}:${BACKEND_PORT}"
     depends_on:
@@ -77,6 +79,8 @@ services:
       - "8080:80"
     environment:
       - TZ=America/New_York
+      - KOMETA_COLLECTIONS_PATH=${KOMETA_COLLECTIONS_PATH:-}
+      - KOMETA_TRIGGER_URL=${KOMETA_TRIGGER_URL:-}
     networks:
       - frontend
     labels:

--- a/src/components/admin/KometaExport.tsx
+++ b/src/components/admin/KometaExport.tsx
@@ -67,7 +67,11 @@ export const KometaExport: React.FC = () => {
   const [updateSchedule, { loading: savingSchedule }] = useMutation(UPDATE_KOMETA_SCHEDULE);
 
   const [copied, setCopied] = useState(false);
-  const [exportResult, setExportResult] = useState<{ path: string } | { error: string } | null>(null);
+  const [exportResult, setExportResult] = useState<{
+    path: string;
+    triggered: boolean;
+    triggerError?: string;
+  } | { error: string } | null>(null);
 
   // Local form state for schedule
   const [schedEnabled, setSchedEnabled] = useState(false);
@@ -116,7 +120,8 @@ export const KometaExport: React.FC = () => {
       const { data: result } = await exportKometa({
         variables: { collectionName },
       });
-      setExportResult({ path: result.exportKometa });
+      const { filePath, triggered, triggerError } = result.exportKometa;
+      setExportResult({ path: filePath, triggered, triggerError });
     } catch (err: any) {
       setExportResult({ error: err.message });
     }
@@ -181,9 +186,23 @@ export const KometaExport: React.FC = () => {
           color={'error' in exportResult ? 'danger' : 'success'}
           sx={{ mb: 2 }}
         >
-          {'error' in exportResult
-            ? exportResult.error
-            : `Written to ${exportResult.path}`}
+          {'error' in exportResult ? (
+            exportResult.error
+          ) : (
+            <Box>
+              <Typography level="body-sm">Written to {exportResult.path}</Typography>
+              {exportResult.triggered && (
+                <Typography level="body-xs" sx={{ mt: 0.5, opacity: 0.8 }}>
+                  Kometa run triggered.
+                </Typography>
+              )}
+              {exportResult.triggerError && (
+                <Typography level="body-xs" sx={{ mt: 0.5, color: 'warning.600' }}>
+                  Could not trigger Kometa run: {exportResult.triggerError}
+                </Typography>
+              )}
+            </Box>
+          )}
         </Alert>
       )}
 

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -163,7 +163,11 @@ export const DELETE_USER = gql`
 
 export const EXPORT_KOMETA = gql`
   mutation ExportKometa($collectionName: String) {
-    exportKometa(collectionName: $collectionName)
+    exportKometa(collectionName: $collectionName) {
+      filePath
+      triggered
+      triggerError
+    }
   }
 `;
 


### PR DESCRIPTION
## Summary

- Adds optional `KOMETA_TRIGGER_URL` env var to the backend
- After a successful Kometa export, fires an HTTP POST to that URL (10s timeout) so a sidecar (e.g. `adnanh/webhook`) can exec a targeted Kometa run on the host
- Export never fails on trigger error — surfaces as a UI warning instead
- Documents both `KOMETA_COLLECTIONS_PATH` and `KOMETA_TRIGGER_URL` in `.env.example`

## Why a webhook sidecar?

Kometa has no built-in HTTP API. The only stable trigger is `docker exec kometa python kometa.py --run`. Since MovieNight's backend runs with a read-only Docker socket proxy, it can't call `docker exec` directly. The recommended setup is an `adnanh/webhook` container configured to run:
```
docker exec kometa python kometa.py --run --collections-only --run-collections "MovieNight Watchlist"
```

## Test plan

- [ ] Export with `KOMETA_TRIGGER_URL` unset — success alert shows only file path, no trigger info
- [ ] Export with a valid `KOMETA_TRIGGER_URL` — success alert shows "Kometa run triggered."
- [ ] Export with an unreachable `KOMETA_TRIGGER_URL` — export still succeeds, alert shows trigger warning
- [ ] Verify audit log `metadata` includes `triggered` and `triggerError` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)