### PR TITLE
feat: speed up CI with path filtering and parallel builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,12 +12,14 @@ env:
   BACKEND_IMAGE: ${{ github.repository }}-backend
 
 jobs:
-  build-and-push:
-    name: Build and Push Docker Image
+  build-push-frontend:
+    name: Build and Push Frontend Image
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
 
     steps:
       - name: Checkout repository
@@ -54,12 +56,33 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,scope=frontend,mode=max
           build-args: |
             REACT_APP_GIT_BRANCH=${{ github.ref_name }}
             REACT_APP_GIT_HASH=${{ github.sha }}
             REACT_APP_DEPLOY_TIME=${{ steps.timestamp.outputs.value }}
+
+  build-push-backend:
+    name: Build and Push Backend Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push backend image
         uses: docker/build-push-action@v5
@@ -67,15 +90,12 @@ jobs:
           context: ./backend
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Image digest
-        run: echo "${{ steps.meta.outputs.tags }}"
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,scope=backend,mode=max
 
   deploy:
     name: Deploy via Nova Compose
-    needs: build-and-push
+    needs: [build-push-frontend, build-push-backend]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -9,32 +9,77 @@ on:
       - dev
 
 jobs:
-  test-build:
-    name: Test Docker Build
+  changes:
+    name: Detect changed paths
     runs-on: ubuntu-latest
-
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      backend: ${{ steps.filter.outputs.backend }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'src/**'
+              - 'public/**'
+              - 'package*.json'
+              - 'Dockerfile'
+              - 'nginx.conf'
+            backend:
+              - 'backend/**'
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build Docker image
+  build-frontend:
+    name: Build Frontend Image
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build frontend Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
           push: false
-          tags: movienight:test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          tags: movienight-frontend:test
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,scope=frontend,mode=max
 
-      - name: Build summary
-        if: success()
+  build-backend:
+    name: Build Backend Image
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build backend Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          push: false
+          tags: movienight-backend:test
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,scope=backend,mode=max
+
+  build-summary:
+    name: Build Summary
+    needs: [changes, build-frontend, build-backend]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summary
         run: |
-          echo "### Docker Build Successful! :white_check_mark:" >> $GITHUB_STEP_SUMMARY
+          echo "### Test Build Results :white_check_mark:" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Branch:** \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "This was a test build only - no deployment performed." >> $GITHUB_STEP_SUMMARY
+          echo "| Image | Result |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Frontend | ${{ needs.changes.outputs.frontend == 'true' && needs.build-frontend.result || 'skipped (no changes)' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Backend  | ${{ needs.changes.outputs.backend == 'true'  && needs.build-backend.result  || 'skipped (no changes)' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Test build only — no images pushed." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- **test-build**: adds `dorny/paths-filter` to skip frontend/backend builds when unrelated files change; adds the missing backend image build; runs both in parallel; shows per-image result in the job summary
- **deploy**: splits the sequential `build-and-push` job into parallel `build-push-frontend` and `build-push-backend` jobs, cutting total build time to whichever image takes longer
- Both workflows now use separate GHA cache scopes (`scope=frontend` / `scope=backend`) to prevent cache key collisions during parallel runs

## Test plan

- [ ] Push a frontend-only change to `dev` — only `build-frontend` should run
- [ ] Push a backend-only change to `dev` — only `build-backend` should run
- [ ] Push a change touching both — both jobs run in parallel
- [ ] Push a docs-only change — both builds skipped, summary shows "skipped (no changes)"
- [ ] Merge to `master` — frontend and backend build jobs run in parallel in deploy workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)