### PR TITLE
Standardize deploy workflow secrets to NOVA_* naming

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,10 +102,10 @@ jobs:
       - name: Deploy to nova host via SSH
         uses: appleboy/ssh-action@v1.0.3
         with:
-          host: ${{ secrets.REMOTE_HOST }}
-          username: ${{ secrets.REMOTE_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          port: ${{ secrets.REMOTE_PORT || 22 }}
+          host: ${{ secrets.NOVA_HOST }}
+          username: ${{ secrets.NOVA_USER }}
+          key: ${{ secrets.NOVA_SSH_KEY }}
+          port: ${{ secrets.NOVA_SSH_PORT || 22 }}
           script: |
             NOVA_DIR="${{ secrets.NOVA_CONFIG_PATH }}"
             COMPOSE_FILE="$NOVA_DIR/docker-compose.movienight.yaml"
@@ -158,5 +158,5 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Frontend:** \`${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:latest\`" >> $GITHUB_STEP_SUMMARY
           echo "**Backend:** \`${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:latest\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Host:** \`${{ secrets.REMOTE_HOST }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Host:** \`${{ secrets.NOVA_HOST }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Renames SSH secrets in `.github/workflows/deploy.yml` to match the org-wide `NOVA_*` convention used by `nova-config` and `vibe-kanban-tools`
- Enables all three repos to share org-level secrets without per-repo overrides

## Secret renames
| Old | New |
|-----|-----|
| `REMOTE_HOST` | `NOVA_HOST` |
| `REMOTE_USER` | `NOVA_USER` |
| `SSH_PRIVATE_KEY` | `NOVA_SSH_KEY` |
| `REMOTE_PORT` | `NOVA_SSH_PORT` |

## Test plan
- [ ] Confirm org secrets `NOVA_HOST`, `NOVA_USER`, `NOVA_SSH_KEY` exist (or add them)
- [ ] Optionally set `NOVA_SSH_PORT` if host uses non-standard SSH port (defaults to 22)
- [ ] Remove old repo-level secrets `REMOTE_HOST`, `REMOTE_USER`, `SSH_PRIVATE_KEY`, `REMOTE_PORT` after verifying deploy works

🤖 Generated with [Claude Code](https://claude.com/claude-code)