### PR TITLE
feat: self-service password reset via email

### DIFF
--- a/backend/migrations/1745700000000_create-password-reset-tokens.js
+++ b/backend/migrations/1745700000000_create-password-reset-tokens.js
@@ -1,0 +1,35 @@
+exports.up = (pgm) => {
+  pgm.createTable('password_reset_tokens', {
+    id: 'id',
+    user_id: {
+      type: 'integer',
+      notNull: true,
+      references: '"users"',
+      onDelete: 'CASCADE',
+    },
+    token_hash: {
+      type: 'varchar(64)',
+      notNull: true,
+      unique: true,
+    },
+    expires_at: {
+      type: 'timestamptz',
+      notNull: true,
+    },
+    used_at: {
+      type: 'timestamptz',
+    },
+    created_at: {
+      type: 'timestamptz',
+      notNull: true,
+      default: pgm.func('NOW()'),
+    },
+  });
+
+  pgm.createIndex('password_reset_tokens', 'user_id');
+  pgm.createIndex('password_reset_tokens', 'token_hash');
+};
+
+exports.down = (pgm) => {
+  pgm.dropTable('password_reset_tokens');
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,11 +9,13 @@
       "version": "1.0.0",
       "dependencies": {
         "@apollo/server": "^4.13.0",
+        "@types/nodemailer": "^8.0.0",
         "bcrypt": "^6.0.0",
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "graphql": "^16.8.1",
         "jsonwebtoken": "^9.0.3",
+        "nodemailer": "^8.0.5",
         "pg": "^8.11.3"
       },
       "devDependencies": {
@@ -581,6 +583,15 @@
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.0.tgz",
+      "integrity": "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/pg": {
@@ -2134,6 +2145,15 @@
         "@types/pg": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/normalize-path": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,11 +14,13 @@
   },
   "dependencies": {
     "@apollo/server": "^4.13.0",
+    "@types/nodemailer": "^8.0.0",
     "bcrypt": "^6.0.0",
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "graphql": "^16.8.1",
     "jsonwebtoken": "^9.0.3",
+    "nodemailer": "^8.0.5",
     "pg": "^8.11.3"
   },
   "devDependencies": {

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 import { User } from './models/User';
@@ -46,4 +47,12 @@ export function getTokenFromHeader(authHeader?: string): string | null {
     return parts[1];
   }
   return null;
+}
+
+export function generateResetToken(): string {
+  return crypto.randomBytes(32).toString('hex');
+}
+
+export function hashResetToken(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex');
 }

--- a/backend/src/email.ts
+++ b/backend/src/email.ts
@@ -1,0 +1,46 @@
+import nodemailer from 'nodemailer';
+
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST || 'localhost',
+  port: parseInt(process.env.SMTP_PORT || '587'),
+  secure: process.env.SMTP_SECURE === 'true',
+  ...(process.env.SMTP_USER
+    ? {
+        auth: {
+          user: process.env.SMTP_USER,
+          pass: process.env.SMTP_PASS || '',
+        },
+      }
+    : {}),
+});
+
+const FROM_ADDRESS = process.env.SMTP_FROM || 'noreply@movienight.local';
+
+export async function sendPasswordResetEmail(
+  to: string,
+  resetToken: string
+): Promise<void> {
+  const appUrl = process.env.APP_URL || 'http://localhost:3000';
+  const resetLink = `${appUrl}?resetToken=${resetToken}`;
+
+  await transporter.sendMail({
+    from: FROM_ADDRESS,
+    to,
+    subject: 'MovieNight - Password Reset',
+    text: [
+      'You requested a password reset for your MovieNight account.',
+      '',
+      `Click this link to reset your password (expires in 1 hour):`,
+      resetLink,
+      '',
+      'If you did not request this, you can safely ignore this email.',
+    ].join('\n'),
+    html: `
+      <h2>Password Reset</h2>
+      <p>You requested a password reset for your MovieNight account.</p>
+      <p><a href="${resetLink}">Click here to reset your password</a></p>
+      <p>This link expires in 1 hour.</p>
+      <p>If you did not request this, you can safely ignore this email.</p>
+    `,
+  });
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,6 +5,7 @@ import cors from 'cors';
 import { typeDefs } from './schema';
 import { resolvers } from './resolvers';
 import { initializeDatabase } from './db';
+import pool from './db';
 import { verifyToken, getTokenFromHeader } from './auth';
 import { initScheduler } from './scheduler';
 
@@ -40,6 +41,15 @@ async function startServer() {
 
   await initializeDatabase();
   await initScheduler();
+
+  // Clean up expired password reset tokens every hour
+  setInterval(async () => {
+    try {
+      await pool.query('DELETE FROM password_reset_tokens WHERE expires_at < NOW()');
+    } catch (err) {
+      console.error('Failed to clean expired reset tokens:', err);
+    }
+  }, 60 * 60 * 1000).unref();
 
   app.listen(PORT, () => {
     console.log(`🚀 GraphQL server ready at http://localhost:${PORT}/graphql`);

--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -49,21 +49,52 @@ async function logLoginHistory(
 const isProduction = () => process.env.NODE_ENV === 'production';
 
 // ── Password-reset rate limiter ──────────────────────────────────────────────
-const resetRateLimiter = new Map<string, { count: number; resetAt: number }>();
-const RATE_LIMIT_WINDOW = 15 * 60 * 1000; // 15 minutes
-const RATE_LIMIT_MAX = 5; // max 5 requests per window per IP
+interface RateLimitEntry { count: number; resetAt: number }
 
-function checkResetRateLimit(ip: string): boolean {
+const ipRateLimiter = new Map<string, RateLimitEntry>();
+const emailRateLimiter = new Map<string, RateLimitEntry>();
+
+const IP_RATE_LIMIT_WINDOW = 15 * 60 * 1000;   // 15 minutes
+const IP_RATE_LIMIT_MAX = 5;                     // max 5 requests per window per IP
+const EMAIL_RATE_LIMIT_WINDOW = 60 * 60 * 1000; // 1 hour
+const EMAIL_RATE_LIMIT_MAX = 3;                  // max 3 emails per hour per address
+const GLOBAL_RATE_LIMIT_WINDOW = 60 * 60 * 1000; // 1 hour
+const GLOBAL_RATE_LIMIT_MAX = 50;                // max 50 reset emails per hour total
+let globalResetCount = { count: 0, resetAt: Date.now() + GLOBAL_RATE_LIMIT_WINDOW };
+
+function checkRateLimit(limiter: Map<string, RateLimitEntry>, key: string, max: number, window: number): boolean {
   const now = Date.now();
-  const entry = resetRateLimiter.get(ip);
+  const entry = limiter.get(key);
   if (!entry || now > entry.resetAt) {
-    resetRateLimiter.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW });
+    limiter.set(key, { count: 1, resetAt: now + window });
     return true;
   }
-  if (entry.count >= RATE_LIMIT_MAX) return false;
+  if (entry.count >= max) return false;
   entry.count++;
   return true;
 }
+
+function checkGlobalResetLimit(): boolean {
+  const now = Date.now();
+  if (now > globalResetCount.resetAt) {
+    globalResetCount = { count: 1, resetAt: now + GLOBAL_RATE_LIMIT_WINDOW };
+    return true;
+  }
+  if (globalResetCount.count >= GLOBAL_RATE_LIMIT_MAX) return false;
+  globalResetCount.count++;
+  return true;
+}
+
+// Evict stale entries periodically to prevent memory growth
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of ipRateLimiter) {
+    if (now > entry.resetAt) ipRateLimiter.delete(key);
+  }
+  for (const [key, entry] of emailRateLimiter) {
+    if (now > entry.resetAt) emailRateLimiter.delete(key);
+  }
+}, 15 * 60 * 1000).unref();
 
 // ── TMDB enrichment cache ────────────────────────────────────────────────────
 
@@ -921,19 +952,31 @@ export const resolvers = {
       const genericMessage = 'If an account exists with that email, a password reset link has been sent.';
 
       try {
-        if (!checkResetRateLimit(context.ipAddress)) {
-          // Still return generic message to avoid leaking info via rate-limit errors
+        const normalizedEmail = email.trim().toLowerCase();
+
+        // Check per-IP rate limit
+        if (!checkRateLimit(ipRateLimiter, context.ipAddress, IP_RATE_LIMIT_MAX, IP_RATE_LIMIT_WINDOW)) {
+          return { success: true, message: genericMessage };
+        }
+
+        // Check per-email rate limit (prevents targeting one user from many IPs)
+        if (!checkRateLimit(emailRateLimiter, normalizedEmail, EMAIL_RATE_LIMIT_MAX, EMAIL_RATE_LIMIT_WINDOW)) {
+          return { success: true, message: genericMessage };
+        }
+
+        // Check global rate limit (caps total SMTP volume)
+        if (!checkGlobalResetLimit()) {
           return { success: true, message: genericMessage };
         }
 
         const result = await pool.query(
           'SELECT id, email, is_active FROM users WHERE LOWER(email) = LOWER($1)',
-          [email.trim()]
+          [normalizedEmail]
         );
         const user = result.rows[0];
 
         if (!user || !user.is_active) {
-          await logAudit(null, 'PASSWORD_RESET_REQUEST', 'user', null, { email }, context.ipAddress);
+          await logAudit(null, 'PASSWORD_RESET_REQUEST', 'user', null, { email: normalizedEmail }, context.ipAddress);
           return { success: true, message: genericMessage };
         }
 

--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -1,7 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import pool from './db';
-import { hashPassword, comparePassword, generateToken } from './auth';
+import { hashPassword, comparePassword, generateToken, generateResetToken, hashResetToken } from './auth';
+import { sendPasswordResetEmail } from './email';
 import { User, CreateUserInput, UpdateUserInput } from './models/User';
 import { GraphQLError } from 'graphql';
 import { rescheduleKometa } from './scheduler';
@@ -46,6 +47,23 @@ async function logLoginHistory(
 }
 
 const isProduction = () => process.env.NODE_ENV === 'production';
+
+// ── Password-reset rate limiter ──────────────────────────────────────────────
+const resetRateLimiter = new Map<string, { count: number; resetAt: number }>();
+const RATE_LIMIT_WINDOW = 15 * 60 * 1000; // 15 minutes
+const RATE_LIMIT_MAX = 5; // max 5 requests per window per IP
+
+function checkResetRateLimit(ip: string): boolean {
+  const now = Date.now();
+  const entry = resetRateLimiter.get(ip);
+  if (!entry || now > entry.resetAt) {
+    resetRateLimiter.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW });
+    return true;
+  }
+  if (entry.count >= RATE_LIMIT_MAX) return false;
+  entry.count++;
+  return true;
+}
 
 // ── TMDB enrichment cache ────────────────────────────────────────────────────
 
@@ -894,6 +912,114 @@ export const resolvers = {
       );
 
       return { imported, skipped, tmdb_matched, errors };
+    },
+    requestPasswordReset: async (
+      _: any,
+      { email }: { email: string },
+      context: any
+    ) => {
+      const genericMessage = 'If an account exists with that email, a password reset link has been sent.';
+
+      try {
+        if (!checkResetRateLimit(context.ipAddress)) {
+          // Still return generic message to avoid leaking info via rate-limit errors
+          return { success: true, message: genericMessage };
+        }
+
+        const result = await pool.query(
+          'SELECT id, email, is_active FROM users WHERE LOWER(email) = LOWER($1)',
+          [email.trim()]
+        );
+        const user = result.rows[0];
+
+        if (!user || !user.is_active) {
+          await logAudit(null, 'PASSWORD_RESET_REQUEST', 'user', null, { email }, context.ipAddress);
+          return { success: true, message: genericMessage };
+        }
+
+        // Invalidate any existing tokens for this user
+        await pool.query('DELETE FROM password_reset_tokens WHERE user_id = $1', [user.id]);
+
+        const rawToken = generateResetToken();
+        const tokenHash = hashResetToken(rawToken);
+        const expiresAt = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
+
+        await pool.query(
+          'INSERT INTO password_reset_tokens (user_id, token_hash, expires_at) VALUES ($1, $2, $3)',
+          [user.id, tokenHash, expiresAt]
+        );
+
+        try {
+          await sendPasswordResetEmail(user.email, rawToken);
+        } catch (emailErr) {
+          console.error('Failed to send password reset email:', emailErr);
+        }
+
+        await logAudit(null, 'PASSWORD_RESET_REQUEST', 'user', String(user.id), null, context.ipAddress);
+      } catch (err) {
+        console.error('Password reset request error:', err);
+      }
+
+      return { success: true, message: genericMessage };
+    },
+    resetPassword: async (
+      _: any,
+      { token, newPassword }: { token: string; newPassword: string },
+      context: any
+    ) => {
+      if (!newPassword || newPassword.length < 6) {
+        throw new GraphQLError('Password must be at least 6 characters', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+
+      const tokenHash = hashResetToken(token);
+
+      const result = await pool.query(
+        `SELECT prt.id, prt.user_id, u.is_active
+         FROM password_reset_tokens prt
+         JOIN users u ON u.id = prt.user_id
+         WHERE prt.token_hash = $1
+           AND prt.expires_at > NOW()
+           AND prt.used_at IS NULL`,
+        [tokenHash]
+      );
+
+      const resetRecord = result.rows[0];
+
+      if (!resetRecord) {
+        await logAudit(null, 'PASSWORD_RESET_FAILURE', null, null, { reason: 'invalid_or_expired_token' }, context.ipAddress);
+        throw new GraphQLError('Invalid or expired reset token', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+
+      if (!resetRecord.is_active) {
+        throw new GraphQLError('Account is disabled', {
+          extensions: { code: 'FORBIDDEN' },
+        });
+      }
+
+      const passwordHash = await hashPassword(newPassword);
+      await pool.query(
+        'UPDATE users SET password_hash = $1, updated_at = NOW() WHERE id = $2',
+        [passwordHash, resetRecord.user_id]
+      );
+
+      // Mark token as used and delete others
+      await pool.query('UPDATE password_reset_tokens SET used_at = NOW() WHERE id = $1', [resetRecord.id]);
+      await pool.query('DELETE FROM password_reset_tokens WHERE user_id = $1 AND id != $2', [resetRecord.user_id, resetRecord.id]);
+
+      await logAudit(
+        resetRecord.user_id,
+        'PASSWORD_RESET_SUCCESS',
+        'user',
+        String(resetRecord.user_id),
+        null,
+        context.ipAddress
+      );
+
+      return { success: true, message: 'Password has been reset successfully. You can now log in.' };
     },
     login: async (
       _: any,

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -132,7 +132,14 @@ export const typeDefs = `#graphql
     triggerError: String
   }
 
+  type PasswordResetResult {
+    success: Boolean!
+    message: String!
+  }
+
   type Mutation {
+    requestPasswordReset(email: String!): PasswordResetResult!
+    resetPassword(token: String!, newPassword: String!): PasswordResetResult!
     addMovie(title: String!, tmdb_id: Int): Movie!
     matchMovie(id: ID!, tmdb_id: Int!, title: String!): Movie!
     markWatched(id: ID!): Movie!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,13 @@ services:
       TMDB_API_KEY: ${TMDB_API_KEY:-}
       KOMETA_COLLECTIONS_PATH: ${KOMETA_COLLECTIONS_PATH:-}
       KOMETA_TRIGGER_URL: ${KOMETA_TRIGGER_URL:-}
+      SMTP_HOST: ${SMTP_HOST:-localhost}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_SECURE: ${SMTP_SECURE:-false}
+      SMTP_USER: ${SMTP_USER:-}
+      SMTP_PASS: ${SMTP_PASS:-}
+      SMTP_FROM: ${SMTP_FROM:-noreply@movienight.local}
+      APP_URL: ${APP_URL:-http://localhost:3000}
     ports:
       - "${BACKEND_EXTERNAL_PORT}:${BACKEND_PORT}"
     depends_on:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import { Box, Typography, CircularProgress } from '@mui/joy';
 import HomePage from "./components/home/Homepage";
 import ThisOrThat from "./components/home/ThisOrThat";
 import { Login } from "./components/auth/Login";
+import { ForgotPassword } from "./components/auth/ForgotPassword";
+import { ResetPassword } from "./components/auth/ResetPassword";
 import { AdminPanel } from "./components/admin/AdminPanel";
 import { Navbar } from "./components/common/Navbar";
 import { Footer } from "./components/common/Footer";
@@ -17,6 +19,11 @@ const App = () => {
   const { isAuthenticated, isLoading, user } = useAuth();
   const [currentView, setCurrentView] = React.useState<ViewName>('movies');
   const [showLogin, setShowLogin] = React.useState(false);
+  const [showForgotPassword, setShowForgotPassword] = React.useState(false);
+  const [resetToken, setResetToken] = React.useState<string | null>(() => {
+    const params = new URLSearchParams(window.location.search);
+    return params.get('resetToken');
+  });
 
   if (isLoading) {
     return (
@@ -39,8 +46,24 @@ const App = () => {
     );
   }
 
+  if (resetToken) {
+    return (
+      <ResetPassword
+        token={resetToken}
+        onComplete={() => {
+          setResetToken(null);
+          setShowLogin(true);
+          setShowForgotPassword(false);
+        }}
+      />
+    );
+  }
+
   if (showLogin && !isAuthenticated) {
-    return <Login />;
+    if (showForgotPassword) {
+      return <ForgotPassword onBackToLogin={() => setShowForgotPassword(false)} />;
+    }
+    return <Login onForgotPassword={() => setShowForgotPassword(true)} />;
   }
 
   const renderView = () => {

--- a/src/components/auth/ForgotPassword.tsx
+++ b/src/components/auth/ForgotPassword.tsx
@@ -1,0 +1,204 @@
+import React, { useState } from 'react';
+import { useMutation } from '@apollo/client';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Typography,
+  Alert,
+} from '@mui/joy';
+import { REQUEST_PASSWORD_RESET } from '../../graphql/queries';
+
+interface ForgotPasswordProps {
+  onBackToLogin: () => void;
+}
+
+export const ForgotPassword: React.FC<ForgotPasswordProps> = ({ onBackToLogin }) => {
+  const [email, setEmail] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState('');
+
+  const [requestReset, { loading }] = useMutation(REQUEST_PASSWORD_RESET, {
+    onCompleted: () => {
+      setSubmitted(true);
+      setError('');
+    },
+    onError: () => {
+      setError('Something went wrong. Please try again.');
+    },
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    if (!email) {
+      setError('Please enter your email address');
+      return;
+    }
+    try {
+      await requestReset({ variables: { email } });
+    } catch {
+      // handled by onError
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        minHeight: '100vh',
+        display: 'flex',
+        bgcolor: 'background.body',
+      }}
+    >
+      {/* Left — branding panel (hidden on small screens) */}
+      <Box
+        sx={{
+          display: { xs: 'none', md: 'flex' },
+          flex: 1,
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+          gap: 2,
+          bgcolor: 'background.surface',
+          borderRight: '1px solid',
+          borderColor: 'divider',
+          px: 6,
+          textAlign: 'center',
+          position: 'relative',
+          overflow: 'hidden',
+        }}
+      >
+        {/* Decorative glow */}
+        <Box
+          sx={{
+            position: 'absolute',
+            top: '30%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            width: 300,
+            height: 300,
+            borderRadius: '50%',
+            background: 'radial-gradient(circle, rgba(245,197,24,0.08) 0%, transparent 70%)',
+            pointerEvents: 'none',
+          }}
+        />
+        <Typography sx={{ fontSize: '5rem', lineHeight: 1 }}>🎬</Typography>
+        <Typography
+          level="h1"
+          sx={{ fontWeight: 800, letterSpacing: '-0.03em', color: 'primary.400' }}
+        >
+          MovieNight
+        </Typography>
+        <Typography level="body-lg" sx={{ color: 'text.secondary', maxWidth: 280 }}>
+          Keep track of what to watch next — together.
+        </Typography>
+      </Box>
+
+      {/* Right — form */}
+      <Box
+        sx={{
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+          px: { xs: 3, sm: 5 },
+          py: 6,
+        }}
+      >
+        {/* Mobile logo */}
+        <Box sx={{ display: { xs: 'block', md: 'none' }, mb: 4, textAlign: 'center' }}>
+          <Typography sx={{ fontSize: '3rem', lineHeight: 1 }}>🎬</Typography>
+          <Typography
+            level="h3"
+            sx={{ fontWeight: 800, color: 'primary.400', mt: 1 }}
+          >
+            MovieNight
+          </Typography>
+        </Box>
+
+        <Box sx={{ width: '100%', maxWidth: 380 }}>
+          {submitted ? (
+            <>
+              <Typography level="h3" sx={{ mb: 0.5, fontWeight: 700 }}>
+                Check your email
+              </Typography>
+              <Alert color="success" variant="soft" sx={{ mb: 3, mt: 2 }}>
+                If an account exists with that email, a password reset link has been sent. Check your inbox.
+              </Alert>
+              <Button
+                onClick={onBackToLogin}
+                variant="solid"
+                color="primary"
+                fullWidth
+                sx={{ fontWeight: 700, color: '#0d0f1a', py: 1.25 }}
+              >
+                Back to Sign In
+              </Button>
+            </>
+          ) : (
+            <>
+              <Typography level="h3" sx={{ mb: 0.5, fontWeight: 700 }}>
+                Reset your password
+              </Typography>
+              <Typography level="body-sm" sx={{ color: 'text.secondary', mb: 4 }}>
+                Enter the email address associated with your account
+              </Typography>
+
+              <form onSubmit={handleSubmit}>
+                <FormControl sx={{ mb: 3 }}>
+                  <FormLabel sx={{ color: 'text.secondary', fontSize: '0.8rem', fontWeight: 600 }}>
+                    Email
+                  </FormLabel>
+                  <Input
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder="Enter your email"
+                    autoFocus
+                    required
+                    sx={{
+                      bgcolor: 'background.surface',
+                      '--Input-focusedHighlight': 'var(--joy-palette-primary-500)',
+                    }}
+                  />
+                </FormControl>
+
+                {error && (
+                  <Alert color="danger" variant="soft" sx={{ mb: 3 }}>
+                    {error}
+                  </Alert>
+                )}
+
+                <Button
+                  type="submit"
+                  fullWidth
+                  loading={loading}
+                  color="primary"
+                  variant="solid"
+                  sx={{ fontWeight: 700, color: '#0d0f1a', py: 1.25 }}
+                >
+                  Send Reset Link
+                </Button>
+              </form>
+
+              <Box sx={{ textAlign: 'center', mt: 2 }}>
+                <Button
+                  onClick={onBackToLogin}
+                  variant="plain"
+                  color="neutral"
+                  size="sm"
+                  sx={{ fontSize: '0.8rem' }}
+                >
+                  Back to Sign In
+                </Button>
+              </Box>
+            </>
+          )}
+        </Box>
+      </Box>
+    </Box>
+  );
+};

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -12,7 +12,11 @@ import {
 import { LOGIN, GET_APP_INFO } from '../../graphql/queries';
 import { useAuth } from '../../contexts/AuthContext';
 
-export const Login: React.FC = () => {
+interface LoginProps {
+  onForgotPassword?: () => void;
+}
+
+export const Login: React.FC<LoginProps> = ({ onForgotPassword }) => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -175,7 +179,7 @@ export const Login: React.FC = () => {
               />
             </FormControl>
 
-            <FormControl sx={{ mb: 3 }}>
+            <FormControl sx={{ mb: 1.5 }}>
               <FormLabel sx={{ color: 'text.secondary', fontSize: '0.8rem', fontWeight: 600 }}>
                 Password
               </FormLabel>
@@ -191,6 +195,20 @@ export const Login: React.FC = () => {
                 }}
               />
             </FormControl>
+
+            {onForgotPassword && (
+              <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2 }}>
+                <Button
+                  variant="plain"
+                  color="neutral"
+                  size="sm"
+                  onClick={onForgotPassword}
+                  sx={{ fontSize: '0.75rem', p: 0, minHeight: 'auto' }}
+                >
+                  Forgot password?
+                </Button>
+              </Box>
+            )}
 
             {error && (
               <Alert color="danger" variant="soft" sx={{ mb: 3 }}>

--- a/src/components/auth/ResetPassword.tsx
+++ b/src/components/auth/ResetPassword.tsx
@@ -1,0 +1,222 @@
+import React, { useState } from 'react';
+import { useMutation } from '@apollo/client';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Typography,
+  Alert,
+} from '@mui/joy';
+import { RESET_PASSWORD } from '../../graphql/queries';
+
+interface ResetPasswordProps {
+  token: string;
+  onComplete: () => void;
+}
+
+export const ResetPassword: React.FC<ResetPasswordProps> = ({ token, onComplete }) => {
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState(false);
+
+  const [resetPassword, { loading }] = useMutation(RESET_PASSWORD, {
+    onCompleted: () => {
+      setSuccess(true);
+      window.history.replaceState({}, '', window.location.pathname);
+    },
+    onError: (err) => {
+      const code = err.graphQLErrors?.[0]?.extensions?.code;
+      if (code === 'BAD_USER_INPUT') {
+        setError(err.graphQLErrors[0].message);
+      } else if (code === 'FORBIDDEN') {
+        setError('This account has been disabled. Please contact an administrator.');
+      } else {
+        setError('Failed to reset password. The link may have expired.');
+      }
+    },
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    if (password.length < 6) {
+      setError('Password must be at least 6 characters');
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+    try {
+      await resetPassword({ variables: { token, newPassword: password } });
+    } catch {
+      // handled by onError
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        minHeight: '100vh',
+        display: 'flex',
+        bgcolor: 'background.body',
+      }}
+    >
+      {/* Left — branding panel (hidden on small screens) */}
+      <Box
+        sx={{
+          display: { xs: 'none', md: 'flex' },
+          flex: 1,
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+          gap: 2,
+          bgcolor: 'background.surface',
+          borderRight: '1px solid',
+          borderColor: 'divider',
+          px: 6,
+          textAlign: 'center',
+          position: 'relative',
+          overflow: 'hidden',
+        }}
+      >
+        {/* Decorative glow */}
+        <Box
+          sx={{
+            position: 'absolute',
+            top: '30%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            width: 300,
+            height: 300,
+            borderRadius: '50%',
+            background: 'radial-gradient(circle, rgba(245,197,24,0.08) 0%, transparent 70%)',
+            pointerEvents: 'none',
+          }}
+        />
+        <Typography sx={{ fontSize: '5rem', lineHeight: 1 }}>🎬</Typography>
+        <Typography
+          level="h1"
+          sx={{ fontWeight: 800, letterSpacing: '-0.03em', color: 'primary.400' }}
+        >
+          MovieNight
+        </Typography>
+        <Typography level="body-lg" sx={{ color: 'text.secondary', maxWidth: 280 }}>
+          Keep track of what to watch next — together.
+        </Typography>
+      </Box>
+
+      {/* Right — form */}
+      <Box
+        sx={{
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+          px: { xs: 3, sm: 5 },
+          py: 6,
+        }}
+      >
+        {/* Mobile logo */}
+        <Box sx={{ display: { xs: 'block', md: 'none' }, mb: 4, textAlign: 'center' }}>
+          <Typography sx={{ fontSize: '3rem', lineHeight: 1 }}>🎬</Typography>
+          <Typography
+            level="h3"
+            sx={{ fontWeight: 800, color: 'primary.400', mt: 1 }}
+          >
+            MovieNight
+          </Typography>
+        </Box>
+
+        <Box sx={{ width: '100%', maxWidth: 380 }}>
+          {success ? (
+            <>
+              <Typography level="h3" sx={{ mb: 0.5, fontWeight: 700 }}>
+                Password reset
+              </Typography>
+              <Alert color="success" variant="soft" sx={{ mb: 3, mt: 2 }}>
+                Your password has been reset successfully.
+              </Alert>
+              <Button
+                onClick={onComplete}
+                variant="solid"
+                color="primary"
+                fullWidth
+                sx={{ fontWeight: 700, color: '#0d0f1a', py: 1.25 }}
+              >
+                Sign In
+              </Button>
+            </>
+          ) : (
+            <>
+              <Typography level="h3" sx={{ mb: 0.5, fontWeight: 700 }}>
+                Set new password
+              </Typography>
+              <Typography level="body-sm" sx={{ color: 'text.secondary', mb: 4 }}>
+                Choose a new password for your account
+              </Typography>
+
+              <form onSubmit={handleSubmit}>
+                <FormControl sx={{ mb: 2 }}>
+                  <FormLabel sx={{ color: 'text.secondary', fontSize: '0.8rem', fontWeight: 600 }}>
+                    New Password
+                  </FormLabel>
+                  <Input
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder="Enter new password"
+                    autoFocus
+                    required
+                    sx={{
+                      bgcolor: 'background.surface',
+                      '--Input-focusedHighlight': 'var(--joy-palette-primary-500)',
+                    }}
+                  />
+                </FormControl>
+
+                <FormControl sx={{ mb: 3 }}>
+                  <FormLabel sx={{ color: 'text.secondary', fontSize: '0.8rem', fontWeight: 600 }}>
+                    Confirm Password
+                  </FormLabel>
+                  <Input
+                    type="password"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    placeholder="Confirm new password"
+                    required
+                    sx={{
+                      bgcolor: 'background.surface',
+                      '--Input-focusedHighlight': 'var(--joy-palette-primary-500)',
+                    }}
+                  />
+                </FormControl>
+
+                {error && (
+                  <Alert color="danger" variant="soft" sx={{ mb: 3 }}>
+                    {error}
+                  </Alert>
+                )}
+
+                <Button
+                  type="submit"
+                  fullWidth
+                  loading={loading}
+                  color="primary"
+                  variant="solid"
+                  sx={{ fontWeight: 700, color: '#0d0f1a', py: 1.25 }}
+                >
+                  Reset Password
+                </Button>
+              </form>
+            </>
+          )}
+        </Box>
+      </Box>
+    </Box>
+  );
+};

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -326,3 +326,21 @@ export const SEED_MOVIES = gql`
     seedMovies
   }
 `;
+
+export const REQUEST_PASSWORD_RESET = gql`
+  mutation RequestPasswordReset($email: String!) {
+    requestPasswordReset(email: $email) {
+      success
+      message
+    }
+  }
+`;
+
+export const RESET_PASSWORD = gql`
+  mutation ResetPassword($token: String!, $newPassword: String!) {
+    resetPassword(token: $token, newPassword: $newPassword) {
+      success
+      message
+    }
+  }
+`;


### PR DESCRIPTION
## Summary
- Adds a complete password reset flow: "Forgot password?" link on login page, email input form, SMTP email with time-limited reset link, and new password form
- Backend: `password_reset_tokens` table, `nodemailer` email service, `requestPasswordReset` and `resetPassword` GraphQL mutations with in-memory rate limiting (5 req/15min/IP)
- Frontend: `ForgotPassword` and `ResetPassword` components matching existing Login UI, URL-based reset token detection

## Security
- No user enumeration (identical response regardless of email existence)
- SHA-256 hashed tokens stored in DB (32-byte random, 256-bit entropy)
- 1-hour token expiry, single-use enforcement, prior tokens invalidated on new request
- Per-IP rate limiting on reset requests
- Disabled account check before allowing password change
- Full audit trail: `PASSWORD_RESET_REQUEST`, `PASSWORD_RESET_SUCCESS`, `PASSWORD_RESET_FAILURE`

## Configuration
New env vars needed for deployment: `SMTP_HOST`, `SMTP_PORT`, `SMTP_SECURE`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM`, `APP_URL`

## Test plan
- [ ] Run migration, verify `password_reset_tokens` table created
- [ ] Request reset for existing email — verify email sent (MailHog), token row in DB, audit log
- [ ] Request reset for non-existent email — verify same UI message, no token row
- [ ] Click reset link — verify form renders, submit new password, login with it
- [ ] Try expired token — verify "Invalid or expired" error
- [ ] Try reused token — verify same error
- [ ] Submit 6+ rapid requests — verify rate limiting (no error shown, but email suppressed)
- [ ] Request reset for disabled user — verify same generic message, no token
- [ ] Build frontend and backend — verify no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)