### PR TITLE
fix: simplify deploy workflows and remove stale workarounds

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -73,32 +73,27 @@ jobs:
           key: ${{ secrets.NOVA_SSH_KEY }}
           port: ${{ secrets.NOVA_SSH_PORT || 22 }}
           script: |
-            NOVA_DIR="${{ secrets.NOVA_CONFIG_PATH }}"
-            BRANCH="${{ github.head_ref || github.ref_name }}"
-            COMPOSE_FILE="$NOVA_DIR/docker-compose.movienight-test.yaml"
-
-            # Update movienight submodule to the feature branch
-            cd "$NOVA_DIR/movienight"
-            git fetch origin
-            git checkout "$BRANCH"
-            git pull origin "$BRANCH"
+            COMPOSE_FILE="${{ secrets.NOVA_CONFIG_PATH }}/docker-compose.movienight-test.yaml"
 
             # Login and pull new test images
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             docker compose -f "$COMPOSE_FILE" pull
 
-            # Restart with new images
-            docker compose -f "$COMPOSE_FILE" up -d
+            # Recreate containers with new images
+            docker compose -f "$COMPOSE_FILE" up -d --force-recreate
 
-            # Verify
-            if docker ps | grep -q movienight-test; then
-              echo "Deployment successful - movienight-test is running"
-              docker ps | grep movienight-test
-            else
-              echo "Deployment failed"
-              docker compose -f "$COMPOSE_FILE" logs --tail=50
-              exit 1
-            fi
+            # Verify containers were actually recreated (not stale)
+            sleep 5
+            for svc in movienight-test-frontend movienight-test-backend; do
+              STATUS=$(docker inspect --format '{{.State.Status}}' "$svc" 2>/dev/null || echo "missing")
+              if [ "$STATUS" != "running" ]; then
+                echo "FAIL: $svc is $STATUS"
+                docker compose -f "$COMPOSE_FILE" logs --tail=30 "$svc"
+                exit 1
+              fi
+            done
+            echo "Deployment successful"
+            docker compose -f "$COMPOSE_FILE" ps
 
       - name: Deployment summary
         if: success()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,46 +110,28 @@ jobs:
             NOVA_DIR="${{ secrets.NOVA_CONFIG_PATH }}"
             COMPOSE_FILE="$NOVA_DIR/docker-compose.movienight.yaml"
 
-            # Update movienight submodule to latest master (picks up backend changes)
-            cd "$NOVA_DIR"
-            git submodule update --remote movienight
-
-            # Login to GHCR so compose can pull the new frontend image
+            # Login to GHCR and pull new images
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
-            # Pull new images
             docker compose -f "$COMPOSE_FILE" pull movienight-frontend movienight-backend
 
-            # Gracefully stop db so postgres can remove postmaster.pid cleanly;
-            # docker rm -f (SIGKILL) leaves postmaster.pid with PID 1, which the
-            # next container's init also runs as, causing postgres to think another
-            # instance is already running and enter a restart loop.
-            docker stop movienight-db 2>/dev/null || true
-            docker rm movienight-db 2>/dev/null || true
-
-            # postgres:18rc1-trixie changed VOLUME /var/lib/postgresql/data to
-            # VOLUME /var/lib/postgresql.  Docker then mounts an empty anonymous
-            # volume at the parent path; our named volume mount at the child path
-            # (/var/lib/postgresql/data) fails with "no such file or directory"
-            # because the empty parent has no data/ subdirectory.
-            # Enforce the same stable image the repo declares (postgres:15-alpine).
-            sed -i 's|image: postgres:.*|image: postgres:15-alpine|g' "$COMPOSE_FILE"
-
-            # Restart all services with new images
+            # Restart with new images
             docker compose -f "$COMPOSE_FILE" up -d
 
             # Clean up dangling images
             docker image prune -f
 
-            # Verify frontend container is running
-            if docker ps | grep -q movienight-frontend; then
-              echo "Deployment successful - movienight-frontend is running"
-              docker ps | grep movienight
-            else
-              echo "Deployment failed - movienight-frontend is not running"
-              docker compose -f "$COMPOSE_FILE" logs --tail=50
-              exit 1
-            fi
+            # Verify all containers are running
+            sleep 5
+            for svc in movienight-frontend movienight-backend movienight-db; do
+              STATUS=$(docker inspect --format '{{.State.Status}}' "$svc" 2>/dev/null || echo "missing")
+              if [ "$STATUS" != "running" ]; then
+                echo "FAIL: $svc is $STATUS"
+                docker compose -f "$COMPOSE_FILE" logs --tail=30 "$svc"
+                exit 1
+              fi
+            done
+            echo "Deployment successful"
+            docker compose -f "$COMPOSE_FILE" ps
 
       - name: Deployment summary
         if: success()


### PR DESCRIPTION
## Summary
- Removed unnecessary submodule checkout from test deploy workflow (images are pre-built, submodule not used)
- Removed `sed` postgres version hack and manual db stop/rm from production deploy (compose file already pins `postgres:15-alpine`)
- Added `--force-recreate` to test deploy so containers always pick up new images
- Replaced weak `grep -q` verification with per-container status checks that fail fast with logs

## Test plan
- [ ] Merge companion PR in nova-config repo (image ref fix — the actual root cause)
- [ ] Open a test PR and verify `deploy-test.yml` builds, pushes, and deploys correctly
- [ ] Verify production `deploy.yml` works on next merge to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)