### PR TITLE
fix: harden API security checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ JWT_SECRET=your-secret-key-change-in-production
 ADMIN_PASSWORD=admin123
 TMDB_API_KEY=your_tmdb_api_key_here
 
+# CORS origin (defaults to http://localhost:3000)
+# Set to your production frontend URL in production
+# CORS_ORIGIN=https://movienight.example.com
+
 # Test user seeded in development mode (NODE_ENV != production)
 # TEST_USER_USERNAME=testuser
 # TEST_USER_PASSWORD=testpass

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -23,12 +23,33 @@ async function startServer() {
 
   app.use(
     '/graphql',
-    cors<cors.CorsRequest>(),
+    cors<cors.CorsRequest>({
+      origin: process.env.CORS_ORIGIN || 'http://localhost:3000',
+      credentials: true,
+    }),
     express.json(),
     expressMiddleware(server, {
       context: async ({ req }) => {
         const token = getTokenFromHeader(req.headers.authorization);
-        const user = token ? verifyToken(token) : null;
+        let user = token ? verifyToken(token) : null;
+
+        // Revalidate JWT claims against DB to catch demoted/deactivated users
+        if (user) {
+          try {
+            const dbUser = await pool.query(
+              'SELECT is_admin, is_active FROM users WHERE id = $1',
+              [user.userId]
+            );
+            if (dbUser.rows.length === 0 || !dbUser.rows[0].is_active) {
+              user = null; // User deleted or deactivated
+            } else {
+              user = { ...user, isAdmin: dbUser.rows[0].is_admin };
+            }
+          } catch {
+            // On DB error, fall back to JWT claims rather than blocking all requests
+          }
+        }
+
         const ipAddress =
           (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
           req.ip ||

--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -461,12 +461,14 @@ export const resolvers = {
       if (!context.user) {
         throw new GraphQLError('Not authenticated', { extensions: { code: 'UNAUTHENTICATED' } });
       }
+      // Escape ILIKE wildcards to prevent user enumeration via % or _
+      const escapedQuery = query.replace(/[%_\\]/g, '\\$&');
       const result = await pool.query(
         `SELECT id, username, display_name FROM users
          WHERE is_active = true AND id <> $1
            AND (username ILIKE $2 OR display_name ILIKE $2)
          ORDER BY username ASC LIMIT 10`,
-        [context.user.userId, `%${query}%`]
+        [context.user.userId, `%${escapedQuery}%`]
       );
       return result.rows;
     },
@@ -839,7 +841,9 @@ export const resolvers = {
         });
       }
 
-      const name = collectionName || 'MovieNight Watchlist';
+      // Sanitize collection name: strip control chars, YAML-special chars, and limit length
+      const rawName = collectionName || 'MovieNight Watchlist';
+      const name = rawName.replace(/[:\n\r\t\\#%@`|>!&*?{}\[\]]/g, '').trim().slice(0, 100) || 'MovieNight Watchlist';
       const today = new Date().toISOString().split('T')[0];
       const idLines = matched.map((m: any) => `      - ${m.tmdb_id}`).join('\n');
       const yaml =

--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -48,11 +48,12 @@ async function logLoginHistory(
 
 const isProduction = () => process.env.NODE_ENV === 'production';
 
-// ── Password-reset rate limiter ──────────────────────────────────────────────
+// ── Rate limiter ─────────────────────────────────────────────────────────────
 interface RateLimitEntry { count: number; resetAt: number }
 
 const ipRateLimiter = new Map<string, RateLimitEntry>();
 const emailRateLimiter = new Map<string, RateLimitEntry>();
+const loginRateLimiter = new Map<string, RateLimitEntry>();
 
 const IP_RATE_LIMIT_WINDOW = 15 * 60 * 1000;   // 15 minutes
 const IP_RATE_LIMIT_MAX = 5;                     // max 5 requests per window per IP
@@ -61,6 +62,9 @@ const EMAIL_RATE_LIMIT_MAX = 3;                  // max 3 emails per hour per ad
 const GLOBAL_RATE_LIMIT_WINDOW = 60 * 60 * 1000; // 1 hour
 const GLOBAL_RATE_LIMIT_MAX = 50;                // max 50 reset emails per hour total
 let globalResetCount = { count: 0, resetAt: Date.now() + GLOBAL_RATE_LIMIT_WINDOW };
+
+const LOGIN_RATE_LIMIT_WINDOW = 15 * 60 * 1000; // 15 minutes
+const LOGIN_RATE_LIMIT_MAX = 10;                 // max 10 login attempts per IP per window
 
 function checkRateLimit(limiter: Map<string, RateLimitEntry>, key: string, max: number, window: number): boolean {
   const now = Date.now();
@@ -93,6 +97,9 @@ setInterval(() => {
   }
   for (const [key, entry] of emailRateLimiter) {
     if (now > entry.resetAt) emailRateLimiter.delete(key);
+  }
+  for (const [key, entry] of loginRateLimiter) {
+    if (now > entry.resetAt) loginRateLimiter.delete(key);
   }
 }, 15 * 60 * 1000).unref();
 
@@ -174,7 +181,12 @@ export const resolvers = {
         },
       ],
     }),
-    searchTmdb: async (_: any, { query }: { query: string }) => {
+    searchTmdb: async (_: any, { query }: { query: string }, context: any) => {
+      if (!context.user) {
+        throw new GraphQLError('Not authenticated', {
+          extensions: { code: 'UNAUTHENTICATED' },
+        });
+      }
       const apiKey = process.env.TMDB_API_KEY;
       if (!apiKey) {
         throw new GraphQLError('TMDB API key not configured', {
@@ -576,9 +588,15 @@ export const resolvers = {
           extensions: { code: 'UNAUTHENTICATED' },
         });
       }
+      const trimmedTitle = title.trim();
+      if (!trimmedTitle || trimmedTitle.length > 500) {
+        throw new GraphQLError('Title must be between 1 and 500 characters', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
       const insertResult = await pool.query(
         'INSERT INTO movies (title, requested_by, rank, tmdb_id) VALUES ($1, $2, 0, $3) RETURNING *',
-        [title, context.user.userId, tmdb_id ?? null]
+        [trimmedTitle, context.user.userId, tmdb_id ?? null]
       );
       const userRow = await pool.query(
         'SELECT username, display_name FROM users WHERE id = $1',
@@ -1193,6 +1211,13 @@ export const resolvers = {
       { username, password }: { username: string; password: string },
       context: any
     ) => {
+      if (!checkRateLimit(loginRateLimiter, context.ipAddress, LOGIN_RATE_LIMIT_MAX, LOGIN_RATE_LIMIT_WINDOW)) {
+        await logLoginHistory(null, context.ipAddress, context.userAgent, false);
+        throw new GraphQLError('Too many login attempts. Please try again later.', {
+          extensions: { code: 'TOO_MANY_REQUESTS' },
+        });
+      }
+
       const result = await pool.query('SELECT * FROM users WHERE username = $1', [username]);
       const user = result.rows[0];
 
@@ -1242,6 +1267,15 @@ export const resolvers = {
         throw new GraphQLError('Not authorized', {
           extensions: { code: 'FORBIDDEN' },
         });
+      }
+      if (!args.username || args.username.length > 100) {
+        throw new GraphQLError('Username must be between 1 and 100 characters', { extensions: { code: 'BAD_USER_INPUT' } });
+      }
+      if (!args.email || args.email.length > 255) {
+        throw new GraphQLError('Email must be between 1 and 255 characters', { extensions: { code: 'BAD_USER_INPUT' } });
+      }
+      if (!args.password || args.password.length < 6 || args.password.length > 128) {
+        throw new GraphQLError('Password must be between 6 and 128 characters', { extensions: { code: 'BAD_USER_INPUT' } });
       }
       const passwordHash = await hashPassword(args.password);
       const isActive = args.is_active !== false;


### PR DESCRIPTION
## Summary
- Add authentication requirement to `searchTmdb` query (was publicly accessible, exposing TMDB API key)
- Add login brute-force rate limiting (10 attempts per IP per 15-minute window)
- Revalidate JWT claims (`isAdmin`, `is_active`) from DB on every request so demoted/deactivated users lose access immediately
- Restrict CORS from wildcard `*` to configurable `CORS_ORIGIN` env var
- Add input length validation on `addMovie` (title 1-500 chars) and `createUser` (username, email, password bounds)

## Test plan
- [ ] Verify unauthenticated `searchTmdb` query returns UNAUTHENTICATED error
- [ ] Verify authenticated `searchTmdb` still works from the UI
- [ ] Test login rate limiting: 11th attempt from same IP within 15 min should be rejected
- [ ] Deactivate a user via admin panel, verify their existing JWT stops working immediately
- [ ] Demote an admin, verify their JWT no longer grants admin access
- [ ] Verify CORS header reflects `CORS_ORIGIN` env var instead of `*`
- [ ] Submit a movie with a 501-char title, verify rejection
- [ ] Create user with password < 6 chars, verify rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)