### PR TITLE
feat: add deploy timestamp to footer and fix PR branch name

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -33,6 +33,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set build timestamp
+        id: timestamp
+        run: echo "value=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
+
       - name: Build and push frontend image
         uses: docker/build-push-action@v5
         with:
@@ -42,8 +46,9 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            REACT_APP_GIT_BRANCH=${{ github.ref_name }}
+            REACT_APP_GIT_BRANCH=${{ github.head_ref || github.ref_name }}
             REACT_APP_GIT_HASH=${{ github.sha }}
+            REACT_APP_DEPLOY_TIME=${{ steps.timestamp.outputs.value }}
 
       - name: Build and push backend image
         uses: docker/build-push-action@v5
@@ -77,6 +82,6 @@ jobs:
         run: |
           echo "### Test Deployment Successful! :rocket:" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Branch:** \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Branch:** \`${{ github.head_ref || github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Frontend:** \`${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:test\`" >> $GITHUB_STEP_SUMMARY
           echo "**Backend:** \`${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:test\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,10 @@ jobs:
             type=sha,prefix={{branch}}-
             type=raw,value=latest,enable={{is_default_branch}}
 
+      - name: Set build timestamp
+        id: timestamp
+        run: echo "value=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
+
       - name: Build and push frontend image
         uses: docker/build-push-action@v5
         with:
@@ -55,6 +59,7 @@ jobs:
           build-args: |
             REACT_APP_GIT_BRANCH=${{ github.ref_name }}
             REACT_APP_GIT_HASH=${{ github.sha }}
+            REACT_APP_DEPLOY_TIME=${{ steps.timestamp.outputs.value }}
 
       - name: Build and push backend image
         uses: docker/build-push-action@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,10 @@ COPY . .
 # Git info baked into the bundle at build time
 ARG REACT_APP_GIT_BRANCH=unknown
 ARG REACT_APP_GIT_HASH=unknown
+ARG REACT_APP_DEPLOY_TIME=unknown
 ENV REACT_APP_GIT_BRANCH=$REACT_APP_GIT_BRANCH
 ENV REACT_APP_GIT_HASH=$REACT_APP_GIT_HASH
+ENV REACT_APP_DEPLOY_TIME=$REACT_APP_DEPLOY_TIME
 
 # Build the application (creates /app/build directory)
 RUN npm run build

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -3,9 +3,29 @@ import { Box, Typography } from "@mui/joy";
 
 const GIT_BRANCH = process.env.REACT_APP_GIT_BRANCH;
 const GIT_HASH = process.env.REACT_APP_GIT_HASH;
+const DEPLOY_TIME = process.env.REACT_APP_DEPLOY_TIME;
+
+function formatDeployTime(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZoneName: "short",
+    timeZone: "UTC",
+  });
+}
 
 export const Footer: React.FC = () => {
   const year = new Date().getFullYear();
+
+  const parts: string[] = [];
+  if (GIT_BRANCH) parts.push(`branch: ${GIT_BRANCH}`);
+  if (GIT_HASH) parts.push(`commit: ${GIT_HASH.slice(0, 7)}`);
+  if (DEPLOY_TIME && DEPLOY_TIME !== "unknown") parts.push(`deployed: ${formatDeployTime(DEPLOY_TIME)}`);
 
   return (
     <Box
@@ -23,11 +43,9 @@ export const Footer: React.FC = () => {
       <Typography level="body-xs" sx={{ color: "text.tertiary" }}>
         &copy; {year} MovieNight
       </Typography>
-      {(GIT_BRANCH || GIT_HASH) && (
+      {parts.length > 0 && (
         <Typography level="body-xs" sx={{ color: "text.tertiary", mt: 0.25, opacity: 0.5 }}>
-          {GIT_BRANCH && <>branch: {GIT_BRANCH}</>}
-          {GIT_BRANCH && GIT_HASH && " · "}
-          {GIT_HASH && <>commit: {GIT_HASH.slice(0, 7)}</>}
+          {parts.join(" · ")}
         </Typography>
       )}
     </Box>

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -8,14 +8,13 @@ const DEPLOY_TIME = process.env.REACT_APP_DEPLOY_TIME;
 function formatDeployTime(iso: string): string {
   const d = new Date(iso);
   if (isNaN(d.getTime())) return iso;
-  return d.toLocaleString("en-US", {
+  return d.toLocaleString(undefined, {
     month: "short",
     day: "numeric",
     year: "numeric",
     hour: "2-digit",
     minute: "2-digit",
     timeZoneName: "short",
-    timeZone: "UTC",
   });
 }
 


### PR DESCRIPTION
## Summary

- Adds `REACT_APP_DEPLOY_TIME` build arg baked into the frontend bundle at deploy time; footer now shows `deployed: Mar 25, 2026, 02:00 PM UTC` alongside branch/commit info
- Omits the deployed field when value is `unknown` (local dev / CI test builds)
- Fixes `deploy-test.yml` to use `github.head_ref || github.ref_name` so PR builds display the real branch name instead of the merge ref (e.g. `47/merge`)

## Test plan

- [ ] Trigger a test deploy from a PR and verify footer shows correct branch name (not `N/merge`)
- [ ] Verify footer shows deploy timestamp on test and production builds
- [ ] Verify footer shows no "deployed" line on local dev builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)