### PR TITLE
fix: sync nova-config on host before deploying

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -73,7 +73,13 @@ jobs:
           key: ${{ secrets.NOVA_SSH_KEY }}
           port: ${{ secrets.NOVA_SSH_PORT || 22 }}
           script: |
-            COMPOSE_FILE="${{ secrets.NOVA_CONFIG_PATH }}/docker-compose.movienight-test.yaml"
+            NOVA_DIR="${{ secrets.NOVA_CONFIG_PATH }}"
+            COMPOSE_FILE="$NOVA_DIR/docker-compose.movienight-test.yaml"
+
+            # Ensure host has latest nova-config compose files
+            cd "$NOVA_DIR"
+            git fetch origin
+            git reset --hard origin/main
 
             # Login and pull new test images
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,6 +110,11 @@ jobs:
             NOVA_DIR="${{ secrets.NOVA_CONFIG_PATH }}"
             COMPOSE_FILE="$NOVA_DIR/docker-compose.movienight.yaml"
 
+            # Ensure host has latest nova-config compose files
+            cd "$NOVA_DIR"
+            git fetch origin
+            git reset --hard origin/main
+
             # Login to GHCR and pull new images
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             docker compose -f "$COMPOSE_FILE" pull movienight-frontend movienight-backend


### PR DESCRIPTION
## Summary
- Deploy workflows read compose files from the host, but the host's nova-config may be stale
- Added `git fetch + reset` to ensure the compose file matches `origin/main` before pulling images
- This prevents the race condition where images are pushed but the host still has old compose refs

Companion PR: nova-firefly/nova-config#103 (sync workflow fix)

## Test plan
- [ ] Merge nova-config sync fix first (#103)
- [ ] Open a test PR to trigger deploy-test and verify fresh compose files are used
- [ ] Verify production deploy also syncs on next merge to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)