### PR TITLE
feat: combined list with user connections

### DIFF
--- a/backend/migrations/1745800000000_create-user-connections.js
+++ b/backend/migrations/1745800000000_create-user-connections.js
@@ -1,0 +1,47 @@
+exports.up = (pgm) => {
+  pgm.createTable('user_connections', {
+    id: 'id',
+    requester_id: {
+      type: 'integer',
+      notNull: true,
+      references: '"users"',
+      onDelete: 'CASCADE',
+    },
+    addressee_id: {
+      type: 'integer',
+      notNull: true,
+      references: '"users"',
+      onDelete: 'CASCADE',
+    },
+    status: {
+      type: 'varchar(20)',
+      notNull: true,
+      default: "'pending'",
+    },
+    created_at: {
+      type: 'timestamptz',
+      notNull: true,
+      default: pgm.func('NOW()'),
+    },
+    updated_at: {
+      type: 'timestamptz',
+      notNull: true,
+      default: pgm.func('NOW()'),
+    },
+  });
+
+  pgm.addConstraint('user_connections', 'user_connections_status_check',
+    "CHECK (status IN ('pending', 'accepted', 'rejected'))");
+  pgm.addConstraint('user_connections', 'user_connections_no_self',
+    'CHECK (requester_id <> addressee_id)');
+  pgm.addConstraint('user_connections', 'user_connections_unique_pair',
+    'UNIQUE (requester_id, addressee_id)');
+
+  pgm.createIndex('user_connections', 'requester_id');
+  pgm.createIndex('user_connections', 'addressee_id');
+  pgm.createIndex('user_connections', ['addressee_id', 'status']);
+};
+
+exports.down = (pgm) => {
+  pgm.dropTable('user_connections');
+};

--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -444,6 +444,130 @@ export const resolvers = {
         comparisonCount: Number(r.comparison_count),
       }));
     },
+
+    searchUsers: async (_: any, { query }: { query: string }, context: any) => {
+      if (!context.user) {
+        throw new GraphQLError('Not authenticated', { extensions: { code: 'UNAUTHENTICATED' } });
+      }
+      const result = await pool.query(
+        `SELECT id, username, display_name FROM users
+         WHERE is_active = true AND id <> $1
+           AND (username ILIKE $2 OR display_name ILIKE $2)
+         ORDER BY username ASC LIMIT 10`,
+        [context.user.userId, `%${query}%`]
+      );
+      return result.rows;
+    },
+
+    myConnections: async (_: any, __: any, context: any) => {
+      if (!context.user) {
+        throw new GraphQLError('Not authenticated', { extensions: { code: 'UNAUTHENTICATED' } });
+      }
+      const result = await pool.query(
+        `SELECT uc.id, uc.status, uc.created_at,
+                CASE WHEN uc.requester_id = $1 THEN 'sent' ELSE 'received' END AS direction,
+                other.id AS user_id, other.username, other.display_name
+         FROM user_connections uc
+         JOIN users other ON other.id = CASE WHEN uc.requester_id = $1 THEN uc.addressee_id ELSE uc.requester_id END
+         WHERE uc.status = 'accepted' AND (uc.requester_id = $1 OR uc.addressee_id = $1)
+         ORDER BY uc.updated_at DESC`,
+        [context.user.userId]
+      );
+      return result.rows.map((r: any) => ({
+        id: r.id,
+        user: { id: r.user_id, username: r.username, display_name: r.display_name },
+        status: r.status,
+        direction: r.direction,
+        created_at: r.created_at instanceof Date ? r.created_at.toISOString() : r.created_at,
+      }));
+    },
+
+    pendingConnectionRequests: async (_: any, __: any, context: any) => {
+      if (!context.user) {
+        throw new GraphQLError('Not authenticated', { extensions: { code: 'UNAUTHENTICATED' } });
+      }
+      const result = await pool.query(
+        `SELECT uc.id, uc.status, uc.created_at,
+                CASE WHEN uc.requester_id = $1 THEN 'sent' ELSE 'received' END AS direction,
+                other.id AS user_id, other.username, other.display_name
+         FROM user_connections uc
+         JOIN users other ON other.id = CASE WHEN uc.requester_id = $1 THEN uc.addressee_id ELSE uc.requester_id END
+         WHERE uc.status = 'pending' AND (uc.requester_id = $1 OR uc.addressee_id = $1)
+         ORDER BY uc.created_at DESC`,
+        [context.user.userId]
+      );
+      return result.rows.map((r: any) => ({
+        id: r.id,
+        user: { id: r.user_id, username: r.username, display_name: r.display_name },
+        status: r.status,
+        direction: r.direction,
+        created_at: r.created_at instanceof Date ? r.created_at.toISOString() : r.created_at,
+      }));
+    },
+
+    combinedList: async (_: any, { connectionId }: { connectionId: string }, context: any) => {
+      if (!context.user) {
+        throw new GraphQLError('Not authenticated', { extensions: { code: 'UNAUTHENTICATED' } });
+      }
+      const userId = context.user.userId;
+
+      const conn = await pool.query(
+        `SELECT uc.id, uc.requester_id, uc.addressee_id, uc.status, uc.created_at,
+                other.id AS other_user_id, other.username, other.display_name
+         FROM user_connections uc
+         JOIN users other ON other.id = CASE WHEN uc.requester_id = $1 THEN uc.addressee_id ELSE uc.requester_id END
+         WHERE uc.id = $2 AND uc.status = 'accepted'
+           AND (uc.requester_id = $1 OR uc.addressee_id = $1)`,
+        [userId, connectionId]
+      );
+      if (conn.rows.length === 0) {
+        throw new GraphQLError('Connection not found or not accepted', { extensions: { code: 'NOT_FOUND' } });
+      }
+
+      const otherUserId = conn.rows[0].other_user_id;
+      const c = conn.rows[0];
+
+      const result = await pool.query(
+        `SELECT m.id, m.title, m.requested_by, m.date_submitted, m.rank, m.tmdb_id, m.watched_at,
+                m.elo_rank,
+                u.username AS user_username, u.display_name AS user_display_name,
+                ume_a.elo_rating AS user_a_elo,
+                ume_b.elo_rating AS user_b_elo,
+                CASE
+                  WHEN ume_a.elo_rating IS NOT NULL AND ume_b.elo_rating IS NOT NULL
+                  THEN (ume_a.elo_rating + ume_b.elo_rating) / 2
+                  ELSE COALESCE(ume_a.elo_rating, ume_b.elo_rating)
+                END AS combined_elo,
+                (ume_a.elo_rating IS NOT NULL AND ume_b.elo_rating IS NOT NULL) AS both_rated
+         FROM movies m
+         LEFT JOIN users u ON m.requested_by = u.id
+         LEFT JOIN user_movie_elo ume_a ON ume_a.movie_id = m.id AND ume_a.user_id = $1
+         LEFT JOIN user_movie_elo ume_b ON ume_b.movie_id = m.id AND ume_b.user_id = $2
+         WHERE m.watched_at IS NULL
+           AND (ume_a.elo_rating IS NOT NULL OR ume_b.elo_rating IS NOT NULL)
+         ORDER BY both_rated DESC, combined_elo DESC`,
+        [userId, otherUserId]
+      );
+
+      const connection = {
+        id: c.id,
+        user: { id: c.other_user_id, username: c.username, display_name: c.display_name },
+        status: c.status,
+        direction: c.requester_id === userId ? 'sent' : 'received',
+        created_at: c.created_at instanceof Date ? c.created_at.toISOString() : c.created_at,
+      };
+
+      return {
+        connection,
+        rankings: result.rows.map((r: any) => ({
+          movie: r,
+          userAElo: r.user_a_elo != null ? Number(r.user_a_elo) : null,
+          userBElo: r.user_b_elo != null ? Number(r.user_b_elo) : null,
+          combinedElo: Number(r.combined_elo),
+          bothRated: r.both_rated,
+        })),
+      };
+    },
   },
   Mutation: {
     addMovie: async (_: any, { title, tmdb_id }: { title: string; tmdb_id?: number }, context: any) => {
@@ -1304,6 +1428,140 @@ export const resolvers = {
       );
 
       return SEED_MOVIES.length;
+    },
+
+    sendConnectionRequest: async (_: any, { addresseeId }: { addresseeId: string }, context: any) => {
+      if (!context.user) {
+        throw new GraphQLError('Not authenticated', { extensions: { code: 'UNAUTHENTICATED' } });
+      }
+      const requesterId = context.user.userId;
+      const addrId = parseInt(addresseeId);
+
+      if (requesterId === addrId) {
+        throw new GraphQLError('Cannot connect with yourself', { extensions: { code: 'BAD_USER_INPUT' } });
+      }
+
+      const targetUser = await pool.query('SELECT id FROM users WHERE id = $1 AND is_active = true', [addrId]);
+      if (targetUser.rows.length === 0) {
+        throw new GraphQLError('User not found', { extensions: { code: 'NOT_FOUND' } });
+      }
+
+      // Check if reverse pending request exists — auto-accept
+      const reverseRow = await pool.query(
+        `SELECT id, status FROM user_connections WHERE requester_id = $1 AND addressee_id = $2`,
+        [addrId, requesterId]
+      );
+      if (reverseRow.rows.length > 0) {
+        const rev = reverseRow.rows[0];
+        if (rev.status === 'accepted') {
+          throw new GraphQLError('Already connected', { extensions: { code: 'BAD_USER_INPUT' } });
+        }
+        if (rev.status === 'pending') {
+          await pool.query(
+            `UPDATE user_connections SET status = 'accepted', updated_at = NOW() WHERE id = $1`,
+            [rev.id]
+          );
+          await logAudit(requesterId, 'CONNECTION_AUTO_ACCEPT', 'user_connection', String(rev.id), { addresseeId: addrId }, context.ipAddress ?? 'unknown');
+          const other = await pool.query('SELECT id, username, display_name FROM users WHERE id = $1', [addrId]);
+          return {
+            id: rev.id,
+            user: other.rows[0],
+            status: 'accepted',
+            direction: 'received',
+            created_at: new Date().toISOString(),
+          };
+        }
+      }
+
+      // Check if forward request already exists
+      const existingRow = await pool.query(
+        `SELECT id, status FROM user_connections WHERE requester_id = $1 AND addressee_id = $2`,
+        [requesterId, addrId]
+      );
+      if (existingRow.rows.length > 0) {
+        const ex = existingRow.rows[0];
+        if (ex.status === 'pending') {
+          throw new GraphQLError('Request already pending', { extensions: { code: 'BAD_USER_INPUT' } });
+        }
+        if (ex.status === 'accepted') {
+          throw new GraphQLError('Already connected', { extensions: { code: 'BAD_USER_INPUT' } });
+        }
+        // Previously rejected — re-send
+        await pool.query(
+          `UPDATE user_connections SET status = 'pending', updated_at = NOW() WHERE id = $1`,
+          [ex.id]
+        );
+        await logAudit(requesterId, 'CONNECTION_REQUEST', 'user_connection', String(ex.id), { addresseeId: addrId }, context.ipAddress ?? 'unknown');
+        const other = await pool.query('SELECT id, username, display_name FROM users WHERE id = $1', [addrId]);
+        return {
+          id: ex.id,
+          user: other.rows[0],
+          status: 'pending',
+          direction: 'sent',
+          created_at: new Date().toISOString(),
+        };
+      }
+
+      // Insert new request
+      const result = await pool.query(
+        `INSERT INTO user_connections (requester_id, addressee_id, status)
+         VALUES ($1, $2, 'pending') RETURNING id, created_at`,
+        [requesterId, addrId]
+      );
+      await logAudit(requesterId, 'CONNECTION_REQUEST', 'user_connection', String(result.rows[0].id), { addresseeId: addrId }, context.ipAddress ?? 'unknown');
+      const other = await pool.query('SELECT id, username, display_name FROM users WHERE id = $1', [addrId]);
+      return {
+        id: result.rows[0].id,
+        user: other.rows[0],
+        status: 'pending',
+        direction: 'sent',
+        created_at: result.rows[0].created_at instanceof Date ? result.rows[0].created_at.toISOString() : result.rows[0].created_at,
+      };
+    },
+
+    respondToConnectionRequest: async (_: any, { connectionId, accept }: { connectionId: string; accept: boolean }, context: any) => {
+      if (!context.user) {
+        throw new GraphQLError('Not authenticated', { extensions: { code: 'UNAUTHENTICATED' } });
+      }
+      const conn = await pool.query(
+        `SELECT * FROM user_connections WHERE id = $1 AND addressee_id = $2 AND status = 'pending'`,
+        [connectionId, context.user.userId]
+      );
+      if (conn.rows.length === 0) {
+        throw new GraphQLError('Connection request not found', { extensions: { code: 'NOT_FOUND' } });
+      }
+
+      const newStatus = accept ? 'accepted' : 'rejected';
+      await pool.query(
+        `UPDATE user_connections SET status = $1, updated_at = NOW() WHERE id = $2`,
+        [newStatus, connectionId]
+      );
+      const action = accept ? 'CONNECTION_ACCEPT' : 'CONNECTION_REJECT';
+      await logAudit(context.user.userId, action, 'user_connection', connectionId, { requesterId: conn.rows[0].requester_id }, context.ipAddress ?? 'unknown');
+
+      const other = await pool.query('SELECT id, username, display_name FROM users WHERE id = $1', [conn.rows[0].requester_id]);
+      return {
+        id: connectionId,
+        user: other.rows[0],
+        status: newStatus,
+        direction: 'received',
+        created_at: conn.rows[0].created_at instanceof Date ? conn.rows[0].created_at.toISOString() : conn.rows[0].created_at,
+      };
+    },
+
+    removeConnection: async (_: any, { connectionId }: { connectionId: string }, context: any) => {
+      if (!context.user) {
+        throw new GraphQLError('Not authenticated', { extensions: { code: 'UNAUTHENTICATED' } });
+      }
+      const result = await pool.query(
+        `DELETE FROM user_connections WHERE id = $1 AND (requester_id = $2 OR addressee_id = $2) RETURNING id`,
+        [connectionId, context.user.userId]
+      );
+      if (result.rows.length === 0) {
+        throw new GraphQLError('Connection not found', { extensions: { code: 'NOT_FOUND' } });
+      }
+      await logAudit(context.user.userId, 'CONNECTION_REMOVE', 'user_connection', connectionId, null, context.ipAddress ?? 'unknown');
+      return true;
     },
   },
   Movie: {

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -104,6 +104,33 @@ export const typeDefs = `#graphql
     comparisonCount: Int!
   }
 
+  type ConnectionUser {
+    id: ID!
+    username: String!
+    display_name: String
+  }
+
+  type UserConnection {
+    id: ID!
+    user: ConnectionUser!
+    status: String!
+    direction: String!
+    created_at: String!
+  }
+
+  type CombinedRanking {
+    movie: Movie!
+    userAElo: Float
+    userBElo: Float
+    combinedElo: Float!
+    bothRated: Boolean!
+  }
+
+  type CombinedListResult {
+    connection: UserConnection!
+    rankings: [CombinedRanking!]!
+  }
+
   type Query {
     appInfo: AppInfo!
     movies: [Movie!]!
@@ -117,6 +144,10 @@ export const typeDefs = `#graphql
     kometaSchedule: KometaSchedule!
     thisOrThat(excludeIds: [ID!]): ThisOrThatPair!
     myRankings: [MovieRanking!]!
+    searchUsers(query: String!): [ConnectionUser!]!
+    myConnections: [UserConnection!]!
+    pendingConnectionRequests: [UserConnection!]!
+    combinedList(connectionId: ID!): CombinedListResult!
   }
 
   type ImportResult {
@@ -154,5 +185,8 @@ export const typeDefs = `#graphql
     updateUser(id: ID!, username: String, email: String, password: String, display_name: String, is_admin: Boolean, is_active: Boolean): User!
     deleteUser(id: ID!): Boolean!
     seedMovies: Int!
+    sendConnectionRequest(addresseeId: ID!): UserConnection!
+    respondToConnectionRequest(connectionId: ID!, accept: Boolean!): UserConnection!
+    removeConnection(connectionId: ID!): Boolean!
   }
 `;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,6 @@ type ViewName = 'movies' | 'this-or-that' | 'combined-list' | 'admin';
 const App = () => {
   const { isAuthenticated, isLoading, user } = useAuth();
   const [currentView, setCurrentView] = React.useState<ViewName>('movies');
-  const [selectedConnectionId, setSelectedConnectionId] = React.useState<string | null>(null);
   const [showLogin, setShowLogin] = React.useState(false);
   const [showForgotPassword, setShowForgotPassword] = React.useState(false);
   const [resetToken, setResetToken] = React.useState<string | null>(() => {
@@ -92,15 +91,15 @@ const App = () => {
     }
 
     if (currentView === 'combined-list' && isAuthenticated) {
-      return (
-        <CombinedList
-          connectionId={selectedConnectionId}
-          onSelectConnection={(id) => setSelectedConnectionId(id)}
-        />
-      );
+      return <CombinedList />;
     }
 
-    return <HomePage onShowThisOrThat={() => setCurrentView('this-or-that')} />;
+    return (
+      <HomePage
+        onShowThisOrThat={() => setCurrentView('this-or-that')}
+        onShowConnections={() => setCurrentView('combined-list')}
+      />
+    );
   };
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Box, Typography, CircularProgress } from '@mui/joy';
 import HomePage from "./components/home/Homepage";
 import ThisOrThat from "./components/home/ThisOrThat";
+import CombinedList from "./components/home/CombinedList";
 import { Login } from "./components/auth/Login";
 import { ForgotPassword } from "./components/auth/ForgotPassword";
 import { ResetPassword } from "./components/auth/ResetPassword";
@@ -13,11 +14,12 @@ import { useAuth } from "./contexts/AuthContext";
 const GIT_BRANCH = process.env.REACT_APP_GIT_BRANCH;
 const IS_TEST_ENV = GIT_BRANCH && GIT_BRANCH !== "master";
 
-type ViewName = 'movies' | 'this-or-that' | 'admin';
+type ViewName = 'movies' | 'this-or-that' | 'combined-list' | 'admin';
 
 const App = () => {
   const { isAuthenticated, isLoading, user } = useAuth();
   const [currentView, setCurrentView] = React.useState<ViewName>('movies');
+  const [selectedConnectionId, setSelectedConnectionId] = React.useState<string | null>(null);
   const [showLogin, setShowLogin] = React.useState(false);
   const [showForgotPassword, setShowForgotPassword] = React.useState(false);
   const [resetToken, setResetToken] = React.useState<string | null>(() => {
@@ -89,6 +91,15 @@ const App = () => {
       return <ThisOrThat />;
     }
 
+    if (currentView === 'combined-list' && isAuthenticated) {
+      return (
+        <CombinedList
+          connectionId={selectedConnectionId}
+          onSelectConnection={(id) => setSelectedConnectionId(id)}
+        />
+      );
+    }
+
     return <HomePage onShowThisOrThat={() => setCurrentView('this-or-that')} />;
   };
 
@@ -124,6 +135,7 @@ const App = () => {
         currentView={currentView}
         onShowMovies={() => setCurrentView('movies')}
         onShowThisOrThat={() => setCurrentView('this-or-that')}
+        onShowCombinedList={() => setCurrentView('combined-list')}
         onShowAdmin={() => setCurrentView('admin')}
         onShowLogin={() => setShowLogin(true)}
       />

--- a/src/components/common/Navbar.tsx
+++ b/src/components/common/Navbar.tsx
@@ -3,12 +3,13 @@ import { Box, Button, Typography, IconButton, Divider } from '@mui/joy';
 import { useAuth } from '../../contexts/AuthContext';
 import { getGravatarUrl } from '../../utils/gravatar';
 
-type ViewName = 'movies' | 'this-or-that' | 'admin';
+type ViewName = 'movies' | 'this-or-that' | 'combined-list' | 'admin';
 
 interface NavbarProps {
   currentView: ViewName;
   onShowMovies: () => void;
   onShowThisOrThat: () => void;
+  onShowCombinedList: () => void;
   onShowAdmin: () => void;
   onShowLogin: () => void;
 }
@@ -17,6 +18,7 @@ export const Navbar: React.FC<NavbarProps> = ({
   currentView,
   onShowMovies,
   onShowThisOrThat,
+  onShowCombinedList,
   onShowAdmin,
   onShowLogin,
 }) => {
@@ -51,6 +53,21 @@ export const Navbar: React.FC<NavbarProps> = ({
           }}
         >
           This or That
+        </Button>
+      )}
+      {isAuthenticated && (
+        <Button
+          variant={currentView === 'combined-list' ? 'soft' : 'plain'}
+          color="neutral"
+          size="sm"
+          onClick={() => { onShowCombinedList(); setMobileOpen(false); }}
+          sx={{
+            fontWeight: 600,
+            color: currentView === 'combined-list' ? 'primary.400' : 'text.secondary',
+            '&:hover': { color: 'primary.300' },
+          }}
+        >
+          Combined
         </Button>
       )}
       {isAuthenticated && user?.is_admin && (

--- a/src/components/home/CombinedList.tsx
+++ b/src/components/home/CombinedList.tsx
@@ -7,23 +7,12 @@ import {
   SEARCH_USERS,
   MY_CONNECTIONS,
   PENDING_CONNECTION_REQUESTS,
-  COMBINED_LIST,
   SEND_CONNECTION_REQUEST,
   RESPOND_TO_CONNECTION_REQUEST,
   REMOVE_CONNECTION,
 } from '../../graphql/queries';
-import { useAuth } from '../../contexts/AuthContext';
 
-type Tab = 'connections' | 'rankings';
-
-interface CombinedListProps {
-  connectionId: string | null;
-  onSelectConnection: (id: string | null) => void;
-}
-
-const CombinedList: React.FC<CombinedListProps> = ({ connectionId, onSelectConnection }) => {
-  const { user } = useAuth();
-  const [tab, setTab] = useState<Tab>(connectionId ? 'rankings' : 'connections');
+const CombinedList: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<any[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -37,12 +26,6 @@ const CombinedList: React.FC<CombinedListProps> = ({ connectionId, onSelectConne
   const { data: connectionsData, refetch: refetchConnections } = useQuery(MY_CONNECTIONS);
   const { data: pendingData, refetch: refetchPending } = useQuery(PENDING_CONNECTION_REQUESTS, {
     pollInterval: 5000,
-  });
-
-  const { data: combinedData, loading: combinedLoading } = useQuery(COMBINED_LIST, {
-    variables: { connectionId },
-    skip: !connectionId,
-    fetchPolicy: 'cache-and-network',
   });
 
   const [sendRequest, { loading: sendingRequest }] = useMutation(SEND_CONNECTION_REQUEST, {
@@ -66,10 +49,7 @@ const CombinedList: React.FC<CombinedListProps> = ({ connectionId, onSelectConne
   });
 
   const [removeConnection] = useMutation(REMOVE_CONNECTION, {
-    onCompleted: () => {
-      if (connectionId) onSelectConnection(null);
-      refetchConnections();
-    },
+    onCompleted: () => refetchConnections(),
     onError: (err) => setError(err.message),
   });
 
@@ -93,19 +73,9 @@ const CombinedList: React.FC<CombinedListProps> = ({ connectionId, onSelectConne
     }
   }, [error, success]);
 
-  // Switch to rankings tab when connection selected
-  useEffect(() => {
-    if (connectionId) setTab('rankings');
-  }, [connectionId]);
-
   const incomingPending = pendingData?.pendingConnectionRequests?.filter((r: any) => r.direction === 'received') || [];
   const outgoingPending = pendingData?.pendingConnectionRequests?.filter((r: any) => r.direction === 'sent') || [];
   const connections = connectionsData?.myConnections || [];
-
-  const handleViewCombined = (connId: string) => {
-    onSelectConnection(connId);
-    setTab('rankings');
-  };
 
   return (
     <Box
@@ -121,341 +91,165 @@ const CombinedList: React.FC<CombinedListProps> = ({ connectionId, onSelectConne
         {/* Header */}
         <Box sx={{ textAlign: 'center', mb: { xs: 3, sm: 4 } }}>
           <Typography level="h2" sx={{ fontWeight: 800, letterSpacing: '-0.02em', mb: 0.5 }}>
-            Combined List
+            Connections
           </Typography>
           <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
-            Connect with friends and see your combined movie rankings
+            Connect with friends to see combined movie rankings on the home page
           </Typography>
-        </Box>
-
-        {/* Tabs */}
-        <Box sx={{ display: 'flex', justifyContent: 'center', gap: 1, mb: 3 }}>
-          <Button
-            variant={tab === 'connections' ? 'soft' : 'plain'}
-            color="neutral"
-            size="sm"
-            onClick={() => setTab('connections')}
-            sx={{ fontWeight: 600, color: tab === 'connections' ? 'primary.400' : 'text.secondary' }}
-          >
-            Connections
-          </Button>
-          <Button
-            variant={tab === 'rankings' ? 'soft' : 'plain'}
-            color="neutral"
-            size="sm"
-            onClick={() => setTab('rankings')}
-            disabled={!connectionId && connections.length === 0}
-            sx={{ fontWeight: 600, color: tab === 'rankings' ? 'primary.400' : 'text.secondary' }}
-          >
-            Rankings
-          </Button>
         </Box>
 
         {/* Alerts */}
         {error && <Alert color="danger" sx={{ mb: 2 }}>{error}</Alert>}
         {success && <Alert color="success" sx={{ mb: 2 }}>{success}</Alert>}
 
-        {tab === 'connections' && (
-          <>
-            {/* Search */}
-            <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'md', mb: 3, borderColor: 'var(--mn-border-vis)' }}>
-              <Typography level="title-sm" sx={{ mb: 1.5, fontWeight: 700 }}>Find a friend</Typography>
-              <Box sx={{ display: 'flex', gap: 1 }}>
-                <Input
-                  placeholder="Search by username..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  sx={{ flex: 1 }}
-                  size="sm"
-                />
-                {searchLoading && <CircularProgress size="sm" />}
-              </Box>
-              {searchResults.length > 0 && (
-                <Box sx={{ mt: 1.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
-                  {searchResults.map((u: any) => (
-                    <Box
-                      key={u.id}
-                      sx={{
-                        display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-                        p: 1, borderRadius: 'sm', bgcolor: 'background.level1',
-                      }}
-                    >
-                      <Typography level="body-sm" sx={{ fontWeight: 600 }}>
-                        {u.display_name || u.username}
-                        {u.display_name && (
-                          <Typography component="span" level="body-xs" sx={{ color: 'text.tertiary', ml: 0.5 }}>
-                            @{u.username}
-                          </Typography>
-                        )}
+        {/* Search */}
+        <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'md', mb: 3, borderColor: 'var(--mn-border-vis)' }}>
+          <Typography level="title-sm" sx={{ mb: 1.5, fontWeight: 700 }}>Find a friend</Typography>
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Input
+              placeholder="Search by username..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              sx={{ flex: 1 }}
+              size="sm"
+            />
+            {searchLoading && <CircularProgress size="sm" />}
+          </Box>
+          {searchResults.length > 0 && (
+            <Box sx={{ mt: 1.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
+              {searchResults.map((u: any) => (
+                <Box
+                  key={u.id}
+                  sx={{
+                    display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                    p: 1, borderRadius: 'sm', bgcolor: 'background.level1',
+                  }}
+                >
+                  <Typography level="body-sm" sx={{ fontWeight: 600 }}>
+                    {u.display_name || u.username}
+                    {u.display_name && (
+                      <Typography component="span" level="body-xs" sx={{ color: 'text.tertiary', ml: 0.5 }}>
+                        @{u.username}
                       </Typography>
-                      <Button
-                        size="sm"
-                        variant="soft"
-                        color="primary"
-                        loading={sendingRequest}
-                        onClick={() => sendRequest({ variables: { addresseeId: u.id } })}
-                      >
-                        Connect
-                      </Button>
-                    </Box>
-                  ))}
-                </Box>
-              )}
-            </Sheet>
-
-            {/* Pending incoming */}
-            {incomingPending.length > 0 && (
-              <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'md', mb: 3, borderColor: 'warning.outlinedBorder' }}>
-                <Typography level="title-sm" sx={{ mb: 1.5, fontWeight: 700 }}>
-                  Pending requests ({incomingPending.length})
-                </Typography>
-                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-                  {incomingPending.map((req: any) => (
-                    <Box
-                      key={req.id}
-                      sx={{
-                        display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-                        p: 1, borderRadius: 'sm', bgcolor: 'background.level1',
-                      }}
-                    >
-                      <Typography level="body-sm" sx={{ fontWeight: 600 }}>
-                        {req.user.display_name || req.user.username}
-                        <Typography component="span" level="body-xs" sx={{ color: 'text.tertiary', ml: 0.5 }}>
-                          wants to connect
-                        </Typography>
-                      </Typography>
-                      <Box sx={{ display: 'flex', gap: 0.5 }}>
-                        <Button
-                          size="sm" variant="soft" color="success"
-                          onClick={() => respond({ variables: { connectionId: req.id, accept: true } })}
-                        >
-                          Accept
-                        </Button>
-                        <Button
-                          size="sm" variant="plain" color="danger"
-                          onClick={() => respond({ variables: { connectionId: req.id, accept: false } })}
-                        >
-                          Decline
-                        </Button>
-                      </Box>
-                    </Box>
-                  ))}
-                </Box>
-              </Sheet>
-            )}
-
-            {/* Outgoing pending */}
-            {outgoingPending.length > 0 && (
-              <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'md', mb: 3, borderColor: 'var(--mn-border-vis)' }}>
-                <Typography level="title-sm" sx={{ mb: 1.5, fontWeight: 700 }}>Sent requests</Typography>
-                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-                  {outgoingPending.map((req: any) => (
-                    <Box
-                      key={req.id}
-                      sx={{
-                        display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-                        p: 1, borderRadius: 'sm', bgcolor: 'background.level1',
-                      }}
-                    >
-                      <Typography level="body-sm" sx={{ fontWeight: 600 }}>
-                        {req.user.display_name || req.user.username}
-                      </Typography>
-                      <Chip size="sm" variant="soft" color="neutral">Pending</Chip>
-                    </Box>
-                  ))}
-                </Box>
-              </Sheet>
-            )}
-
-            {/* Active connections */}
-            <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'md', borderColor: 'var(--mn-border-vis)' }}>
-              <Typography level="title-sm" sx={{ mb: 1.5, fontWeight: 700 }}>Your connections</Typography>
-              {connections.length === 0 && (
-                <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
-                  No connections yet. Search for a friend above!
-                </Typography>
-              )}
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-                {connections.map((conn: any) => (
-                  <Box
-                    key={conn.id}
-                    sx={{
-                      display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-                      p: 1, borderRadius: 'sm', bgcolor: 'background.level1',
-                    }}
-                  >
-                    <Typography level="body-sm" sx={{ fontWeight: 600 }}>
-                      {conn.user.display_name || conn.user.username}
-                    </Typography>
-                    <Box sx={{ display: 'flex', gap: 0.5 }}>
-                      <Button
-                        size="sm" variant="soft" color="primary"
-                        onClick={() => handleViewCombined(conn.id)}
-                      >
-                        View Combined
-                      </Button>
-                      <Button
-                        size="sm" variant="plain" color="danger"
-                        onClick={() => {
-                          if (window.confirm(`Remove connection with ${conn.user.display_name || conn.user.username}?`)) {
-                            removeConnection({ variables: { connectionId: conn.id } });
-                          }
-                        }}
-                        sx={{ opacity: 0.5, '&:hover': { opacity: 1 } }}
-                      >
-                        Remove
-                      </Button>
-                    </Box>
-                  </Box>
-                ))}
-              </Box>
-            </Sheet>
-          </>
-        )}
-
-        {tab === 'rankings' && (
-          <>
-            {!connectionId && connections.length > 0 && (
-              <Box sx={{ textAlign: 'center', py: 4 }}>
-                <Typography level="body-md" sx={{ color: 'text.secondary', mb: 2 }}>
-                  Select a connection to view combined rankings
-                </Typography>
-                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, maxWidth: 400, mx: 'auto' }}>
-                  {connections.map((conn: any) => (
-                    <Button
-                      key={conn.id}
-                      variant="outlined"
-                      color="neutral"
-                      onClick={() => handleViewCombined(conn.id)}
-                      sx={{ justifyContent: 'flex-start' }}
-                    >
-                      {conn.user.display_name || conn.user.username}
-                    </Button>
-                  ))}
-                </Box>
-              </Box>
-            )}
-
-            {!connectionId && connections.length === 0 && (
-              <Box sx={{ textAlign: 'center', py: 6 }}>
-                <Typography level="body-md" sx={{ color: 'text.secondary' }}>
-                  No connections yet. Go to the Connections tab to add a friend!
-                </Typography>
-              </Box>
-            )}
-
-            {connectionId && combinedLoading && (
-              <Box sx={{ textAlign: 'center', py: 4 }}>
-                <CircularProgress size="sm" />
-              </Box>
-            )}
-
-            {connectionId && combinedData?.combinedList && (
-              <>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-                  <Typography level="title-md" sx={{ fontWeight: 700 }}>
-                    {user?.display_name || user?.username} + {combinedData.combinedList.connection.user.display_name || combinedData.combinedList.connection.user.username}
+                    )}
                   </Typography>
                   <Button
-                    size="sm" variant="plain" color="neutral"
-                    onClick={() => { onSelectConnection(null); setTab('connections'); }}
+                    size="sm"
+                    variant="soft"
+                    color="primary"
+                    loading={sendingRequest}
+                    onClick={() => sendRequest({ variables: { addresseeId: u.id } })}
                   >
-                    Change
+                    Connect
                   </Button>
                 </Box>
+              ))}
+            </Box>
+          )}
+        </Sheet>
 
-                {combinedData.combinedList.rankings.length === 0 ? (
-                  <Box sx={{ textAlign: 'center', py: 6 }}>
-                    <Typography level="body-md" sx={{ color: 'text.secondary' }}>
-                      No rankings to combine yet. Both users need to do some "This or That" comparisons first!
+        {/* Pending incoming */}
+        {incomingPending.length > 0 && (
+          <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'md', mb: 3, borderColor: 'warning.outlinedBorder' }}>
+            <Typography level="title-sm" sx={{ mb: 1.5, fontWeight: 700 }}>
+              Pending requests ({incomingPending.length})
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+              {incomingPending.map((req: any) => (
+                <Box
+                  key={req.id}
+                  sx={{
+                    display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                    p: 1, borderRadius: 'sm', bgcolor: 'background.level1',
+                  }}
+                >
+                  <Typography level="body-sm" sx={{ fontWeight: 600 }}>
+                    {req.user.display_name || req.user.username}
+                    <Typography component="span" level="body-xs" sx={{ color: 'text.tertiary', ml: 0.5 }}>
+                      wants to connect
                     </Typography>
+                  </Typography>
+                  <Box sx={{ display: 'flex', gap: 0.5 }}>
+                    <Button
+                      size="sm" variant="soft" color="success"
+                      onClick={() => respond({ variables: { connectionId: req.id, accept: true } })}
+                    >
+                      Accept
+                    </Button>
+                    <Button
+                      size="sm" variant="plain" color="danger"
+                      onClick={() => respond({ variables: { connectionId: req.id, accept: false } })}
+                    >
+                      Decline
+                    </Button>
                   </Box>
-                ) : (
-                  <Sheet
-                    variant="outlined"
-                    sx={{ borderRadius: 'md', overflow: 'clip', borderColor: 'var(--mn-border-vis)' }}
-                  >
-                    <Box sx={{ overflowX: 'auto' }}>
-                      <table style={{ width: '100%', borderCollapse: 'collapse', tableLayout: 'auto' }}>
-                        <thead>
-                          <tr style={{ background: 'var(--mn-bg-elevated)', borderBottom: '1px solid var(--mn-border-vis)' }}>
-                            <th style={thStyle}>#</th>
-                            <th style={{ ...thStyle, textAlign: 'left' }}>Title</th>
-                            <th style={thStyle}>You</th>
-                            <th style={thStyle}>Them</th>
-                            <th style={thStyle}>Combined</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {combinedData.combinedList.rankings.map((r: any, idx: number) => (
-                            <tr key={r.movie.id}>
-                              <td style={{ ...tdStyle, textAlign: 'center', width: 48 }}>
-                                <Typography level="body-xs" sx={{ fontWeight: 700, color: idx < 3 ? 'primary.400' : 'text.tertiary' }}>
-                                  {idx + 1}
-                                </Typography>
-                              </td>
-                              <td style={tdStyle}>
-                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                                  <Typography level="body-sm" sx={{ fontWeight: 600 }}>
-                                    {r.movie.title}
-                                  </Typography>
-                                  {!r.bothRated && (
-                                    <Chip size="sm" variant="soft" color="neutral">partial</Chip>
-                                  )}
-                                </Box>
-                              </td>
-                              <td style={{ ...tdStyle, textAlign: 'center' }}>
-                                {r.userAElo != null ? (
-                                  <Chip size="sm" variant="soft" color={r.userAElo >= 1000 ? 'success' : 'warning'}>
-                                    {Math.round(r.userAElo)}
-                                  </Chip>
-                                ) : (
-                                  <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>--</Typography>
-                                )}
-                              </td>
-                              <td style={{ ...tdStyle, textAlign: 'center' }}>
-                                {r.userBElo != null ? (
-                                  <Chip size="sm" variant="soft" color={r.userBElo >= 1000 ? 'success' : 'warning'}>
-                                    {Math.round(r.userBElo)}
-                                  </Chip>
-                                ) : (
-                                  <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>--</Typography>
-                                )}
-                              </td>
-                              <td style={{ ...tdStyle, textAlign: 'center' }}>
-                                <Chip size="sm" variant="solid" color="primary">
-                                  {Math.round(r.combinedElo)}
-                                </Chip>
-                              </td>
-                            </tr>
-                          ))}
-                        </tbody>
-                      </table>
-                    </Box>
-                  </Sheet>
-                )}
-              </>
-            )}
-          </>
+                </Box>
+              ))}
+            </Box>
+          </Sheet>
         )}
+
+        {/* Outgoing pending */}
+        {outgoingPending.length > 0 && (
+          <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'md', mb: 3, borderColor: 'var(--mn-border-vis)' }}>
+            <Typography level="title-sm" sx={{ mb: 1.5, fontWeight: 700 }}>Sent requests</Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+              {outgoingPending.map((req: any) => (
+                <Box
+                  key={req.id}
+                  sx={{
+                    display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                    p: 1, borderRadius: 'sm', bgcolor: 'background.level1',
+                  }}
+                >
+                  <Typography level="body-sm" sx={{ fontWeight: 600 }}>
+                    {req.user.display_name || req.user.username}
+                  </Typography>
+                  <Chip size="sm" variant="soft" color="neutral">Pending</Chip>
+                </Box>
+              ))}
+            </Box>
+          </Sheet>
+        )}
+
+        {/* Active connections */}
+        <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'md', borderColor: 'var(--mn-border-vis)' }}>
+          <Typography level="title-sm" sx={{ mb: 1.5, fontWeight: 700 }}>Your connections</Typography>
+          {connections.length === 0 && (
+            <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
+              No connections yet. Search for a friend above!
+            </Typography>
+          )}
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            {connections.map((conn: any) => (
+              <Box
+                key={conn.id}
+                sx={{
+                  display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                  p: 1, borderRadius: 'sm', bgcolor: 'background.level1',
+                }}
+              >
+                <Typography level="body-sm" sx={{ fontWeight: 600 }}>
+                  {conn.user.display_name || conn.user.username}
+                </Typography>
+                <Button
+                  size="sm" variant="plain" color="danger"
+                  onClick={() => {
+                    if (window.confirm(`Remove connection with ${conn.user.display_name || conn.user.username}?`)) {
+                      removeConnection({ variables: { connectionId: conn.id } });
+                    }
+                  }}
+                  sx={{ opacity: 0.5, '&:hover': { opacity: 1 } }}
+                >
+                  Remove
+                </Button>
+              </Box>
+            ))}
+          </Box>
+        </Sheet>
       </Box>
     </Box>
   );
-};
-
-const thStyle: React.CSSProperties = {
-  padding: '10px 12px',
-  textAlign: 'center',
-  fontSize: '0.7rem',
-  fontWeight: 700,
-  textTransform: 'uppercase',
-  letterSpacing: '0.08em',
-  color: 'var(--mn-text-muted)',
-};
-
-const tdStyle: React.CSSProperties = {
-  padding: '12px',
-  verticalAlign: 'middle',
 };
 
 export default CombinedList;

--- a/src/components/home/CombinedList.tsx
+++ b/src/components/home/CombinedList.tsx
@@ -1,0 +1,461 @@
+import React, { useState, useEffect } from 'react';
+import { useQuery, useLazyQuery, useMutation } from '@apollo/client';
+import {
+  Box, Typography, Button, Sheet, Chip, Input, CircularProgress, Alert,
+} from '@mui/joy';
+import {
+  SEARCH_USERS,
+  MY_CONNECTIONS,
+  PENDING_CONNECTION_REQUESTS,
+  COMBINED_LIST,
+  SEND_CONNECTION_REQUEST,
+  RESPOND_TO_CONNECTION_REQUEST,
+  REMOVE_CONNECTION,
+} from '../../graphql/queries';
+import { useAuth } from '../../contexts/AuthContext';
+
+type Tab = 'connections' | 'rankings';
+
+interface CombinedListProps {
+  connectionId: string | null;
+  onSelectConnection: (id: string | null) => void;
+}
+
+const CombinedList: React.FC<CombinedListProps> = ({ connectionId, onSelectConnection }) => {
+  const { user } = useAuth();
+  const [tab, setTab] = useState<Tab>(connectionId ? 'rankings' : 'connections');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<any[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const [searchUsers, { loading: searchLoading }] = useLazyQuery(SEARCH_USERS, {
+    fetchPolicy: 'network-only',
+    onCompleted: (data) => setSearchResults(data.searchUsers),
+  });
+
+  const { data: connectionsData, refetch: refetchConnections } = useQuery(MY_CONNECTIONS);
+  const { data: pendingData, refetch: refetchPending } = useQuery(PENDING_CONNECTION_REQUESTS, {
+    pollInterval: 5000,
+  });
+
+  const { data: combinedData, loading: combinedLoading } = useQuery(COMBINED_LIST, {
+    variables: { connectionId },
+    skip: !connectionId,
+    fetchPolicy: 'cache-and-network',
+  });
+
+  const [sendRequest, { loading: sendingRequest }] = useMutation(SEND_CONNECTION_REQUEST, {
+    onCompleted: (data) => {
+      const status = data.sendConnectionRequest.status;
+      setSuccess(status === 'accepted' ? 'Connected! (mutual request)' : 'Request sent!');
+      setSearchQuery('');
+      setSearchResults([]);
+      refetchPending();
+      refetchConnections();
+    },
+    onError: (err) => setError(err.message),
+  });
+
+  const [respond] = useMutation(RESPOND_TO_CONNECTION_REQUEST, {
+    onCompleted: () => {
+      refetchPending();
+      refetchConnections();
+    },
+    onError: (err) => setError(err.message),
+  });
+
+  const [removeConnection] = useMutation(REMOVE_CONNECTION, {
+    onCompleted: () => {
+      if (connectionId) onSelectConnection(null);
+      refetchConnections();
+    },
+    onError: (err) => setError(err.message),
+  });
+
+  // Debounced search
+  useEffect(() => {
+    if (searchQuery.trim().length < 2) {
+      setSearchResults([]);
+      return;
+    }
+    const timer = setTimeout(() => {
+      searchUsers({ variables: { query: searchQuery.trim() } });
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [searchQuery, searchUsers]);
+
+  // Auto-clear alerts
+  useEffect(() => {
+    if (error || success) {
+      const timer = setTimeout(() => { setError(null); setSuccess(null); }, 4000);
+      return () => clearTimeout(timer);
+    }
+  }, [error, success]);
+
+  // Switch to rankings tab when connection selected
+  useEffect(() => {
+    if (connectionId) setTab('rankings');
+  }, [connectionId]);
+
+  const incomingPending = pendingData?.pendingConnectionRequests?.filter((r: any) => r.direction === 'received') || [];
+  const outgoingPending = pendingData?.pendingConnectionRequests?.filter((r: any) => r.direction === 'sent') || [];
+  const connections = connectionsData?.myConnections || [];
+
+  const handleViewCombined = (connId: string) => {
+    onSelectConnection(connId);
+    setTab('rankings');
+  };
+
+  return (
+    <Box
+      component="main"
+      sx={{
+        flex: 1,
+        bgcolor: 'background.body',
+        px: { xs: 2, sm: 3, md: 4 },
+        py: { xs: 3, sm: 5 },
+      }}
+    >
+      <Box sx={{ maxWidth: 900, mx: 'auto' }}>
+        {/* Header */}
+        <Box sx={{ textAlign: 'center', mb: { xs: 3, sm: 4 } }}>
+          <Typography level="h2" sx={{ fontWeight: 800, letterSpacing: '-0.02em', mb: 0.5 }}>
+            Combined List
+          </Typography>
+          <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
+            Connect with friends and see your combined movie rankings
+          </Typography>
+        </Box>
+
+        {/* Tabs */}
+        <Box sx={{ display: 'flex', justifyContent: 'center', gap: 1, mb: 3 }}>
+          <Button
+            variant={tab === 'connections' ? 'soft' : 'plain'}
+            color="neutral"
+            size="sm"
+            onClick={() => setTab('connections')}
+            sx={{ fontWeight: 600, color: tab === 'connections' ? 'primary.400' : 'text.secondary' }}
+          >
+            Connections
+          </Button>
+          <Button
+            variant={tab === 'rankings' ? 'soft' : 'plain'}
+            color="neutral"
+            size="sm"
+            onClick={() => setTab('rankings')}
+            disabled={!connectionId && connections.length === 0}
+            sx={{ fontWeight: 600, color: tab === 'rankings' ? 'primary.400' : 'text.secondary' }}
+          >
+            Rankings
+          </Button>
+        </Box>
+
+        {/* Alerts */}
+        {error && <Alert color="danger" sx={{ mb: 2 }}>{error}</Alert>}
+        {success && <Alert color="success" sx={{ mb: 2 }}>{success}</Alert>}
+
+        {tab === 'connections' && (
+          <>
+            {/* Search */}
+            <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'md', mb: 3, borderColor: 'var(--mn-border-vis)' }}>
+              <Typography level="title-sm" sx={{ mb: 1.5, fontWeight: 700 }}>Find a friend</Typography>
+              <Box sx={{ display: 'flex', gap: 1 }}>
+                <Input
+                  placeholder="Search by username..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  sx={{ flex: 1 }}
+                  size="sm"
+                />
+                {searchLoading && <CircularProgress size="sm" />}
+              </Box>
+              {searchResults.length > 0 && (
+                <Box sx={{ mt: 1.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
+                  {searchResults.map((u: any) => (
+                    <Box
+                      key={u.id}
+                      sx={{
+                        display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                        p: 1, borderRadius: 'sm', bgcolor: 'background.level1',
+                      }}
+                    >
+                      <Typography level="body-sm" sx={{ fontWeight: 600 }}>
+                        {u.display_name || u.username}
+                        {u.display_name && (
+                          <Typography component="span" level="body-xs" sx={{ color: 'text.tertiary', ml: 0.5 }}>
+                            @{u.username}
+                          </Typography>
+                        )}
+                      </Typography>
+                      <Button
+                        size="sm"
+                        variant="soft"
+                        color="primary"
+                        loading={sendingRequest}
+                        onClick={() => sendRequest({ variables: { addresseeId: u.id } })}
+                      >
+                        Connect
+                      </Button>
+                    </Box>
+                  ))}
+                </Box>
+              )}
+            </Sheet>
+
+            {/* Pending incoming */}
+            {incomingPending.length > 0 && (
+              <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'md', mb: 3, borderColor: 'warning.outlinedBorder' }}>
+                <Typography level="title-sm" sx={{ mb: 1.5, fontWeight: 700 }}>
+                  Pending requests ({incomingPending.length})
+                </Typography>
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                  {incomingPending.map((req: any) => (
+                    <Box
+                      key={req.id}
+                      sx={{
+                        display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                        p: 1, borderRadius: 'sm', bgcolor: 'background.level1',
+                      }}
+                    >
+                      <Typography level="body-sm" sx={{ fontWeight: 600 }}>
+                        {req.user.display_name || req.user.username}
+                        <Typography component="span" level="body-xs" sx={{ color: 'text.tertiary', ml: 0.5 }}>
+                          wants to connect
+                        </Typography>
+                      </Typography>
+                      <Box sx={{ display: 'flex', gap: 0.5 }}>
+                        <Button
+                          size="sm" variant="soft" color="success"
+                          onClick={() => respond({ variables: { connectionId: req.id, accept: true } })}
+                        >
+                          Accept
+                        </Button>
+                        <Button
+                          size="sm" variant="plain" color="danger"
+                          onClick={() => respond({ variables: { connectionId: req.id, accept: false } })}
+                        >
+                          Decline
+                        </Button>
+                      </Box>
+                    </Box>
+                  ))}
+                </Box>
+              </Sheet>
+            )}
+
+            {/* Outgoing pending */}
+            {outgoingPending.length > 0 && (
+              <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'md', mb: 3, borderColor: 'var(--mn-border-vis)' }}>
+                <Typography level="title-sm" sx={{ mb: 1.5, fontWeight: 700 }}>Sent requests</Typography>
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                  {outgoingPending.map((req: any) => (
+                    <Box
+                      key={req.id}
+                      sx={{
+                        display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                        p: 1, borderRadius: 'sm', bgcolor: 'background.level1',
+                      }}
+                    >
+                      <Typography level="body-sm" sx={{ fontWeight: 600 }}>
+                        {req.user.display_name || req.user.username}
+                      </Typography>
+                      <Chip size="sm" variant="soft" color="neutral">Pending</Chip>
+                    </Box>
+                  ))}
+                </Box>
+              </Sheet>
+            )}
+
+            {/* Active connections */}
+            <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'md', borderColor: 'var(--mn-border-vis)' }}>
+              <Typography level="title-sm" sx={{ mb: 1.5, fontWeight: 700 }}>Your connections</Typography>
+              {connections.length === 0 && (
+                <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
+                  No connections yet. Search for a friend above!
+                </Typography>
+              )}
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                {connections.map((conn: any) => (
+                  <Box
+                    key={conn.id}
+                    sx={{
+                      display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                      p: 1, borderRadius: 'sm', bgcolor: 'background.level1',
+                    }}
+                  >
+                    <Typography level="body-sm" sx={{ fontWeight: 600 }}>
+                      {conn.user.display_name || conn.user.username}
+                    </Typography>
+                    <Box sx={{ display: 'flex', gap: 0.5 }}>
+                      <Button
+                        size="sm" variant="soft" color="primary"
+                        onClick={() => handleViewCombined(conn.id)}
+                      >
+                        View Combined
+                      </Button>
+                      <Button
+                        size="sm" variant="plain" color="danger"
+                        onClick={() => {
+                          if (window.confirm(`Remove connection with ${conn.user.display_name || conn.user.username}?`)) {
+                            removeConnection({ variables: { connectionId: conn.id } });
+                          }
+                        }}
+                        sx={{ opacity: 0.5, '&:hover': { opacity: 1 } }}
+                      >
+                        Remove
+                      </Button>
+                    </Box>
+                  </Box>
+                ))}
+              </Box>
+            </Sheet>
+          </>
+        )}
+
+        {tab === 'rankings' && (
+          <>
+            {!connectionId && connections.length > 0 && (
+              <Box sx={{ textAlign: 'center', py: 4 }}>
+                <Typography level="body-md" sx={{ color: 'text.secondary', mb: 2 }}>
+                  Select a connection to view combined rankings
+                </Typography>
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, maxWidth: 400, mx: 'auto' }}>
+                  {connections.map((conn: any) => (
+                    <Button
+                      key={conn.id}
+                      variant="outlined"
+                      color="neutral"
+                      onClick={() => handleViewCombined(conn.id)}
+                      sx={{ justifyContent: 'flex-start' }}
+                    >
+                      {conn.user.display_name || conn.user.username}
+                    </Button>
+                  ))}
+                </Box>
+              </Box>
+            )}
+
+            {!connectionId && connections.length === 0 && (
+              <Box sx={{ textAlign: 'center', py: 6 }}>
+                <Typography level="body-md" sx={{ color: 'text.secondary' }}>
+                  No connections yet. Go to the Connections tab to add a friend!
+                </Typography>
+              </Box>
+            )}
+
+            {connectionId && combinedLoading && (
+              <Box sx={{ textAlign: 'center', py: 4 }}>
+                <CircularProgress size="sm" />
+              </Box>
+            )}
+
+            {connectionId && combinedData?.combinedList && (
+              <>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+                  <Typography level="title-md" sx={{ fontWeight: 700 }}>
+                    {user?.display_name || user?.username} + {combinedData.combinedList.connection.user.display_name || combinedData.combinedList.connection.user.username}
+                  </Typography>
+                  <Button
+                    size="sm" variant="plain" color="neutral"
+                    onClick={() => { onSelectConnection(null); setTab('connections'); }}
+                  >
+                    Change
+                  </Button>
+                </Box>
+
+                {combinedData.combinedList.rankings.length === 0 ? (
+                  <Box sx={{ textAlign: 'center', py: 6 }}>
+                    <Typography level="body-md" sx={{ color: 'text.secondary' }}>
+                      No rankings to combine yet. Both users need to do some "This or That" comparisons first!
+                    </Typography>
+                  </Box>
+                ) : (
+                  <Sheet
+                    variant="outlined"
+                    sx={{ borderRadius: 'md', overflow: 'clip', borderColor: 'var(--mn-border-vis)' }}
+                  >
+                    <Box sx={{ overflowX: 'auto' }}>
+                      <table style={{ width: '100%', borderCollapse: 'collapse', tableLayout: 'auto' }}>
+                        <thead>
+                          <tr style={{ background: 'var(--mn-bg-elevated)', borderBottom: '1px solid var(--mn-border-vis)' }}>
+                            <th style={thStyle}>#</th>
+                            <th style={{ ...thStyle, textAlign: 'left' }}>Title</th>
+                            <th style={thStyle}>You</th>
+                            <th style={thStyle}>Them</th>
+                            <th style={thStyle}>Combined</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {combinedData.combinedList.rankings.map((r: any, idx: number) => (
+                            <tr key={r.movie.id}>
+                              <td style={{ ...tdStyle, textAlign: 'center', width: 48 }}>
+                                <Typography level="body-xs" sx={{ fontWeight: 700, color: idx < 3 ? 'primary.400' : 'text.tertiary' }}>
+                                  {idx + 1}
+                                </Typography>
+                              </td>
+                              <td style={tdStyle}>
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                  <Typography level="body-sm" sx={{ fontWeight: 600 }}>
+                                    {r.movie.title}
+                                  </Typography>
+                                  {!r.bothRated && (
+                                    <Chip size="sm" variant="soft" color="neutral">partial</Chip>
+                                  )}
+                                </Box>
+                              </td>
+                              <td style={{ ...tdStyle, textAlign: 'center' }}>
+                                {r.userAElo != null ? (
+                                  <Chip size="sm" variant="soft" color={r.userAElo >= 1000 ? 'success' : 'warning'}>
+                                    {Math.round(r.userAElo)}
+                                  </Chip>
+                                ) : (
+                                  <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>--</Typography>
+                                )}
+                              </td>
+                              <td style={{ ...tdStyle, textAlign: 'center' }}>
+                                {r.userBElo != null ? (
+                                  <Chip size="sm" variant="soft" color={r.userBElo >= 1000 ? 'success' : 'warning'}>
+                                    {Math.round(r.userBElo)}
+                                  </Chip>
+                                ) : (
+                                  <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>--</Typography>
+                                )}
+                              </td>
+                              <td style={{ ...tdStyle, textAlign: 'center' }}>
+                                <Chip size="sm" variant="solid" color="primary">
+                                  {Math.round(r.combinedElo)}
+                                </Chip>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </Box>
+                  </Sheet>
+                )}
+              </>
+            )}
+          </>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+const thStyle: React.CSSProperties = {
+  padding: '10px 12px',
+  textAlign: 'center',
+  fontSize: '0.7rem',
+  fontWeight: 700,
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  color: 'var(--mn-text-muted)',
+};
+
+const tdStyle: React.CSSProperties = {
+  padding: '12px',
+  verticalAlign: 'middle',
+};
+
+export default CombinedList;

--- a/src/components/home/Homepage.tsx
+++ b/src/components/home/Homepage.tsx
@@ -8,6 +8,9 @@ import {
   SEARCH_TMDB,
   SEED_MOVIES,
   GET_APP_INFO,
+  MY_CONNECTIONS,
+  PENDING_CONNECTION_REQUESTS,
+  COMBINED_LIST,
 } from "../../graphql/queries";
 import {
   Autocomplete,
@@ -19,6 +22,7 @@ import {
   Chip,
   IconButton,
   ListItemContent,
+  CircularProgress,
 } from "@mui/joy";
 import TmdbMatchFlow from "./TmdbMatchFlow";
 import { Movie } from "../../models/Movies";
@@ -154,9 +158,10 @@ const MovieRow: React.FC<MovieRowProps> = ({
 
 interface HomePageProps {
   onShowThisOrThat?: () => void;
+  onShowConnections?: () => void;
 }
 
-const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat }) => {
+const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections }) => {
   const { isAuthenticated, user } = useAuth();
   const isAdmin = user?.is_admin ?? false;
 
@@ -166,6 +171,25 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat }) => {
   const [successMessage, setSuccessMessage] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
   const [matchFlowOpen, setMatchFlowOpen] = useState(false);
+  const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
+
+  // Connections data (only when authenticated)
+  const { data: connectionsData } = useQuery(MY_CONNECTIONS, { skip: !isAuthenticated });
+  const { data: pendingData } = useQuery(PENDING_CONNECTION_REQUESTS, {
+    skip: !isAuthenticated,
+    pollInterval: 10000,
+  });
+  const { data: combinedData, loading: combinedLoading } = useQuery(COMBINED_LIST, {
+    variables: { connectionId: selectedConnectionId },
+    skip: !selectedConnectionId,
+    fetchPolicy: 'cache-and-network',
+  });
+
+  const connections = connectionsData?.myConnections || [];
+  const incomingPending = pendingData?.pendingConnectionRequests?.filter(
+    (r: any) => r.direction === 'received'
+  ) || [];
+  const isCombinedView = selectedConnectionId !== null;
 
   const debouncedTitle = useDebounce(title, 400);
 
@@ -284,7 +308,7 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat }) => {
     >
       <Box sx={{ maxWidth: 900, mx: "auto" }}>
         {/* Page header */}
-        <Box sx={{ textAlign: "center", mb: { xs: 4, sm: 5 } }}>
+        <Box sx={{ textAlign: "center", mb: { xs: 3, sm: 4 } }}>
           <Typography
             level="h2"
             sx={{ fontWeight: 800, letterSpacing: "-0.02em", mb: 0.5 }}
@@ -298,8 +322,69 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat }) => {
           </Typography>
         </Box>
 
+        {/* View selector — segmented control */}
+        {isAuthenticated && connections.length > 0 && (
+          <Box sx={{
+            display: 'flex', justifyContent: 'center', flexWrap: 'wrap',
+            gap: 0.5, mb: 3,
+          }}>
+            <Button
+              variant={!isCombinedView ? 'soft' : 'plain'}
+              color="neutral"
+              size="sm"
+              onClick={() => setSelectedConnectionId(null)}
+              sx={{
+                fontWeight: 600,
+                color: !isCombinedView ? 'primary.400' : 'text.secondary',
+                '&:hover': { color: 'primary.300' },
+              }}
+            >
+              My List
+            </Button>
+            {connections.map((conn: any) => (
+              <Button
+                key={conn.id}
+                variant={selectedConnectionId === conn.id ? 'soft' : 'plain'}
+                color="neutral"
+                size="sm"
+                onClick={() => setSelectedConnectionId(conn.id)}
+                sx={{
+                  fontWeight: 600,
+                  color: selectedConnectionId === conn.id ? 'primary.400' : 'text.secondary',
+                  '&:hover': { color: 'primary.300' },
+                }}
+              >
+                {conn.user.display_name || conn.user.username} + Me
+              </Button>
+            ))}
+          </Box>
+        )}
+
+        {/* Pending connection request banner */}
+        {isAuthenticated && incomingPending.length > 0 && (
+          <Box
+            sx={{
+              mb: 3, p: 1.5, borderRadius: 'md',
+              bgcolor: 'warning.softBg', border: '1px solid', borderColor: 'warning.outlinedBorder',
+              textAlign: 'center', display: 'flex', alignItems: 'center',
+              justifyContent: 'center', gap: 1,
+            }}
+          >
+            <Typography level="body-sm" sx={{ color: 'warning.softColor' }}>
+              {incomingPending.length === 1
+                ? `${incomingPending[0].user.display_name || incomingPending[0].user.username} wants to connect`
+                : `${incomingPending.length} pending connection requests`}
+            </Typography>
+            {onShowConnections && (
+              <Button variant="soft" color="warning" size="sm" onClick={onShowConnections} sx={{ fontWeight: 700 }}>
+                View
+              </Button>
+            )}
+          </Box>
+        )}
+
         {/* This or That indicator */}
-        {movies.length >= 2 && (
+        {!isCombinedView && movies.length >= 2 && (
           <Box
             sx={{
               mb: 3,
@@ -442,7 +527,96 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat }) => {
           </Typography>
         )}
 
-        {/* Movie table */}
+        {/* Combined view */}
+        {isCombinedView && (
+          <>
+            {combinedLoading && (
+              <Box sx={{ textAlign: 'center', py: 4 }}>
+                <CircularProgress size="sm" />
+              </Box>
+            )}
+            {!combinedLoading && combinedData?.combinedList && (
+              <>
+                {combinedData.combinedList.rankings.length === 0 ? (
+                  <Box sx={{ textAlign: 'center', py: 6 }}>
+                    <Typography level="body-md" sx={{ color: 'text.secondary' }}>
+                      No rankings to combine yet. Both users need to do some "This or That" comparisons first!
+                    </Typography>
+                  </Box>
+                ) : (
+                  <Sheet
+                    variant="outlined"
+                    sx={{ borderRadius: 'md', overflow: 'clip', borderColor: 'var(--mn-border-vis)' }}
+                  >
+                    <Box sx={{ overflowX: 'auto' }}>
+                      <table style={{ width: '100%', minWidth: 480, borderCollapse: 'collapse', tableLayout: 'auto' }}>
+                        <thead>
+                          <tr style={{ background: 'var(--mn-bg-elevated)', borderBottom: '1px solid var(--mn-border-vis)' }}>
+                            <th style={combinedThStyle}>#</th>
+                            <th style={{ ...combinedThStyle, textAlign: 'left' }}>Title</th>
+                            <th style={combinedThStyle}>You</th>
+                            <th style={combinedThStyle}>
+                              {combinedData.combinedList.connection.user.display_name ||
+                               combinedData.combinedList.connection.user.username}
+                            </th>
+                            <th style={combinedThStyle}>Combined</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {combinedData.combinedList.rankings.map((r: any, idx: number) => (
+                            <tr key={r.movie.id}>
+                              <td style={{ ...combinedTdStyle, textAlign: 'center', width: 48 }}>
+                                <Typography level="body-xs" sx={{ fontWeight: 700, color: idx < 3 ? 'primary.400' : 'text.tertiary' }}>
+                                  {idx + 1}
+                                </Typography>
+                              </td>
+                              <td style={combinedTdStyle}>
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                  <Typography level="body-sm" sx={{ fontWeight: 600 }}>
+                                    {r.movie.title}
+                                  </Typography>
+                                  {!r.bothRated && (
+                                    <Chip size="sm" variant="soft" color="neutral">partial</Chip>
+                                  )}
+                                </Box>
+                              </td>
+                              <td style={{ ...combinedTdStyle, textAlign: 'center' }}>
+                                {r.userAElo != null ? (
+                                  <Chip size="sm" variant="soft" color={r.userAElo >= 1000 ? 'success' : 'warning'}>
+                                    {Math.round(r.userAElo)}
+                                  </Chip>
+                                ) : (
+                                  <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>--</Typography>
+                                )}
+                              </td>
+                              <td style={{ ...combinedTdStyle, textAlign: 'center' }}>
+                                {r.userBElo != null ? (
+                                  <Chip size="sm" variant="soft" color={r.userBElo >= 1000 ? 'success' : 'warning'}>
+                                    {Math.round(r.userBElo)}
+                                  </Chip>
+                                ) : (
+                                  <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>--</Typography>
+                                )}
+                              </td>
+                              <td style={{ ...combinedTdStyle, textAlign: 'center' }}>
+                                <Chip size="sm" variant="solid" color="primary">
+                                  {Math.round(r.combinedElo)}
+                                </Chip>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </Box>
+                  </Sheet>
+                )}
+              </>
+            )}
+          </>
+        )}
+
+        {/* Movie table (personal view) */}
+        {!isCombinedView && (
         <Sheet
           variant="outlined"
           sx={{
@@ -569,6 +743,7 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat }) => {
             </table>
           </Box>
         </Sheet>
+        )}
 
         {/* Seed button — admin only, test env only */}
         {isAdmin && !isProd && (
@@ -587,6 +762,21 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat }) => {
       </Box>
     </Box>
   );
+};
+
+const combinedThStyle: React.CSSProperties = {
+  padding: '10px 12px',
+  textAlign: 'center',
+  fontSize: '0.7rem',
+  fontWeight: 700,
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  color: 'var(--mn-text-muted)',
+};
+
+const combinedTdStyle: React.CSSProperties = {
+  padding: '12px',
+  verticalAlign: 'middle',
 };
 
 export default HomePage;

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -344,3 +344,102 @@ export const RESET_PASSWORD = gql`
     }
   }
 `;
+
+export const SEARCH_USERS = gql`
+  query SearchUsers($query: String!) {
+    searchUsers(query: $query) {
+      id
+      username
+      display_name
+    }
+  }
+`;
+
+export const MY_CONNECTIONS = gql`
+  query MyConnections {
+    myConnections {
+      id
+      user {
+        id
+        username
+        display_name
+      }
+      status
+      direction
+      created_at
+    }
+  }
+`;
+
+export const PENDING_CONNECTION_REQUESTS = gql`
+  query PendingConnectionRequests {
+    pendingConnectionRequests {
+      id
+      user {
+        id
+        username
+        display_name
+      }
+      status
+      direction
+      created_at
+    }
+  }
+`;
+
+export const COMBINED_LIST = gql`
+  query CombinedList($connectionId: ID!) {
+    combinedList(connectionId: $connectionId) {
+      connection {
+        id
+        user {
+          id
+          username
+          display_name
+        }
+      }
+      rankings {
+        movie {
+          id
+          title
+          tmdb_id
+          elo_rank
+        }
+        userAElo
+        userBElo
+        combinedElo
+        bothRated
+      }
+    }
+  }
+`;
+
+export const SEND_CONNECTION_REQUEST = gql`
+  mutation SendConnectionRequest($addresseeId: ID!) {
+    sendConnectionRequest(addresseeId: $addresseeId) {
+      id
+      user {
+        id
+        username
+        display_name
+      }
+      status
+      direction
+    }
+  }
+`;
+
+export const RESPOND_TO_CONNECTION_REQUEST = gql`
+  mutation RespondToConnectionRequest($connectionId: ID!, $accept: Boolean!) {
+    respondToConnectionRequest(connectionId: $connectionId, accept: $accept) {
+      id
+      status
+    }
+  }
+`;
+
+export const REMOVE_CONNECTION = gql`
+  mutation RemoveConnection($connectionId: ID!) {
+    removeConnection(connectionId: $connectionId)
+  }
+`;


### PR DESCRIPTION
## Summary
- Users can search for other users by username and send connection requests
- Connection requests require approval — the recipient sees pending requests (polled every 5s) with Accept/Decline buttons
- Mutual pending requests auto-accept
- Once connected, both users can view a combined movie ranking table (averaged Elo ratings)
- New `user_connections` table with pending/accepted/rejected status
- "Combined" tab added to navbar for authenticated users

## Test plan
- [ ] Create two test users, each does some "This or That" comparisons
- [ ] User A searches for User B by username, sends connection request
- [ ] User B sees pending request notification, accepts it
- [ ] Both users can view combined rankings table with averaged Elo scores
- [ ] Verify mutual request auto-accept (both send requests simultaneously)
- [ ] Verify connection removal works from either side
- [ ] Verify re-request after rejection resets to pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)