### PR TITLE
Add dotenv-linter for .env/.env.example drift detection

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -9,6 +9,16 @@ on:
       - dev
 
 jobs:
+  lint-env:
+    name: Lint .env.example
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dotenv-linter
+        run: curl -sSfL https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh | sh -s -- -b /usr/local/bin
+      - name: Lint .env.example
+        run: dotenv-linter --skip UnorderedKey .env.example
+
   changes:
     name: Detect changed paths
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/dotenv-linter/dotenv-linter
+    rev: v3.3.0
+    hooks:
+      - id: dotenv-linter
+        args: [--skip, UnorderedKey]
+
+  - repo: local
+    hooks:
+      - id: dotenv-compare
+        name: Check .env matches .env.example
+        language: system
+        entry: bash -c 'if [[ -f .env && -f .env.example ]]; then dotenv-linter compare .env .env.example; fi'
+        pass_filenames: false
+        always_run: true


### PR DESCRIPTION
## Summary

- Add `.pre-commit-config.yaml` with two hooks: dotenv-linter lint on staged `.env*` files, and a compare hook that checks `.env` against `.env.example` when both exist
- Add `lint-env` CI job to `test-build.yml` that lints `.env.example` on every push to `dev`

## Test plan

- [ ] Install pre-commit (`pip install pre-commit` or `brew install pre-commit`) and run `pre-commit install` in the repo
- [ ] Verify `pre-commit run --all-files` passes
- [ ] Confirm `lint-env` CI job passes in GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)