### PR TITLE
chore: standardize SSH secret names to NOVA_* convention

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -68,10 +68,9 @@ jobs:
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1.0.3
         with:
-          host: ${{ secrets.REMOTE_HOST }}
-          username: ${{ secrets.REMOTE_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          port: ${{ secrets.REMOTE_PORT || 22 }}
+          host: ${{ secrets.NOVA_HOST }}
+          username: ${{ secrets.NOVA_USER }}
+          key: ${{ secrets.NOVA_SSH_KEY }}
           script: |
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             cd ${{ secrets.NOVA_CONFIG_PATH }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,10 +102,9 @@ jobs:
       - name: Deploy to nova host via SSH
         uses: appleboy/ssh-action@v1.0.3
         with:
-          host: ${{ secrets.REMOTE_HOST }}
-          username: ${{ secrets.REMOTE_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          port: ${{ secrets.REMOTE_PORT || 22 }}
+          host: ${{ secrets.NOVA_HOST }}
+          username: ${{ secrets.NOVA_USER }}
+          key: ${{ secrets.NOVA_SSH_KEY }}
           script: |
             NOVA_DIR="${{ secrets.NOVA_CONFIG_PATH }}"
             COMPOSE_FILE="$NOVA_DIR/docker-compose.movienight.yaml"
@@ -158,5 +157,5 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Frontend:** \`${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:latest\`" >> $GITHUB_STEP_SUMMARY
           echo "**Backend:** \`${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:latest\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Host:** \`${{ secrets.REMOTE_HOST }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Host:** \`${{ secrets.NOVA_HOST }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Replaces `REMOTE_HOST` → `NOVA_HOST`
- Replaces `REMOTE_USER` → `NOVA_USER`
- Replaces `SSH_PRIVATE_KEY` → `NOVA_SSH_KEY`
- Drops `REMOTE_PORT` (appleboy/ssh-action defaults to 22)

Aligns `deploy.yml` and `deploy-test.yml` with the naming convention used in `nova-config` and `vibe-kanban-tools`, so all three repos share the same org-level secrets.

## Test plan

- [ ] Confirm `NOVA_HOST`, `NOVA_USER`, `NOVA_SSH_KEY`, `NOVA_CONFIG_PATH` are set at the org level in nova-firefly
- [ ] Merge and verify a deployment run completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)