### PR TITLE
fix: upsert seed users to prevent FK data loss on dev restart

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -13,24 +13,17 @@ const pool = new Pool({
 
 const seedAdminUser = async () => {
   try {
-    const result = await pool.query('SELECT id FROM users WHERE username = $1', ['admin']);
+    const defaultPassword = process.env.ADMIN_PASSWORD || 'admin123';
+    const passwordHash = await hashPassword(defaultPassword);
 
-    if (result.rows.length === 0) {
-      const defaultPassword = process.env.ADMIN_PASSWORD || 'admin123';
-      const passwordHash = await hashPassword(defaultPassword);
+    await pool.query(
+      `INSERT INTO users (username, email, password_hash, is_admin)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (username) DO UPDATE SET password_hash = EXCLUDED.password_hash, is_admin = EXCLUDED.is_admin`,
+      ['admin', 'admin@movienight.local', passwordHash, true]
+    );
 
-      await pool.query(
-        'INSERT INTO users (username, email, password_hash, is_admin) VALUES ($1, $2, $3, $4)',
-        ['admin', 'admin@movienight.local', passwordHash, true]
-      );
-
-      console.log('✅ Admin user created successfully');
-      console.log('   Username: admin');
-      console.log(`   Password: ${defaultPassword}`);
-      console.log('   ⚠️  Please change this password after first login!');
-    } else {
-      console.log('Admin user already exists');
-    }
+    console.log('✅ Admin user ensured (username: admin)');
   } catch (error) {
     console.error('Error seeding admin user:', error);
   }
@@ -39,21 +32,17 @@ const seedAdminUser = async () => {
 const seedTestUser = async () => {
   try {
     const username = process.env.TEST_USER_USERNAME || 'testuser';
-    const result = await pool.query('SELECT id FROM users WHERE username = $1', [username]);
+    const password = process.env.TEST_USER_PASSWORD || 'testpass';
+    const passwordHash = await hashPassword(password);
 
-    if (result.rows.length === 0) {
-      const password = process.env.TEST_USER_PASSWORD || 'testpass';
-      const passwordHash = await hashPassword(password);
+    await pool.query(
+      `INSERT INTO users (username, email, password_hash, display_name, is_admin)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (username) DO UPDATE SET password_hash = EXCLUDED.password_hash`,
+      [username, `${username}@movienight.local`, passwordHash, 'Test User', false]
+    );
 
-      await pool.query(
-        'INSERT INTO users (username, email, password_hash, display_name, is_admin) VALUES ($1, $2, $3, $4, $5)',
-        [username, `${username}@movienight.local`, passwordHash, 'Test User', false]
-      );
-
-      console.log('✅ Test user seeded');
-    } else {
-      console.log('Test user already exists');
-    }
+    console.log(`✅ Test user ensured (username: ${username})`);
   } catch (error) {
     console.error('Error seeding test user:', error);
   }
@@ -77,12 +66,6 @@ export const initializeDatabase = async () => {
     });
 
     console.log('Database migrations completed successfully');
-
-    // In development, wipe all users so credentials are always fresh
-    if (process.env.NODE_ENV !== 'production') {
-      await pool.query('DELETE FROM users');
-      console.log('Dev mode: users reset');
-    }
 
     await seedAdminUser();
 


### PR DESCRIPTION
## Summary

- Removes `DELETE FROM users` that ran on every non-production startup, which wiped user IDs and broke `movies.requested_by` FK references
- Replaces the delete+insert pattern with `INSERT ... ON CONFLICT (username) DO UPDATE SET password_hash = ...` in both `seedAdminUser` and `seedTestUser`

## Behaviour after fix

- `admin` and `testuser` always exist with credentials from env vars after each restart
- Their database IDs never change, so all movie-to-user FK connections are preserved
- Any other users created at runtime are untouched

## Test plan

- [ ] Restart backend in dev mode — confirm `admin` and `testuser` still exist with expected credentials
- [ ] Add a movie as a non-seed user, restart backend, confirm the movie still shows the correct requester
- [ ] Verify movies added by `admin`/`testuser` before restart still display correct requester after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)