### PR TITLE
feat: serve app from root path instead of /movienight/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,7 @@ RUN npm run build
 FROM nginx:alpine
 
 # Copy built application from build stage
-# The build output goes to /movienight because of homepage in package.json
-COPY --from=build /app/build /usr/share/nginx/html/movienight
+COPY --from=build /app/build /usr/share/nginx/html
 
 # Copy custom nginx configuration
 COPY nginx.conf /etc/nginx/conf.d/default.conf
@@ -40,7 +39,7 @@ EXPOSE 80
 
 # Health check to verify container is serving content
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-  CMD wget --quiet --tries=1 --spider http://localhost/movienight/ || exit 1
+  CMD wget --quiet --tries=1 --spider http://localhost/ || exit 1
 
 # Run nginx in foreground
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       - "com.movienight.app=true"
       - "com.movienight.version=1.0"
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost/movienight/"]
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost/"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/nginx.conf
+++ b/nginx.conf
@@ -15,10 +15,9 @@ server {
                application/json application/javascript application/xml+rss
                application/atom+xml image/svg+xml;
 
-    # Main application location - /movienight subpath
-    location /movienight {
-        alias /usr/share/nginx/html/movienight;
-        try_files $uri $uri/ /movienight/index.html;
+    # Main application
+    location / {
+        try_files $uri $uri/ /index.html;
 
         # Cache static assets aggressively
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|otf|map)$ {
@@ -49,18 +48,13 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # Redirect root to /movienight/
-    location = / {
-        return 301 /movienight/;
-    }
-
     # Security headers
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
     # Error pages
-    error_page 404 /movienight/index.html;
+    error_page 404 /index.html;
     error_page 500 502 503 504 /50x.html;
     location = /50x.html {
         root /usr/share/nginx/html;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "movienight",
   "version": "0.1.0",
-  "homepage": "/movienight/",
+  "homepage": "/",
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.8.8",


### PR DESCRIPTION
## Summary

- Remove `/movienight/` subpath so the app serves from the domain root (`https://movienight.firefly-koonan.duckdns.org/`)
- Update `nginx.conf`: replace `location /movienight { alias ... }` with `location / { try_files ... /index.html }`, remove the `301` redirect, fix `error_page 404`
- Update `Dockerfile`: copy build output to `/usr/share/nginx/html` (not `.../movienight`), fix healthcheck URL
- Update `docker-compose.yml`: fix healthcheck URL
- Update `package.json`: set `"homepage": "/"` so CRA uses root-relative asset paths

## Test plan

- [ ] Build the Docker image and verify the app loads at `/`
- [ ] Confirm `/graphql` proxy still works
- [ ] Confirm static assets (JS/CSS) are served with correct cache headers
- [ ] Confirm 404s fall back to `index.html` (client-side routing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)