### PR TITLE
fix: document missing env vars in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,22 @@ DB_NAME=movienight
 DB_USER=movienight_user
 DB_PASSWORD=movienight_pass
 BACKEND_PORT=4000
+JWT_SECRET=your-secret-key-change-in-production
+ADMIN_PASSWORD=admin123
 TMDB_API_KEY=your_tmdb_api_key_here
+
+# Test user seeded in development mode (NODE_ENV != production)
+# TEST_USER_USERNAME=testuser
+# TEST_USER_PASSWORD=testpass
+
+# SMTP for password-reset emails (optional for local dev)
+# SMTP_HOST=localhost
+# SMTP_PORT=587
+# SMTP_SECURE=false
+# SMTP_USER=
+# SMTP_PASS=
+# SMTP_FROM=noreply@movienight.local
+# APP_URL=http://localhost:3000
 
 # Frontend Configuration
 # GraphQL requests go to /graphql (proxied by nginx to the backend).


### PR DESCRIPTION
## Summary
- Add `JWT_SECRET`, `ADMIN_PASSWORD`, test user vars, SMTP settings, and `APP_URL` to `.env.example`
- These are all read by the backend via `process.env` but were never documented in the example file

## Test plan
- [ ] Verify `.env.example` covers all `process.env` references in backend source

🤖 Generated with [Claude Code](https://claude.com/claude-code)