### PR TITLE
Standardize deploy workflow secrets to NOVA_* naming

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,10 +102,10 @@ jobs:
       - name: Deploy to nova host via SSH
         uses: appleboy/ssh-action@v1.0.3
         with:
-          host: ${{ secrets.REMOTE_HOST }}
-          username: ${{ secrets.REMOTE_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          port: ${{ secrets.REMOTE_PORT || 22 }}
+          host: ${{ secrets.NOVA_HOST }}
+          username: ${{ secrets.NOVA_USER }}
+          key: ${{ secrets.NOVA_SSH_KEY }}
+          port: ${{ secrets.NOVA_SSH_PORT || 22 }}
           script: |
             NOVA_DIR="${{ secrets.NOVA_CONFIG_PATH }}"
             COMPOSE_FILE="$NOVA_DIR/docker-compose.movienight.yaml"
@@ -158,5 +158,5 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Frontend:** \`${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:latest\`" >> $GITHUB_STEP_SUMMARY
           echo "**Backend:** \`${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:latest\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Host:** \`${{ secrets.REMOTE_HOST }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Host:** \`${{ secrets.NOVA_HOST }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Rename SSH secrets to match the org-wide convention used by nova-config and vibe-kanban-tools, enabling shared org-level secrets:
- REMOTE_HOST → NOVA_HOST
- REMOTE_USER → NOVA_USER
- SSH_PRIVATE_KEY → NOVA_SSH_KEY
- REMOTE_PORT → NOVA_SSH_PORT