### PR TITLE
feat: comprehensive unit test suite with CI and linting

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -19,11 +19,13 @@ This directory contains the development container configuration for the MovieNig
 ## What's Included
 
 ### Base Environment
+
 - Node.js 20 (LTS)
 - Git
 - GitHub CLI
 
 ### VS Code Extensions
+
 - ESLint
 - Prettier
 - ES7+ React/Redux/React-Native snippets
@@ -32,6 +34,7 @@ This directory contains the development container configuration for the MovieNig
 - Tailwind CSS IntelliSense
 
 ### Port Forwarding
+
 - Port 3000 is automatically forwarded for the React development server
 
 ## Running the Application
@@ -58,19 +61,23 @@ The Firebase configuration is already set up in [src/db/firebase.js](../src/db/f
 ## Troubleshooting
 
 ### Container won't build
+
 - Ensure Docker Desktop is running
 - Try rebuilding the container: Command Palette > `Dev Containers: Rebuild Container`
 
 ### Port 3000 already in use
+
 - Stop any other processes using port 3000
 - Or change the port in [package.json](../package.json) scripts
 
 ### Permission issues
+
 - The container runs as the `node` user (non-root) for security
 - If you encounter permission issues, they may need to be addressed in the Dockerfile
 
 ## Customization
 
 You can customize the devcontainer by editing:
+
 - [devcontainer.json](devcontainer.json) - VS Code settings, extensions, and features
 - [Dockerfile](Dockerfile) - Base image and system dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint & Format Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: ['*']
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  lint:
+    name: Lint & Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: cd backend && npm ci
+      - name: Check formatting
+        run: npx prettier --check .
+      - name: Lint backend
+        run: cd backend && npx eslint src/
+
+  test-backend:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - name: Install dependencies
+        run: cd backend && npm ci
+      - name: Run tests with coverage
+        run: cd backend && npm test -- --coverage --ci
+
+  test-frontend:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests with coverage
+        run: npm test -- --coverage --ci --watchAll=false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  workflow_dispatch:  # Allow manual triggers from GitHub UI
+  workflow_dispatch: # Allow manual triggers from GitHub UI
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - dev
 
+permissions:
+  contents: read
+
 jobs:
   test-backend:
     name: Backend Tests

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -9,8 +9,34 @@ on:
       - dev
 
 jobs:
+  test-backend:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: cd backend && npm ci
+      - run: cd backend && npm test -- --coverage --ci
+
+  test-frontend:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm test -- --coverage --ci --watchAll=false
+
   changes:
     name: Detect changed paths
+    needs: [test-backend, test-frontend]
     runs-on: ubuntu-latest
     outputs:
       frontend: ${{ steps.filter.outputs.frontend }}

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-error.log*
 # backend
 /backend/node_modules
 /backend/dist
+/backend/coverage
 /backend/.env
 
 # docker

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+build/
+dist/
+coverage/
+node_modules/
+package-lock.json
+backend/package-lock.json
+backend/dist/
+backend/coverage/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "semi": true,
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,3 @@
 {
-  "recommendations": [
-    "anthropic.claude-code",
-    "ms-azuretools.vscode-containers"
-  ]
+  "recommendations": ["anthropic.claude-code", "ms-azuretools.vscode-containers"]
 }

--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -5,6 +5,7 @@ This document describes the authentication system implemented in MovieNight.
 ## Overview
 
 The MovieNight application now includes a complete authentication system with:
+
 - Password-based login using JWT (JSON Web Tokens)
 - Initial admin user with default credentials
 - User management for admin users (create, edit, delete users)
@@ -133,18 +134,21 @@ deleteUser(id: ID!): Boolean!  # Admin only
 Admin users can manage other users through the "Manage Users" interface:
 
 ### Create User
+
 - Click "Add User" button
 - Enter username, email, and password
 - Optionally check "Is Admin" to grant admin privileges
 - Click "Create"
 
 ### Edit User
+
 - Click "Edit" button next to a user
 - Update username, email, or admin status
 - Optionally enter a new password (leave blank to keep current password)
 - Click "Update"
 
 ### Delete User
+
 - Click "Delete" button next to a user
 - Confirm the deletion
 - Note: Users cannot delete their own account
@@ -161,12 +165,14 @@ Admin users can manage other users through the "Manage Users" interface:
 ## Testing
 
 ### Test Login
+
 1. Start the application: `docker-compose up`
 2. Navigate to `http://localhost:3000`
 3. Login with credentials: `admin` / `admin123`
 4. You should be redirected to the movie list
 
 ### Test User Management (Admin)
+
 1. Login as admin
 2. Click "Manage Users" in the navigation
 3. Create a new user
@@ -175,6 +181,7 @@ Admin users can manage other users through the "Manage Users" interface:
 6. Login as admin again and delete the test user
 
 ### Test Authorization
+
 1. Create a non-admin user
 2. Login as that user
 3. Verify that "Manage Users" is not visible
@@ -195,19 +202,23 @@ If you're upgrading an existing MovieNight installation:
 ## Troubleshooting
 
 ### "Invalid credentials" error
+
 - Verify you're using the correct username and password
 - Check if the admin user was created (check backend logs)
 - Ensure the database migration ran successfully
 
 ### Token expired
+
 - Tokens expire after 7 days
 - Simply login again to get a new token
 
 ### Can't access user management
+
 - Verify you're logged in as an admin user
 - Check the `is_admin` field in the database
 
 ### Backend errors on startup
+
 - Ensure all environment variables are set
 - Check database connectivity
 - Review backend logs for migration errors

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,13 @@ A full-stack movie suggestion app: React + TypeScript frontend, Apollo GraphQL b
 
 ## Quick orientation
 
-| Layer | Location | Key files |
-|---|---|---|
-| Frontend | `src/` | `App.tsx`, `src/components/`, `src/graphql/queries.ts`, `src/contexts/AuthContext.tsx` |
-| Backend | `backend/src/` | `index.ts`, `schema.ts`, `resolvers.ts`, `db.ts`, `auth.ts`, `scheduler.ts` |
-| DB migrations | `backend/migrations/` | numbered JS files run by node-pg-migrate |
-| Docker | root | `docker-compose.yml`, `Dockerfile`, `nginx.conf` |
-| Backend Docker | `backend/` | `backend/Dockerfile` |
+| Layer          | Location              | Key files                                                                              |
+| -------------- | --------------------- | -------------------------------------------------------------------------------------- |
+| Frontend       | `src/`                | `App.tsx`, `src/components/`, `src/graphql/queries.ts`, `src/contexts/AuthContext.tsx` |
+| Backend        | `backend/src/`        | `index.ts`, `schema.ts`, `resolvers.ts`, `db.ts`, `auth.ts`, `scheduler.ts`            |
+| DB migrations  | `backend/migrations/` | numbered JS files run by node-pg-migrate                                               |
+| Docker         | root                  | `docker-compose.yml`, `Dockerfile`, `nginx.conf`                                       |
+| Backend Docker | `backend/`            | `backend/Dockerfile`                                                                   |
 
 ## Running the project
 
@@ -107,13 +107,13 @@ src/components/
 
 ## Database schema (current)
 
-| Table | Notable columns |
-|---|---|
-| `movies` | id, title, requester (text), requested_by (FK→users), date_submitted, rank (NUMERIC 20,10), tmdb_id (nullable int), watched_at (nullable timestamptz) |
-| `users` | id, username, password_hash, email, display_name, is_admin, is_active, last_login_at, created_at, updated_at |
-| `audit_logs` | id, actor_id (FK→users), action, target_type, target_id, metadata (JSONB), ip_address, created_at |
-| `login_history` | id, user_id (FK→users), ip_address, user_agent, succeeded, created_at |
-| `kometa_schedule` | id, enabled, frequency, daily_time, collection_name, last_run_at, updated_at |
+| Table             | Notable columns                                                                                                                                       |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `movies`          | id, title, requester (text), requested_by (FK→users), date_submitted, rank (NUMERIC 20,10), tmdb_id (nullable int), watched_at (nullable timestamptz) |
+| `users`           | id, username, password_hash, email, display_name, is_admin, is_active, last_login_at, created_at, updated_at                                          |
+| `audit_logs`      | id, actor_id (FK→users), action, target_type, target_id, metadata (JSONB), ip_address, created_at                                                     |
+| `login_history`   | id, user_id (FK→users), ip_address, user_agent, succeeded, created_at                                                                                 |
+| `kometa_schedule` | id, enabled, frequency, daily_time, collection_name, last_run_at, updated_at                                                                          |
 
 ## Audit log actions
 
@@ -122,27 +122,34 @@ src/components/
 ## Key features
 
 ### Watched tracking
+
 `markWatched(id)` sets `watched_at = NOW()`. `movies` query returns only `WHERE watched_at IS NULL`.
 
 ### Drag-and-drop reordering
+
 `reorderMovie(id, afterId?)` uses fractional indexing (midpoint between neighbors). `afterId=null` moves movie to top (`rank / 2`). Frontend uses `@dnd-kit/core` + `@dnd-kit/sortable`.
 
 ### TMDB integration
+
 `searchTmdb(query)` hits TMDB API (requires `TMDB_API_KEY`). `matchMovie(id, tmdb_id, title)` links a movie to its TMDB entry. `addMovie` accepts optional `tmdb_id`.
 
 ### Kometa/Plex integration (production-only)
+
 `exportKometa` writes a YAML collection file to `KOMETA_COLLECTIONS_PATH` and optionally POSTs to `KOMETA_TRIGGER_URL`. `scheduler.ts` runs automated exports (hourly or daily); `initScheduler()` called on startup only when `NODE_ENV === 'production'`.
 
 ### Letterboxd import
+
 `importFromLetterboxd(url)` fetches the public Letterboxd list, parses film titles from HTML (data-item-name), skips duplicates (case-insensitive), optionally matches to TMDB. Returns `{ imported, skipped, tmdb_matched, errors }`.
 
 ## Environment variables
 
 **Frontend** (`.env`):
+
 - `REACT_APP_GRAPHQL_URL` — defaults to `/graphql`
 - `REACT_APP_GIT_BRANCH`, `REACT_APP_GIT_HASH`, `REACT_APP_DEPLOY_TIME` — baked in at Docker build time
 
 **Backend** (`backend/.env`):
+
 - `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`
 - `PORT` (default 4000)
 - `JWT_SECRET` — **change in production** (default: `'your-secret-key-change-in-production'`)
@@ -154,17 +161,80 @@ src/components/
 
 ## Docker profiles
 
-| Profile | Services |
-|---|---|
-| `development` | db (postgres:15-alpine), backend, frontend (hot-reload) |
-| `production` | Single `movienight` container (ghcr.io image, port 8080→80, 1 CPU / 512 MB limit) |
+| Profile       | Services                                                                          |
+| ------------- | --------------------------------------------------------------------------------- |
+| `development` | db (postgres:15-alpine), backend, frontend (hot-reload)                           |
+| `production`  | Single `movienight` container (ghcr.io image, port 8080→80, 1 CPU / 512 MB limit) |
 
 **Production image**: Multi-stage Dockerfile — node:20-alpine builds React, nginx:alpine serves static files + proxies `/graphql` to `movienight-backend:4000`.
 
 ## CI/CD
 
-- `dev` branch push → `.github/workflows/test-build.yml` — build only (no push), with dorny/paths-filter to skip unchanged layers
+- All branches + all PRs (including draft) → `.github/workflows/ci.yml` — lint, format check, backend tests, frontend tests
+- `dev` branch push → `.github/workflows/test-build.yml` — tests must pass before Docker build (no push), with dorny/paths-filter to skip unchanged layers
 - `master` branch push → `.github/workflows/deploy.yml` — build + push to GHCR, SSH deploy to remote host
+
+## Testing
+
+### Running tests
+
+```bash
+# Backend
+cd backend && npm test                    # run all backend tests
+cd backend && npm test -- --coverage      # with coverage report
+cd backend && npm run test:watch          # watch mode
+
+# Frontend
+npm test -- --watchAll=false              # run all frontend tests
+npm test -- --coverage --watchAll=false   # with coverage report
+```
+
+### Test structure
+
+```
+backend/src/__tests__/
+  auth.test.ts              # bcrypt, JWT, token parsing
+  elo.test.ts               # Elo algorithm + DB mocks
+  pairSelection.test.ts     # pair selection algorithm
+  scheduler.test.ts         # Kometa scheduler
+  email.test.ts             # nodemailer mocking
+  resolvers/
+    __helpers.ts            # shared mocks + context factories
+    field-resolvers.test.ts
+    auth-resolvers.test.ts
+    movie-resolvers.test.ts
+    query-resolvers.test.ts
+    connection-resolvers.test.ts
+    letterboxd-resolvers.test.ts
+    kometa-resolvers.test.ts
+
+src/utils/__tests__/
+  textUtils.test.ts
+  gravatar.test.ts
+src/contexts/__tests__/
+  AuthContext.test.tsx
+```
+
+### Coverage thresholds (enforced in CI)
+
+- **Backend**: 80% statements/lines/functions, 65% branches
+- **Frontend**: no enforced threshold yet (utility + context tests only)
+
+### Requirements for new code
+
+- All new backend functions **must** have companion tests
+- All new resolvers must test: happy path, auth/authz check, at least 2 error/edge cases
+- `pool.query` calls must always use parameterized queries (`$1, $2, ...`) — never interpolate user input
+- Run `cd backend && npm test` after writing backend code
+- Run `npm test -- --watchAll=false` after writing frontend code
+
+### Code consistency
+
+- **Prettier** enforced via pre-commit hook (Husky + lint-staged) and CI format check
+- **ESLint** enforced for backend TypeScript (`backend/eslint.config.mjs`)
+- CRA ESLint enforced for frontend
+- Run `npx prettier --write <changed-files>` before committing
+- Never skip pre-commit hooks (`--no-verify`) unless explicitly approved
 
 ## Existing docs
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -16,12 +16,14 @@ This document describes how to deploy the MovieNight React application to a remo
 The repository uses GitHub Actions for automated builds and deployments:
 
 ### Test Builds (`.github/workflows/test-build.yml`)
+
 - **Triggers:** Push to `dev` branch, pull requests to `dev`
 - **Actions:** Builds Docker image to verify it compiles successfully
 - **Output:** Build success/failure status in GitHub Actions
 - **No deployment:** Test builds do not push to registry or deploy
 
 ### Production Deployment (`.github/workflows/deploy.yml`)
+
 - **Triggers:** Push to `master` branch, manual workflow dispatch
 - **Actions:**
   1. Builds Docker image
@@ -31,6 +33,7 @@ The repository uses GitHub Actions for automated builds and deployments:
 - **Output:** Live application at `http://REMOTE_HOST:8080/movienight/`
 
 **Workflow:**
+
 ```
 Feature Branch → PR to dev → Test Build ✓ → Merge to dev → Test Build ✓
                                                     ↓
@@ -42,16 +45,19 @@ Feature Branch → PR to dev → Test Build ✓ → Merge to dev → Test Build 
 ### On Remote Docker Host
 
 1. **Docker installed and running**
+
    ```bash
    docker --version  # Should be v20.10 or higher
    ```
 
 2. **SSH server running**
+
    ```bash
    sudo systemctl status ssh  # Should be active
    ```
 
 3. **Deployment user with Docker permissions**
+
    ```bash
    sudo useradd -m -s /bin/bash deploy
    sudo usermod -aG docker deploy
@@ -78,6 +84,7 @@ ssh-keygen -t ed25519 -C "github-actions-movienight" -f ~/.ssh/movienight_deploy
 ```
 
 This creates two files:
+
 - `~/.ssh/movienight_deploy` (private key) - Keep this SECRET
 - `~/.ssh/movienight_deploy.pub` (public key) - This goes on the server
 
@@ -129,20 +136,22 @@ exit
 3. Click **New repository secret**
 4. Add the following secrets:
 
-| Secret Name | Value | Example |
-|-------------|-------|---------|
-| `REMOTE_HOST` | IP address or hostname of your Docker host | `192.168.1.100` or `docker.example.com` |
-| `REMOTE_USER` | SSH username (usually `deploy`) | `deploy` |
-| `SSH_PRIVATE_KEY` | Content of `~/.ssh/movienight_deploy` file | (entire file including headers) |
-| `REMOTE_PORT` | SSH port (optional, defaults to 22) | `22` or `2222` |
+| Secret Name       | Value                                      | Example                                 |
+| ----------------- | ------------------------------------------ | --------------------------------------- |
+| `REMOTE_HOST`     | IP address or hostname of your Docker host | `192.168.1.100` or `docker.example.com` |
+| `REMOTE_USER`     | SSH username (usually `deploy`)            | `deploy`                                |
+| `SSH_PRIVATE_KEY` | Content of `~/.ssh/movienight_deploy` file | (entire file including headers)         |
+| `REMOTE_PORT`     | SSH port (optional, defaults to 22)        | `22` or `2222`                          |
 
 **Important for SSH_PRIVATE_KEY:**
+
 - Copy the ENTIRE content of the private key file
 - Include the `-----BEGIN OPENSSH PRIVATE KEY-----` header
 - Include the `-----END OPENSSH PRIVATE KEY-----` footer
 - Paste exactly as-is into the secret value
 
 Example format:
+
 ```
 -----BEGIN OPENSSH PRIVATE KEY-----
 b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
@@ -262,6 +271,7 @@ git push origin master
 **Symptom:** Build job fails in GitHub Actions
 
 **Solutions:**
+
 1. Check that `package.json` and `package-lock.json` are committed
 2. Verify Node.js dependencies are compatible
 3. Check GitHub Actions logs for specific npm errors
@@ -271,6 +281,7 @@ git push origin master
 **Symptom:** "Permission denied" or "Connection refused"
 
 **Solutions:**
+
 1. Verify `REMOTE_HOST` secret is correct
 2. Test SSH connection manually: `ssh -i private_key deploy@host`
 3. Check SSH_PRIVATE_KEY format (must include headers)
@@ -282,6 +293,7 @@ git push origin master
 **Symptom:** Container exits immediately after starting
 
 **Solutions:**
+
 ```bash
 # SSH to remote host
 ssh deploy@remote-host
@@ -300,6 +312,7 @@ docker logs movienight
 **Symptom:** nginx returns 404 for all routes
 
 **Solutions:**
+
 1. Check nginx.conf is properly copied in Dockerfile
 2. Verify build output structure: `docker exec movienight ls -la /usr/share/nginx/html/`
 3. Check package.json `homepage` setting matches nginx config
@@ -309,6 +322,7 @@ docker logs movienight
 **Symptom:** "denied: permission_denied"
 
 **Solutions:**
+
 1. Check repository package settings (may need to make package public)
 2. Verify workflow has `packages: write` permission
 3. Ensure GITHUB_TOKEN is valid
@@ -466,6 +480,7 @@ docker rm movienight-test
 ## Support
 
 For issues or questions:
+
 1. Check workflow logs in GitHub Actions
 2. Check container logs on remote host
 3. Review this documentation

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A full-stack movie suggestion application built with React, GraphQL, Apollo Serv
 ### Quick Start with Docker
 
 1. **Start all services:**
+
    ```bash
    docker-compose up -d
    ```
@@ -36,11 +37,13 @@ A full-stack movie suggestion application built with React, GraphQL, Apollo Serv
 ### Local Development (without Docker)
 
 1. **Install frontend dependencies:**
+
    ```bash
    npm install
    ```
 
 2. **Install backend dependencies:**
+
    ```bash
    cd backend
    npm install
@@ -48,6 +51,7 @@ A full-stack movie suggestion application built with React, GraphQL, Apollo Serv
    ```
 
 3. **Set up environment variables:**
+
    ```bash
    cp .env.example .env
    cp backend/.env.example backend/.env
@@ -56,6 +60,7 @@ A full-stack movie suggestion application built with React, GraphQL, Apollo Serv
 4. **Start PostgreSQL** (you'll need a running PostgreSQL instance)
 
 5. **Start the backend:**
+
    ```bash
    cd backend
    npm run dev
@@ -81,6 +86,7 @@ A full-stack movie suggestion application built with React, GraphQL, Apollo Serv
 ### Example Queries
 
 **Get all movies:**
+
 ```graphql
 query {
   movies {
@@ -93,6 +99,7 @@ query {
 ```
 
 **Add a movie:**
+
 ```graphql
 mutation {
   addMovie(title: "Inception", requester: "John") {
@@ -129,9 +136,11 @@ movienight/
 ## Environment Variables
 
 ### Frontend (.env)
+
 - `REACT_APP_GRAPHQL_URL`: GraphQL server URL (default: http://localhost:4000/graphql)
 
 ### Backend (backend/.env)
+
 - `DB_HOST`: PostgreSQL host (default: db)
 - `DB_PORT`: PostgreSQL port (default: 5432)
 - `DB_NAME`: Database name (default: movienight)
@@ -152,17 +161,21 @@ The application uses hot-reloading for both frontend and backend during developm
 ## Available Scripts (Create React App)
 
 ### `npm start`
+
 Runs the app in development mode at http://localhost:3000
 
 ### `npm test`
+
 Launches the test runner in interactive watch mode
 
 ### `npm run build`
+
 Builds the app for production to the `build` folder
 
 ## Migration from Firebase
 
 This application was migrated from Firebase Realtime Database to a self-hosted GraphQL + PostgreSQL stack, providing:
+
 - Full control over data and infrastructure
 - Better type safety with GraphQL
 - Relational data capabilities

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -5,6 +5,7 @@ Apollo Server 4 + Express + PostgreSQL. TypeScript, no ORM, raw `pg` queries.
 ## Entry point & startup sequence
 
 `src/index.ts`:
+
 1. Create Express app + ApolloServer
 2. Mount `/graphql` with CORS, JSON body parser, `expressMiddleware` (JWT context)
 3. Call `initializeDatabase()` (runs migrations, seeds admin user)
@@ -14,14 +15,14 @@ Apollo Server 4 + Express + PostgreSQL. TypeScript, no ORM, raw `pg` queries.
 
 ## Source files
 
-| File | Purpose |
-|---|---|
-| `src/index.ts` | Server bootstrap, Express setup, JWT context injection |
-| `src/schema.ts` | GraphQL SDL (`typeDefs`). **Bug**: duplicate `type Query` block at lines 30–33 — remove it. |
-| `src/resolvers.ts` | All Query/Mutation resolvers + field resolvers for timestamp conversion |
-| `src/db.ts` | `pg.Pool` setup + `initializeDatabase()` (runs migrations, creates admin user) |
-| `src/auth.ts` | `hashPassword`, `comparePassword` (bcrypt), `generateToken`, `verifyToken` (JWT), `getTokenFromHeader` |
-| `src/models/User.ts` | TypeScript interfaces: `User`, `CreateUserInput`, `UpdateUserInput` |
+| File                 | Purpose                                                                                                |
+| -------------------- | ------------------------------------------------------------------------------------------------------ |
+| `src/index.ts`       | Server bootstrap, Express setup, JWT context injection                                                 |
+| `src/schema.ts`      | GraphQL SDL (`typeDefs`). **Bug**: duplicate `type Query` block at lines 30–33 — remove it.            |
+| `src/resolvers.ts`   | All Query/Mutation resolvers + field resolvers for timestamp conversion                                |
+| `src/db.ts`          | `pg.Pool` setup + `initializeDatabase()` (runs migrations, creates admin user)                         |
+| `src/auth.ts`        | `hashPassword`, `comparePassword` (bcrypt), `generateToken`, `verifyToken` (JWT), `getTokenFromHeader` |
+| `src/models/User.ts` | TypeScript interfaces: `User`, `CreateUserInput`, `UpdateUserInput`                                    |
 
 ## Database
 
@@ -35,10 +36,12 @@ Apollo Server 4 + Express + PostgreSQL. TypeScript, no ORM, raw `pg` queries.
 
 ```ts
 // Authenticated only
-if (!context.user) throw new GraphQLError('Not authenticated', { extensions: { code: 'UNAUTHENTICATED' } });
+if (!context.user)
+  throw new GraphQLError('Not authenticated', { extensions: { code: 'UNAUTHENTICATED' } });
 
 // Admin only
-if (!context.user?.isAdmin) throw new GraphQLError('Not authorized', { extensions: { code: 'FORBIDDEN' } });
+if (!context.user?.isAdmin)
+  throw new GraphQLError('Not authorized', { extensions: { code: 'FORBIDDEN' } });
 ```
 
 `context.user` shape (from `verifyToken`): `{ userId: number, isAdmin: boolean }`.

--- a/backend/MIGRATIONS.md
+++ b/backend/MIGRATIONS.md
@@ -15,6 +15,7 @@ npm run migrate:create <migration-name>
 ```
 
 Example:
+
 ```bash
 npm run migrate:create add-watched-column
 ```
@@ -24,11 +25,13 @@ This creates a new migration file in `migrations/` with a timestamp prefix.
 ## Manual Migration Commands
 
 Run all pending migrations:
+
 ```bash
 npm run migrate:up
 ```
 
 Rollback the last migration:
+
 ```bash
 npm run migrate:down
 ```
@@ -61,6 +64,7 @@ exports.down = (pgm) => {
 ## Environment Variables
 
 Migrations use the same database connection settings as the application:
+
 - `DB_HOST`
 - `DB_PORT`
 - `DB_NAME`

--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -1,0 +1,25 @@
+import tseslint from '@typescript-eslint/eslint-plugin';
+import tsparser from '@typescript-eslint/parser';
+
+export default [
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      parser: tsparser,
+      ecmaVersion: 2020,
+      sourceType: 'module',
+    },
+    plugins: {
+      '@typescript-eslint': tseslint,
+    },
+    rules: {
+      ...tseslint.configs.recommended.rules,
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+      'no-console': 'off',
+    },
+  },
+  {
+    ignores: ['dist/', 'coverage/', 'node_modules/'],
+  },
+];

--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -1,0 +1,35 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  transform: {
+    '^.+\\.ts$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          module: 'CommonJS',
+          moduleResolution: 'Node',
+          target: 'ES2020',
+          esModuleInterop: true,
+          strict: true,
+        },
+      },
+    ],
+  },
+  clearMocks: true,
+  restoreMocks: true,
+  collectCoverageFrom: ['src/**/*.ts', '!src/index.ts', '!src/schema.ts', '!src/db.ts'],
+  coverageThreshold: {
+    global: {
+      branches: 65,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
+};
+
+export default config;

--- a/backend/migrations/1742460000000_add-tmdb-id-to-movies.js
+++ b/backend/migrations/1742460000000_add-tmdb-id-to-movies.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 exports.shorthands = undefined;
 
-exports.up = pgm => {
+exports.up = (pgm) => {
   pgm.addColumn('movies', {
     tmdb_id: {
       type: 'integer',
@@ -10,6 +10,6 @@ exports.up = pgm => {
   });
 };
 
-exports.down = pgm => {
+exports.down = (pgm) => {
   pgm.dropColumn('movies', 'tmdb_id');
 };

--- a/backend/migrations/1742460001000_create-kometa-schedule.js
+++ b/backend/migrations/1742460001000_create-kometa-schedule.js
@@ -33,7 +33,9 @@ exports.up = (pgm) => {
   });
 
   // Insert the single config row
-  pgm.sql(`INSERT INTO kometa_schedule (enabled, frequency, daily_time) VALUES (false, 'daily', '03:00')`);
+  pgm.sql(
+    `INSERT INTO kometa_schedule (enabled, frequency, daily_time) VALUES (false, 'daily', '03:00')`,
+  );
 };
 
 exports.down = (pgm) => {

--- a/backend/migrations/1745500000000_create-user-movie-rankings.js
+++ b/backend/migrations/1745500000000_create-user-movie-rankings.js
@@ -34,7 +34,7 @@ exports.up = (pgm) => {
   pgm.addConstraint(
     'user_movie_rankings',
     'user_movie_rankings_pkey',
-    'PRIMARY KEY (user_id, movie_id)'
+    'PRIMARY KEY (user_id, movie_id)',
   );
   pgm.addIndex('user_movie_rankings', ['user_id', 'rank']);
 

--- a/backend/migrations/1745600000000_add-elo-ranking-drop-borda.js
+++ b/backend/migrations/1745600000000_add-elo-ranking-drop-borda.js
@@ -6,10 +6,10 @@ exports.up = (pgm) => {
 
   // Append-only log of every pairwise pick
   pgm.createTable('movie_comparisons', {
-    id:         { type: 'serial', primaryKey: true },
-    user_id:    { type: 'integer', notNull: true, references: '"users"',  onDelete: 'CASCADE' },
-    winner_id:  { type: 'integer', notNull: true, references: '"movies"', onDelete: 'CASCADE' },
-    loser_id:   { type: 'integer', notNull: true, references: '"movies"', onDelete: 'CASCADE' },
+    id: { type: 'serial', primaryKey: true },
+    user_id: { type: 'integer', notNull: true, references: '"users"', onDelete: 'CASCADE' },
+    winner_id: { type: 'integer', notNull: true, references: '"movies"', onDelete: 'CASCADE' },
+    loser_id: { type: 'integer', notNull: true, references: '"movies"', onDelete: 'CASCADE' },
     created_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
   });
   pgm.createIndex('movie_comparisons', 'user_id');
@@ -18,11 +18,11 @@ exports.up = (pgm) => {
 
   // Per-user, per-movie Elo rating
   pgm.createTable('user_movie_elo', {
-    user_id:          { type: 'integer', notNull: true, references: '"users"',  onDelete: 'CASCADE' },
-    movie_id:         { type: 'integer', notNull: true, references: '"movies"', onDelete: 'CASCADE' },
-    elo_rating:       { type: 'numeric(10,4)', notNull: true, default: 1000 },
+    user_id: { type: 'integer', notNull: true, references: '"users"', onDelete: 'CASCADE' },
+    movie_id: { type: 'integer', notNull: true, references: '"movies"', onDelete: 'CASCADE' },
+    elo_rating: { type: 'numeric(10,4)', notNull: true, default: 1000 },
     comparison_count: { type: 'integer', notNull: true, default: 0 },
-    updated_at:       { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
   });
   pgm.addConstraint('user_movie_elo', 'user_movie_elo_pkey', 'PRIMARY KEY (user_id, movie_id)');
 
@@ -37,12 +37,16 @@ exports.down = (pgm) => {
   pgm.dropTable('movie_comparisons');
   pgm.dropColumn('movies', 'elo_rank');
   pgm.createTable('user_movie_rankings', {
-    user_id:    { type: 'integer', notNull: true, references: '"users"',  onDelete: 'CASCADE' },
-    movie_id:   { type: 'integer', notNull: true, references: '"movies"', onDelete: 'CASCADE' },
-    rank:       { type: 'numeric(20,10)', notNull: false },
+    user_id: { type: 'integer', notNull: true, references: '"users"', onDelete: 'CASCADE' },
+    movie_id: { type: 'integer', notNull: true, references: '"movies"', onDelete: 'CASCADE' },
+    rank: { type: 'numeric(20,10)', notNull: false },
     created_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
     updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
   });
-  pgm.addConstraint('user_movie_rankings', 'user_movie_rankings_pkey', 'PRIMARY KEY (user_id, movie_id)');
+  pgm.addConstraint(
+    'user_movie_rankings',
+    'user_movie_rankings_pkey',
+    'PRIMARY KEY (user_id, movie_id)',
+  );
   pgm.createIndex('user_movie_rankings', ['user_id', 'rank']);
 };

--- a/backend/migrations/1745800000000_create-user-connections.js
+++ b/backend/migrations/1745800000000_create-user-connections.js
@@ -30,12 +30,21 @@ exports.up = (pgm) => {
     },
   });
 
-  pgm.addConstraint('user_connections', 'user_connections_status_check',
-    "CHECK (status IN ('pending', 'accepted', 'rejected'))");
-  pgm.addConstraint('user_connections', 'user_connections_no_self',
-    'CHECK (requester_id <> addressee_id)');
-  pgm.addConstraint('user_connections', 'user_connections_unique_pair',
-    'UNIQUE (requester_id, addressee_id)');
+  pgm.addConstraint(
+    'user_connections',
+    'user_connections_status_check',
+    "CHECK (status IN ('pending', 'accepted', 'rejected'))",
+  );
+  pgm.addConstraint(
+    'user_connections',
+    'user_connections_no_self',
+    'CHECK (requester_id <> addressee_id)',
+  );
+  pgm.addConstraint(
+    'user_connections',
+    'user_connections_unique_pair',
+    'UNIQUE (requester_id, addressee_id)',
+  );
 
   pgm.createIndex('user_connections', 'requester_id');
   pgm.createIndex('user_connections', 'addressee_id');

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -22,10 +22,17 @@
         "@types/bcrypt": "^6.0.0",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
+        "@types/jest": "^30.0.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^20.11.5",
         "@types/pg": "^8.10.9",
+        "@typescript-eslint/eslint-plugin": "^8.59.0",
+        "@typescript-eslint/parser": "^8.59.0",
+        "eslint": "^10.2.1",
+        "jest": "^30.3.0",
         "node-pg-migrate": "^8.0.4",
+        "prettier": "^3.8.3",
+        "ts-jest": "^29.4.9",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.3.3"
       }
@@ -274,6 +281,593 @@
         "node": ">=14"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/core/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -285,6 +879,159 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@graphql-tools/merge": {
@@ -337,6 +1084,72 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
@@ -345,6 +1158,704 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.3.0.tgz",
+      "integrity": "sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "jest-message-util": "30.3.0",
+        "jest-util": "30.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.3.0.tgz",
+      "integrity": "sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.3.0",
+        "@jest/pattern": "30.0.1",
+        "@jest/reporters": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-changed-files": "30.3.0",
+        "jest-config": "30.3.0",
+        "jest-haste-map": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-resolve": "30.3.0",
+        "jest-resolve-dependencies": "30.3.0",
+        "jest-runner": "30.3.0",
+        "jest-runtime": "30.3.0",
+        "jest-snapshot": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "jest-watcher": "30.3.0",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
+      "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+      "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
+      "integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "30.3.0",
+        "jest-snapshot": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
+      "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+      "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@sinonjs/fake-timers": "^15.0.0",
+        "@types/node": "*",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz",
+      "integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/expect": "30.3.0",
+        "@jest/types": "30.3.0",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.3.0.tgz",
+      "integrity": "sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "collect-v8-coverage": "^1.0.2",
+        "exit-x": "^0.2.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^5.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-worker": "30.3.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.2",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jest/reporters/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jest/reporters/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@jest/reporters/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz",
+      "integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
+      "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "callsites": "^3.1.0",
+        "graceful-fs": "^4.2.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/source-map/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.3.0.tgz",
+      "integrity": "sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "collect-v8-coverage": "^1.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.3.0.tgz",
+      "integrity": "sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.3.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
+      "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/types": "30.3.0",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "babel-plugin-istanbul": "^7.0.1",
+        "chalk": "^4.1.2",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-util": "30.3.0",
+        "pirates": "^4.0.7",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -373,6 +1884,43 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -439,6 +1987,33 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -466,6 +2041,62 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
     },
     "node_modules/@types/bcrypt": {
       "version": "6.0.0",
@@ -506,6 +2137,20 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/express": {
       "version": "4.17.25",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
@@ -534,6 +2179,51 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
@@ -648,6 +2338,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -661,6 +2358,632 @@
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
+      "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/type-utils": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
+      "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
+      "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.0",
+        "@typescript-eslint/types": "^8.59.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/project-service/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
+      "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
+      "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
+      "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
+      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
+      "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.0",
+        "@typescript-eslint/tsconfig-utils": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
+      "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
+      "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -697,6 +3020,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.5",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
@@ -708,6 +3041,39 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-regex": {
@@ -757,6 +3123,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -793,6 +3169,105 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/babel-jest": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
+      "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "30.3.0",
+        "@types/babel__core": "^7.20.5",
+        "babel-plugin-istanbul": "^7.0.1",
+        "babel-preset-jest": "30.3.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "workspaces": [
+        "test/babel-8"
+      ],
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-instrument": "^6.0.2",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz",
+      "integrity": "sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/babel__core": "^7.20.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz",
+      "integrity": "sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "30.3.0",
+        "babel-preset-current-node-syntax": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -801,6 +3276,19 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
+      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bcrypt": {
@@ -880,6 +3368,63 @@
         "node": ">=8"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -949,6 +3494,74 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001790",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
+      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -974,6 +3587,29 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -988,6 +3624,24 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -1048,6 +3702,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -1112,6 +3773,38 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -1157,6 +3850,16 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/diff": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
@@ -1191,6 +3894,13 @@
         "xtend": "^4.0.0"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -1206,6 +3916,26 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -1220,6 +3950,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-define-property": {
@@ -1283,6 +4023,259 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
+      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -1290,6 +4283,65 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/exit-x": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
+      "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
+      "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/express": {
@@ -1338,6 +4390,50 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1368,6 +4464,44 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -1466,6 +4600,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1500,6 +4644,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -1511,6 +4665,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/glob": {
@@ -1563,6 +4730,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/graphql": {
       "version": "16.13.2",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
@@ -1570,6 +4744,38 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-property-descriptors": {
@@ -1623,6 +4829,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -1643,6 +4856,16 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1653,6 +4876,46 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/inflight": {
@@ -1681,6 +4944,13 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -1743,6 +5013,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -1764,6 +5044,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-typed-array": {
@@ -1794,6 +5087,113 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
@@ -1808,6 +5208,1129 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz",
+      "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.3.0",
+        "@jest/types": "30.3.0",
+        "import-local": "^3.2.0",
+        "jest-cli": "30.3.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.3.0.tgz",
+      "integrity": "sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.1.1",
+        "jest-util": "30.3.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.3.0.tgz",
+      "integrity": "sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/expect": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "co": "^4.6.0",
+        "dedent": "^1.6.0",
+        "is-generator-fn": "^2.1.0",
+        "jest-each": "30.3.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-runtime": "30.3.0",
+        "jest-snapshot": "30.3.0",
+        "jest-util": "30.3.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "30.3.0",
+        "pure-rand": "^7.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.3.0.tgz",
+      "integrity": "sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/types": "30.3.0",
+        "chalk": "^4.1.2",
+        "exit-x": "^0.2.2",
+        "import-local": "^3.2.0",
+        "jest-config": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.3.0.tgz",
+      "integrity": "sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/get-type": "30.1.0",
+        "@jest/pattern": "30.0.1",
+        "@jest/test-sequencer": "30.3.0",
+        "@jest/types": "30.3.0",
+        "babel-jest": "30.3.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "deepmerge": "^4.3.1",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-circus": "30.3.0",
+        "jest-docblock": "30.2.0",
+        "jest-environment-node": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-resolve": "30.3.0",
+        "jest-runner": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "parse-json": "^5.2.0",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "esbuild-register": ">=3.4.0",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "esbuild-register": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jest-config/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/jest-config/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-config/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-config/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/jest-config/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-config/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest-config/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-config/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-config/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/jest-config/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-config/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+      "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
+      "integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.3.0.tgz",
+      "integrity": "sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.3.0",
+        "chalk": "^4.1.2",
+        "jest-util": "30.3.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.3.0.tgz",
+      "integrity": "sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
+      "integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "anymatch": "^3.1.3",
+        "fb-watchman": "^2.0.2",
+        "graceful-fs": "^4.2.11",
+        "jest-regex-util": "30.0.1",
+        "jest-util": "30.3.0",
+        "jest-worker": "30.3.0",
+        "picomatch": "^4.0.3",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.3"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.3.0.tgz",
+      "integrity": "sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
+      "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.3.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz",
+      "integrity": "sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "jest-pnp-resolver": "^1.2.3",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "slash": "^3.0.0",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.3.0.tgz",
+      "integrity": "sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "30.0.1",
+        "jest-snapshot": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.3.0.tgz",
+      "integrity": "sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.3.0",
+        "@jest/environment": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-docblock": "30.2.0",
+        "jest-environment-node": "30.3.0",
+        "jest-haste-map": "30.3.0",
+        "jest-leak-detector": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-resolve": "30.3.0",
+        "jest-runtime": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-watcher": "30.3.0",
+        "jest-worker": "30.3.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.3.0.tgz",
+      "integrity": "sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/globals": "30.3.0",
+        "@jest/source-map": "30.0.1",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "cjs-module-lexer": "^2.1.0",
+        "collect-v8-coverage": "^1.0.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-resolve": "30.3.0",
+        "jest-snapshot": "30.3.0",
+        "jest-util": "30.3.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-runtime/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-runtime/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-runtime/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz",
+      "integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@babel/generator": "^7.27.5",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1",
+        "@babel/types": "^7.27.3",
+        "@jest/expect-utils": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "@jest/snapshot-utils": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "babel-preset-current-node-syntax": "^1.2.0",
+        "chalk": "^4.1.2",
+        "expect": "30.3.0",
+        "graceful-fs": "^4.2.11",
+        "jest-diff": "30.3.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-util": "30.3.0",
+        "pretty-format": "30.3.0",
+        "semver": "^7.7.2",
+        "synckit": "^0.11.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.3.0.tgz",
+      "integrity": "sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.3.0",
+        "camelcase": "^6.3.0",
+        "chalk": "^4.1.2",
+        "leven": "^3.1.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.3.0.tgz",
+      "integrity": "sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "jest-util": "30.3.0",
+        "string-length": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
+      "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@ungap/structured-clone": "^1.3.0",
+        "jest-util": "30.3.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -1859,6 +6382,63 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -1893,6 +6473,13 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.once": {
@@ -1935,12 +6522,38 @@
         "node": ">=12"
       }
     },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1968,6 +6581,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -2009,6 +6629,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/minimatch": {
@@ -2066,6 +6696,29 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
@@ -2074,6 +6727,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
@@ -2121,6 +6781,13 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-pg-migrate": {
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/node-pg-migrate/-/node-pg-migrate-8.0.4.tgz",
@@ -2147,6 +6814,13 @@
         }
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nodemailer": {
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
@@ -2164,6 +6838,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/object-assign": {
@@ -2209,12 +6896,107 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -2223,6 +7005,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-is-absolute": {
@@ -2374,6 +7166,13 @@
         "split2": "^4.1.0"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
@@ -2385,6 +7184,85 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -2435,6 +7313,60 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2447,6 +7379,33 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.14.2",
@@ -2486,6 +7445,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -2530,6 +7496,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/retry": {
@@ -2842,6 +7831,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -2872,6 +7871,36 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -2881,7 +7910,37 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
@@ -2909,6 +7968,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -2919,6 +7992,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -2927,6 +8010,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -2941,6 +8037,145 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/synckit": {
+      "version": "0.11.12",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.9"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/to-buffer": {
       "version": "1.2.2",
@@ -2992,6 +8227,85 @@
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-jest": {
+      "version": "29.4.9",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.9",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.4",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <7"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ts-node": {
@@ -3092,6 +8406,42 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -3133,6 +8483,20 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -3146,6 +8510,82 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/utils-merge": {
@@ -3177,6 +8617,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/value-or-promise": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
@@ -3193,6 +8659,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
       }
     },
     "node_modules/webidl-conversions": {
@@ -3257,7 +8733,43 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
@@ -3282,6 +8794,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -3300,6 +8826,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -3338,6 +8871,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,13 @@
     "migrate": "node-pg-migrate",
     "migrate:up": "node-pg-migrate up",
     "migrate:down": "node-pg-migrate down",
-    "migrate:create": "node-pg-migrate create"
+    "migrate:create": "node-pg-migrate create",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "format": "prettier --write 'src/**/*.ts'",
+    "format:check": "prettier --check 'src/**/*.ts'",
+    "lint": "eslint src/"
   },
   "dependencies": {
     "@apollo/server": "^4.13.0",
@@ -27,10 +33,17 @@
     "@types/bcrypt": "^6.0.0",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/jest": "^30.0.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20.11.5",
     "@types/pg": "^8.10.9",
+    "@typescript-eslint/eslint-plugin": "^8.59.0",
+    "@typescript-eslint/parser": "^8.59.0",
+    "eslint": "^10.2.1",
+    "jest": "^30.3.0",
     "node-pg-migrate": "^8.0.4",
+    "prettier": "^3.8.3",
+    "ts-jest": "^29.4.9",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.3.3"
   }

--- a/backend/src/__tests__/auth.test.ts
+++ b/backend/src/__tests__/auth.test.ts
@@ -1,0 +1,168 @@
+import {
+  hashPassword,
+  comparePassword,
+  generateToken,
+  verifyToken,
+  getTokenFromHeader,
+  generateResetToken,
+  hashResetToken,
+} from '../auth';
+
+const mockUser = {
+  id: 1,
+  username: 'testuser',
+  email: 'test@example.com',
+  display_name: 'Test User',
+  is_admin: false,
+  is_active: true,
+  last_login_at: null,
+  created_at: new Date(),
+  updated_at: new Date(),
+};
+
+describe('hashPassword', () => {
+  it('returns a bcrypt hash string', async () => {
+    const hash = await hashPassword('password123');
+    expect(hash).toMatch(/^\$2[aby]\$\d+\$/);
+  });
+
+  it('uses 10 salt rounds', async () => {
+    const hash = await hashPassword('password123');
+    expect(hash).toContain('$2b$10$');
+  });
+
+  it('produces different hashes for the same input', async () => {
+    const hash1 = await hashPassword('password123');
+    const hash2 = await hashPassword('password123');
+    expect(hash1).not.toBe(hash2);
+  });
+});
+
+describe('comparePassword', () => {
+  it('returns true for matching password and hash', async () => {
+    const hash = await hashPassword('password123');
+    const result = await comparePassword('password123', hash);
+    expect(result).toBe(true);
+  });
+
+  it('returns false for non-matching password', async () => {
+    const hash = await hashPassword('password123');
+    const result = await comparePassword('wrongpassword', hash);
+    expect(result).toBe(false);
+  });
+});
+
+describe('generateToken', () => {
+  it('returns a JWT string with 3 dot-separated segments', () => {
+    const token = generateToken(mockUser);
+    expect(token.split('.')).toHaveLength(3);
+  });
+
+  it('embeds userId, username, isAdmin in payload', () => {
+    const token = generateToken(mockUser);
+    const payload = verifyToken(token);
+    expect(payload).toMatchObject({
+      userId: 1,
+      username: 'testuser',
+      isAdmin: false,
+    });
+  });
+
+  it('sets 7-day expiry', () => {
+    const token = generateToken(mockUser);
+    const payload = verifyToken(token);
+    expect(payload).not.toBeNull();
+    const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
+    const expiresIn = decoded.exp - decoded.iat;
+    expect(expiresIn).toBe(7 * 24 * 60 * 60);
+  });
+});
+
+describe('verifyToken', () => {
+  it('returns JWTPayload for a valid token', () => {
+    const token = generateToken(mockUser);
+    const payload = verifyToken(token);
+    expect(payload).toMatchObject({
+      userId: 1,
+      username: 'testuser',
+      isAdmin: false,
+    });
+  });
+
+  it('returns null for a malformed string', () => {
+    expect(verifyToken('not.a.token')).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(verifyToken('')).toBeNull();
+  });
+
+  it('returns null for a token signed with a different secret', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const jwt = require('jsonwebtoken');
+    const fakeToken = jwt.sign({ userId: 1 }, 'wrong-secret', { expiresIn: '7d' });
+    expect(verifyToken(fakeToken)).toBeNull();
+  });
+});
+
+describe('getTokenFromHeader', () => {
+  it('returns token from "Bearer <token>" format', () => {
+    expect(getTokenFromHeader('Bearer abc123')).toBe('abc123');
+  });
+
+  it('returns null for undefined input', () => {
+    expect(getTokenFromHeader(undefined)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(getTokenFromHeader('')).toBeNull();
+  });
+
+  it('returns null for wrong scheme (Basic)', () => {
+    expect(getTokenFromHeader('Basic abc123')).toBeNull();
+  });
+
+  it('returns null for lowercase bearer', () => {
+    expect(getTokenFromHeader('bearer abc123')).toBeNull();
+  });
+
+  it('returns null for "Bearer" with no token', () => {
+    expect(getTokenFromHeader('Bearer')).toBeNull();
+  });
+
+  it('returns null for too many parts', () => {
+    expect(getTokenFromHeader('Bearer token extra')).toBeNull();
+  });
+});
+
+describe('generateResetToken', () => {
+  it('returns a 64-character hex string', () => {
+    const token = generateResetToken();
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('produces unique values on successive calls', () => {
+    const token1 = generateResetToken();
+    const token2 = generateResetToken();
+    expect(token1).not.toBe(token2);
+  });
+});
+
+describe('hashResetToken', () => {
+  it('returns a 64-character hex SHA256 hash', () => {
+    const hash = hashResetToken('some-token');
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic', () => {
+    const hash1 = hashResetToken('same-token');
+    const hash2 = hashResetToken('same-token');
+    expect(hash1).toBe(hash2);
+  });
+
+  it('different inputs produce different outputs', () => {
+    const hash1 = hashResetToken('token-a');
+    const hash2 = hashResetToken('token-b');
+    expect(hash1).not.toBe(hash2);
+  });
+});

--- a/backend/src/__tests__/elo.test.ts
+++ b/backend/src/__tests__/elo.test.ts
@@ -1,0 +1,102 @@
+jest.mock('../db', () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}));
+
+import { calculateElo, getOrCreateElo, applyComparison, updateGlobalEloRank } from '../elo';
+import pool from '../db';
+
+const mockQuery = pool.query as jest.Mock;
+
+describe('calculateElo', () => {
+  it('equal ratings: winner gains, loser loses by equal amount', () => {
+    const { newA, newB } = calculateElo(1000, 1000);
+    expect(newA).toBeGreaterThan(1000);
+    expect(newB).toBeLessThan(1000);
+    // Zero-sum
+    expect(newA + newB).toBeCloseTo(2000);
+  });
+
+  it('higher-rated beats lower-rated: smaller change', () => {
+    const { newA, newB } = calculateElo(1200, 800);
+    const gain = newA - 1200;
+    // Expected outcome, so small gain
+    expect(gain).toBeLessThan(16);
+    expect(gain).toBeGreaterThan(0);
+    expect(newA + newB).toBeCloseTo(2000);
+  });
+
+  it('lower-rated beats higher-rated (upset): larger change', () => {
+    const { newA, newB } = calculateElo(800, 1200);
+    const gain = newA - 800;
+    // Upset, so large gain
+    expect(gain).toBeGreaterThan(16);
+    expect(newA + newB).toBeCloseTo(2000);
+  });
+
+  it('uses default K factor of 32', () => {
+    const { newA } = calculateElo(1000, 1000);
+    // With equal ratings, expected = 0.5, so gain = 32 * (1 - 0.5) = 16
+    expect(newA - 1000).toBeCloseTo(16);
+  });
+
+  it('custom K factor changes magnitude', () => {
+    const { newA: defaultK } = calculateElo(1000, 1000);
+    const { newA: doubleK } = calculateElo(1000, 1000, 64);
+    expect(doubleK - 1000).toBeCloseTo((defaultK - 1000) * 2);
+  });
+
+  it('extreme rating difference: changes are bounded', () => {
+    const { newA, newB } = calculateElo(2000, 200);
+    expect(newA - 2000).toBeGreaterThan(0);
+    expect(newA - 2000).toBeLessThan(32);
+    expect(newA + newB).toBeCloseTo(2200);
+  });
+});
+
+describe('getOrCreateElo', () => {
+  it('calls pool.query with upsert SQL and returns rating', async () => {
+    mockQuery.mockResolvedValue({ rows: [{ elo_rating: '1000' }] });
+    const result = await getOrCreateElo(1, 5);
+    expect(result).toBe(1000);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO user_movie_elo'),
+      [1, 5, 1000],
+    );
+  });
+});
+
+describe('applyComparison', () => {
+  it('updates both ratings, inserts comparison, and recomputes global ranks', async () => {
+    // getOrCreateElo for winner and loser
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ elo_rating: '1000' }] }) // winner
+      .mockResolvedValueOnce({ rows: [{ elo_rating: '1000' }] }) // loser
+      .mockResolvedValueOnce({ rows: [] }) // update winner
+      .mockResolvedValueOnce({ rows: [] }) // update loser
+      .mockResolvedValueOnce({ rows: [] }) // insert comparison
+      .mockResolvedValueOnce({ rows: [] }) // updateGlobalEloRank winner
+      .mockResolvedValueOnce({ rows: [] }); // updateGlobalEloRank loser
+
+    const result = await applyComparison(1, 10, 20);
+    expect(result.winnerElo).toBeGreaterThan(1000);
+    expect(result.loserElo).toBeLessThan(1000);
+
+    // Check comparison was inserted
+    expect(mockQuery).toHaveBeenCalledWith(
+      'INSERT INTO movie_comparisons (user_id, winner_id, loser_id) VALUES ($1, $2, $3)',
+      [1, 10, 20],
+    );
+  });
+});
+
+describe('updateGlobalEloRank', () => {
+  it('updates movies elo_rank to average of user ratings', async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    await updateGlobalEloRank(5);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE movies SET elo_rank'),
+      [5],
+    );
+  });
+});

--- a/backend/src/__tests__/email.test.ts
+++ b/backend/src/__tests__/email.test.ts
@@ -1,0 +1,43 @@
+const mockSendMail = jest.fn();
+jest.mock('nodemailer', () => ({
+  createTransport: () => ({ sendMail: mockSendMail }),
+}));
+
+import { sendPasswordResetEmail } from '../email';
+
+describe('sendPasswordResetEmail', () => {
+  beforeEach(() => {
+    mockSendMail.mockResolvedValue({ messageId: 'test-id' });
+  });
+
+  it('sends email with correct to and subject', async () => {
+    await sendPasswordResetEmail('user@test.com', 'reset-token-123');
+    expect(mockSendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'user@test.com',
+        subject: 'MovieNight - Password Reset',
+      }),
+    );
+  });
+
+  it('includes reset link with token in text body', async () => {
+    await sendPasswordResetEmail('user@test.com', 'my-token');
+    const call = mockSendMail.mock.calls[0][0];
+    expect(call.text).toContain('my-token');
+  });
+
+  it('includes reset link in HTML body', async () => {
+    await sendPasswordResetEmail('user@test.com', 'my-token');
+    const call = mockSendMail.mock.calls[0][0];
+    expect(call.html).toContain('my-token');
+  });
+
+  it('uses APP_URL env var in reset link', async () => {
+    const origAppUrl = process.env.APP_URL;
+    process.env.APP_URL = 'https://movies.example.com';
+    await sendPasswordResetEmail('u@t.com', 'tok');
+    const call = mockSendMail.mock.calls[0][0];
+    expect(call.text).toContain('https://movies.example.com?resetToken=tok');
+    process.env.APP_URL = origAppUrl;
+  });
+});

--- a/backend/src/__tests__/pairSelection.test.ts
+++ b/backend/src/__tests__/pairSelection.test.ts
@@ -1,0 +1,157 @@
+import { selectPair, MovieCandidate } from '../pairSelection';
+
+function makeCandidate(overrides: Partial<MovieCandidate> & { id: number }): MovieCandidate {
+  return {
+    title: `Movie ${overrides.id}`,
+    tmdb_id: null,
+    userComparisonCount: 0,
+    elo_rating: 1000,
+    ...overrides,
+  };
+}
+
+describe('selectPair', () => {
+  let randomSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    randomSpy = jest.spyOn(Math, 'random');
+  });
+
+  describe('error handling', () => {
+    it('throws for empty array', () => {
+      expect(() => selectPair([])).toThrow('Not enough movies');
+    });
+
+    it('throws for single-element array', () => {
+      expect(() => selectPair([makeCandidate({ id: 1 })])).toThrow('Not enough movies');
+    });
+  });
+
+  describe('basic pair selection (2 movies)', () => {
+    it('returns both movies in the pair', () => {
+      randomSpy.mockReturnValue(0.5);
+      const movies = [makeCandidate({ id: 1 }), makeCandidate({ id: 2 })];
+      const [first, second] = selectPair(movies);
+      const ids = [first.id, second.id].sort();
+      expect(ids).toEqual([1, 2]);
+    });
+
+    it('returned pair contains two different movies', () => {
+      randomSpy.mockReturnValue(0.5);
+      const movies = [makeCandidate({ id: 1 }), makeCandidate({ id: 2 })];
+      const [first, second] = selectPair(movies);
+      expect(first.id).not.toBe(second.id);
+    });
+  });
+
+  describe('Tier 1: IFW first pick favors fewer comparisons', () => {
+    it('with Math.random = 0, picks first item in array', () => {
+      // weightedRandomPick: r = Math.random() * total. When random=0, r=0.
+      // Loop: r -= weight[0] => r < 0, returns items[0].
+      // So place the fewest-comparison movie first to verify IFW weighting.
+      randomSpy.mockReturnValue(0);
+      const movies = [
+        makeCandidate({ id: 2, userComparisonCount: 0 }),
+        makeCandidate({ id: 1, userComparisonCount: 10 }),
+        makeCandidate({ id: 3, userComparisonCount: 5 }),
+      ];
+      const [first] = selectPair(movies);
+      expect(first.id).toBe(2);
+    });
+
+    it('statistically favors movies with fewer comparisons', () => {
+      randomSpy.mockRestore();
+      const movies = [
+        makeCandidate({ id: 1, userComparisonCount: 100 }),
+        makeCandidate({ id: 2, userComparisonCount: 0 }),
+        makeCandidate({ id: 3, userComparisonCount: 100 }),
+      ];
+      const counts: Record<number, number> = { 1: 0, 2: 0, 3: 0 };
+      for (let i = 0; i < 200; i++) {
+        const [first] = selectPair(movies);
+        counts[first.id]++;
+      }
+      // id=2 should be picked significantly more often
+      expect(counts[2]).toBeGreaterThan(counts[1]);
+      expect(counts[2]).toBeGreaterThan(counts[3]);
+    });
+  });
+
+  describe('Tier 2: seeded pick for new movie', () => {
+    it('selects second from established movies when first is new', () => {
+      // First pick is new (< K=5 comparisons), enough established movies exist (>= K=5)
+      randomSpy.mockReturnValue(0.01); // small value to pick first movie (new one, high weight)
+      const movies = [
+        makeCandidate({ id: 1, userComparisonCount: 0, elo_rating: 1000 }),
+        makeCandidate({ id: 2, userComparisonCount: 10, elo_rating: 1050 }),
+        makeCandidate({ id: 3, userComparisonCount: 10, elo_rating: 1020 }),
+        makeCandidate({ id: 4, userComparisonCount: 10, elo_rating: 980 }),
+        makeCandidate({ id: 5, userComparisonCount: 10, elo_rating: 950 }),
+        makeCandidate({ id: 6, userComparisonCount: 10, elo_rating: 900 }),
+      ];
+      const [first, second] = selectPair(movies);
+      expect(first.userComparisonCount).toBeLessThan(5);
+      expect(second.userComparisonCount).toBeGreaterThanOrEqual(5);
+    });
+  });
+
+  describe('Tier 3: Elo-proximity for established first pick', () => {
+    it('selects second from closest Elo-rated movies', () => {
+      // All movies are established (>= K=5 comparisons)
+      randomSpy.mockReturnValue(0.01);
+      const movies = [
+        makeCandidate({ id: 1, userComparisonCount: 10, elo_rating: 1000 }),
+        makeCandidate({ id: 2, userComparisonCount: 10, elo_rating: 1001 }),
+        makeCandidate({ id: 3, userComparisonCount: 10, elo_rating: 1500 }),
+        makeCandidate({ id: 4, userComparisonCount: 10, elo_rating: 500 }),
+        makeCandidate({ id: 5, userComparisonCount: 10, elo_rating: 999 }),
+        makeCandidate({ id: 6, userComparisonCount: 10, elo_rating: 998 }),
+      ];
+      const [first, second] = selectPair(movies);
+      // Second should be from the closest Elo pool to first
+      const eloDiff = Math.abs(first.elo_rating - second.elo_rating);
+      expect(eloDiff).toBeLessThan(500); // should be close, not picking the extremes
+    });
+  });
+
+  describe('Fallback: IFW from remaining when not enough established', () => {
+    it('uses IFW when first is new but too few established movies', () => {
+      randomSpy.mockReturnValue(0.01);
+      const movies = [
+        makeCandidate({ id: 1, userComparisonCount: 0 }),
+        makeCandidate({ id: 2, userComparisonCount: 1 }),
+        makeCandidate({ id: 3, userComparisonCount: 2 }),
+      ];
+      // Not enough established (K=5), so fallback to IFW
+      const [first, second] = selectPair(movies);
+      expect(first.id).not.toBe(second.id);
+    });
+  });
+
+  describe('statistical properties', () => {
+    it('never returns the same movie twice', () => {
+      const movies = Array.from({ length: 20 }, (_, i) =>
+        makeCandidate({
+          id: i + 1,
+          userComparisonCount: i,
+          elo_rating: 1000 + i * 10,
+        }),
+      );
+      // Run 50 iterations with real Math.random
+      randomSpy.mockRestore();
+      for (let i = 0; i < 50; i++) {
+        const [first, second] = selectPair(movies);
+        expect(first.id).not.toBe(second.id);
+      }
+    });
+
+    it('always returns exactly 2 movies', () => {
+      randomSpy.mockRestore();
+      const movies = Array.from({ length: 10 }, (_, i) =>
+        makeCandidate({ id: i + 1, userComparisonCount: i }),
+      );
+      const result = selectPair(movies);
+      expect(result).toHaveLength(2);
+    });
+  });
+});

--- a/backend/src/__tests__/resolvers/__helpers.ts
+++ b/backend/src/__tests__/resolvers/__helpers.ts
@@ -1,0 +1,75 @@
+// Mock pool - must be before resolvers import
+export const mockQuery = jest.fn();
+jest.mock('../../db', () => ({
+  __esModule: true,
+  default: { query: mockQuery },
+}));
+
+// Mock auth module
+export const mockHashPassword = jest.fn();
+export const mockComparePassword = jest.fn();
+export const mockGenerateToken = jest.fn();
+export const mockGenerateResetToken = jest.fn();
+export const mockHashResetToken = jest.fn();
+jest.mock('../../auth', () => ({
+  hashPassword: (...args: any[]) => mockHashPassword(...args),
+  comparePassword: (...args: any[]) => mockComparePassword(...args),
+  generateToken: (...args: any[]) => mockGenerateToken(...args),
+  generateResetToken: (...args: any[]) => mockGenerateResetToken(...args),
+  hashResetToken: (...args: any[]) => mockHashResetToken(...args),
+}));
+
+// Mock email
+export const mockSendPasswordResetEmail = jest.fn();
+jest.mock('../../email', () => ({
+  sendPasswordResetEmail: (...args: any[]) => mockSendPasswordResetEmail(...args),
+}));
+
+// Mock scheduler
+export const mockRescheduleKometa = jest.fn();
+jest.mock('../../scheduler', () => ({
+  rescheduleKometa: (...args: any[]) => mockRescheduleKometa(...args),
+}));
+
+// Mock elo
+export const mockApplyComparison = jest.fn();
+export const mockUpdateGlobalEloRank = jest.fn();
+jest.mock('../../elo', () => ({
+  applyComparison: (...args: any[]) => mockApplyComparison(...args),
+  updateGlobalEloRank: (...args: any[]) => mockUpdateGlobalEloRank(...args),
+}));
+
+// Mock pairSelection
+export const mockSelectPair = jest.fn();
+jest.mock('../../pairSelection', () => ({
+  selectPair: (...args: any[]) => mockSelectPair(...args),
+}));
+
+// Mock fs (for Kometa export)
+export const mockWriteFile = jest.fn();
+jest.mock('fs', () => ({
+  promises: { writeFile: mockWriteFile },
+}));
+
+// Mock global fetch
+export const mockFetch = jest.fn();
+(global as any).fetch = mockFetch;
+
+// Context factories
+export function authContext(
+  overrides?: Partial<{ userId: number; isAdmin: boolean; username: string }>,
+) {
+  return {
+    user: { userId: 1, isAdmin: false, username: 'testuser', ...overrides },
+    ipAddress: '127.0.0.1',
+    userAgent: 'test-agent',
+  };
+}
+
+export function adminContext(overrides?: Partial<{ userId: number }>) {
+  return authContext({ isAdmin: true, username: 'admin', ...overrides });
+}
+
+export function anonContext() {
+  return { user: null, ipAddress: '127.0.0.1', userAgent: 'test-agent' };
+}

--- a/backend/src/__tests__/resolvers/auth-resolvers.test.ts
+++ b/backend/src/__tests__/resolvers/auth-resolvers.test.ts
@@ -124,6 +124,62 @@ describe('Mutation.createUser', () => {
       createUser(null, { username: 'u', email: 'e@e.com', password: 'p' } as any, anonContext()),
     ).rejects.toThrow('Not authorized');
   });
+
+  it('rejects empty username', async () => {
+    await expect(
+      createUser(
+        null,
+        { username: '', email: 'e@e.com', password: 'pass123' } as any,
+        adminContext(),
+      ),
+    ).rejects.toThrow('Username must be between 1 and 100 characters');
+  });
+
+  it('rejects username exceeding 100 characters', async () => {
+    await expect(
+      createUser(
+        null,
+        { username: 'A'.repeat(101), email: 'e@e.com', password: 'pass123' } as any,
+        adminContext(),
+      ),
+    ).rejects.toThrow('Username must be between 1 and 100 characters');
+  });
+
+  it('rejects empty email', async () => {
+    await expect(
+      createUser(null, { username: 'user', email: '', password: 'pass123' } as any, adminContext()),
+    ).rejects.toThrow('Email must be between 1 and 255 characters');
+  });
+
+  it('rejects email exceeding 255 characters', async () => {
+    await expect(
+      createUser(
+        null,
+        { username: 'user', email: 'a'.repeat(256), password: 'pass123' } as any,
+        adminContext(),
+      ),
+    ).rejects.toThrow('Email must be between 1 and 255 characters');
+  });
+
+  it('rejects password shorter than 6 characters', async () => {
+    await expect(
+      createUser(
+        null,
+        { username: 'user', email: 'e@e.com', password: '12345' } as any,
+        adminContext(),
+      ),
+    ).rejects.toThrow('Password must be between 6 and 128 characters');
+  });
+
+  it('rejects password exceeding 128 characters', async () => {
+    await expect(
+      createUser(
+        null,
+        { username: 'user', email: 'e@e.com', password: 'A'.repeat(129) } as any,
+        adminContext(),
+      ),
+    ).rejects.toThrow('Password must be between 6 and 128 characters');
+  });
 });
 
 describe('Mutation.updateUser', () => {

--- a/backend/src/__tests__/resolvers/auth-resolvers.test.ts
+++ b/backend/src/__tests__/resolvers/auth-resolvers.test.ts
@@ -75,6 +75,25 @@ describe('Mutation.login', () => {
       'Account is disabled',
     );
   });
+
+  it('throws TOO_MANY_REQUESTS after exceeding login rate limit', async () => {
+    const rateLimitCtx = { user: null, ipAddress: '10.99.99.99', userAgent: 'Mozilla/5.0' };
+    // Exhaust 10 login attempts (LOGIN_RATE_LIMIT_MAX = 10)
+    for (let i = 0; i < 10; i++) {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [] }) // no user found
+        .mockResolvedValueOnce({ rows: [] }); // logLoginHistory
+      try {
+        await login(null, { username: `user${i}`, password: 'pass' }, rateLimitCtx);
+      } catch {
+        // Expected: "Invalid credentials"
+      }
+    }
+    // 11th attempt should be rate limited
+    await expect(
+      login(null, { username: 'user11', password: 'pass' }, rateLimitCtx),
+    ).rejects.toThrow('Too many login attempts');
+  });
 });
 
 describe('Mutation.createUser', () => {

--- a/backend/src/__tests__/resolvers/auth-resolvers.test.ts
+++ b/backend/src/__tests__/resolvers/auth-resolvers.test.ts
@@ -1,0 +1,267 @@
+import {
+  mockQuery,
+  mockHashPassword,
+  mockComparePassword,
+  mockGenerateToken,
+  mockGenerateResetToken,
+  mockHashResetToken,
+  mockSendPasswordResetEmail,
+  authContext,
+  adminContext,
+  anonContext,
+} from './__helpers';
+import { resolvers } from '../../resolvers';
+
+const { login, createUser, updateUser, deleteUser, requestPasswordReset, resetPassword } =
+  resolvers.Mutation;
+
+describe('Mutation.login', () => {
+  const ctx = { user: null, ipAddress: '10.0.0.1', userAgent: 'Mozilla/5.0' };
+
+  it('returns token and user on successful login', async () => {
+    const dbUser = {
+      id: 1,
+      username: 'alice',
+      email: 'alice@example.com',
+      display_name: 'Alice',
+      password_hash: 'hashed',
+      is_admin: false,
+      is_active: true,
+      last_login_at: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    };
+    mockQuery
+      .mockResolvedValueOnce({ rows: [dbUser] }) // SELECT user
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE last_login_at
+      .mockResolvedValueOnce({ rows: [] }) // logLoginHistory
+      .mockResolvedValueOnce({ rows: [] }); // logAudit
+    mockComparePassword.mockResolvedValue(true);
+    mockGenerateToken.mockReturnValue('jwt-token');
+
+    const result = await login(null, { username: 'alice', password: 'pass' }, ctx);
+    expect(result.token).toBe('jwt-token');
+    expect(result.user.username).toBe('alice');
+    expect(result.user).not.toHaveProperty('password_hash');
+  });
+
+  it('throws UNAUTHENTICATED for invalid username', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // no user found
+      .mockResolvedValueOnce({ rows: [] }); // logLoginHistory
+    await expect(login(null, { username: 'nobody', password: 'pass' }, ctx)).rejects.toThrow(
+      'Invalid credentials',
+    );
+  });
+
+  it('throws UNAUTHENTICATED for wrong password', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1, username: 'alice', password_hash: 'h' }] })
+      .mockResolvedValueOnce({ rows: [] }); // logLoginHistory
+    mockComparePassword.mockResolvedValue(false);
+    await expect(login(null, { username: 'alice', password: 'wrong' }, ctx)).rejects.toThrow(
+      'Invalid credentials',
+    );
+  });
+
+  it('throws FORBIDDEN for disabled account', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 1, username: 'alice', password_hash: 'h', is_active: false }],
+      })
+      .mockResolvedValueOnce({ rows: [] }); // logLoginHistory
+    mockComparePassword.mockResolvedValue(true);
+    await expect(login(null, { username: 'alice', password: 'pass' }, ctx)).rejects.toThrow(
+      'Account is disabled',
+    );
+  });
+});
+
+describe('Mutation.createUser', () => {
+  it('admin can create user', async () => {
+    mockHashPassword.mockResolvedValue('hashed-pw');
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 2, username: 'newuser', email: 'new@test.com', is_admin: false }],
+      })
+      .mockResolvedValueOnce({ rows: [] }); // logAudit
+    const result = await createUser(
+      null,
+      { username: 'newuser', email: 'new@test.com', password: 'pass123' } as any,
+      adminContext(),
+    );
+    expect(result.username).toBe('newuser');
+    expect(mockHashPassword).toHaveBeenCalledWith('pass123');
+  });
+
+  it('non-admin gets FORBIDDEN', async () => {
+    await expect(
+      createUser(null, { username: 'u', email: 'e@e.com', password: 'p' } as any, authContext()),
+    ).rejects.toThrow('Not authorized');
+  });
+
+  it('unauthenticated gets FORBIDDEN', async () => {
+    await expect(
+      createUser(null, { username: 'u', email: 'e@e.com', password: 'p' } as any, anonContext()),
+    ).rejects.toThrow('Not authorized');
+  });
+});
+
+describe('Mutation.updateUser', () => {
+  it('admin can update user fields', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 2, username: 'updated', email: 'u@t.com' }],
+      })
+      .mockResolvedValueOnce({ rows: [] }); // logAudit
+    const result = await updateUser(null, { id: '2', username: 'updated' } as any, adminContext());
+    expect(result.username).toBe('updated');
+  });
+
+  it('hashes password when provided', async () => {
+    mockHashPassword.mockResolvedValue('new-hash');
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 2 }] }).mockResolvedValueOnce({ rows: [] });
+    await updateUser(null, { id: '2', password: 'newpass' } as any, adminContext());
+    expect(mockHashPassword).toHaveBeenCalledWith('newpass');
+  });
+
+  it('non-admin gets FORBIDDEN', async () => {
+    await expect(
+      updateUser(null, { id: '2', username: 'x' } as any, authContext()),
+    ).rejects.toThrow('Not authorized');
+  });
+});
+
+describe('Mutation.deleteUser', () => {
+  it('admin can delete another user', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ username: 'victim', email: 'v@t.com' }] }) // SELECT target
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] }) // DELETE
+      .mockResolvedValueOnce({ rows: [] }); // logAudit
+    const result = await deleteUser(null, { id: '2' }, adminContext({ userId: 1 }));
+    expect(result).toBe(true);
+  });
+
+  it('prevents self-deletion', async () => {
+    await expect(deleteUser(null, { id: '1' }, adminContext({ userId: 1 }))).rejects.toThrow(
+      'Cannot delete your own account',
+    );
+  });
+
+  it('non-admin gets FORBIDDEN', async () => {
+    await expect(deleteUser(null, { id: '2' }, authContext())).rejects.toThrow('Not authorized');
+  });
+
+  it('returns false when user does not exist', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // SELECT target (not found)
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] }); // DELETE (no rows affected)
+    const result = await deleteUser(null, { id: '999' }, adminContext({ userId: 1 }));
+    expect(result).toBe(false);
+  });
+});
+
+describe('Mutation.requestPasswordReset', () => {
+  it('always returns generic success message', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // no user found
+      .mockResolvedValueOnce({ rows: [] }); // logAudit
+    const result = await requestPasswordReset(null, { email: 'no@one.com' }, anonContext());
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('If an account exists');
+  });
+
+  it('generates token and sends email for valid user', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1, email: 'a@b.com', is_active: true }] })
+      .mockResolvedValueOnce({ rows: [] }) // DELETE existing tokens
+      .mockResolvedValueOnce({ rows: [] }) // INSERT new token
+      .mockResolvedValueOnce({ rows: [] }); // logAudit
+    mockGenerateResetToken.mockReturnValue('raw-token');
+    mockHashResetToken.mockReturnValue('hashed-token');
+    mockSendPasswordResetEmail.mockResolvedValue(undefined);
+
+    const result = await requestPasswordReset(null, { email: 'a@b.com' }, anonContext());
+    expect(result.success).toBe(true);
+    expect(mockSendPasswordResetEmail).toHaveBeenCalledWith('a@b.com', 'raw-token');
+  });
+
+  it('does not reveal whether email exists', async () => {
+    // Non-existent email
+    mockQuery.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: [] });
+    const result1 = await requestPasswordReset(
+      null,
+      { email: 'fake@fake.com' },
+      { ...anonContext(), ipAddress: '10.0.0.2' },
+    );
+
+    // Existing email
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1, email: 'real@r.com', is_active: true }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    mockGenerateResetToken.mockReturnValue('t');
+    mockHashResetToken.mockReturnValue('h');
+    mockSendPasswordResetEmail.mockResolvedValue(undefined);
+    const result2 = await requestPasswordReset(
+      null,
+      { email: 'real@r.com' },
+      { ...anonContext(), ipAddress: '10.0.0.3' },
+    );
+
+    expect(result1.message).toBe(result2.message);
+  });
+});
+
+describe('Mutation.resetPassword', () => {
+  it('throws BAD_USER_INPUT for password too short', async () => {
+    await expect(
+      resetPassword(null, { token: 'abc', newPassword: '12345' }, anonContext()),
+    ).rejects.toThrow('Password must be at least 6 characters');
+  });
+
+  it('throws BAD_USER_INPUT for empty password', async () => {
+    await expect(
+      resetPassword(null, { token: 'abc', newPassword: '' }, anonContext()),
+    ).rejects.toThrow('Password must be at least 6 characters');
+  });
+
+  it('throws BAD_USER_INPUT for invalid/expired token', async () => {
+    mockHashResetToken.mockReturnValue('bad-hash');
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // no matching token
+      .mockResolvedValueOnce({ rows: [] }); // logAudit
+    await expect(
+      resetPassword(null, { token: 'bad', newPassword: 'newpass123' }, anonContext()),
+    ).rejects.toThrow('Invalid or expired reset token');
+  });
+
+  it('throws FORBIDDEN for disabled account', async () => {
+    mockHashResetToken.mockReturnValue('hash');
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 1, user_id: 5, is_active: false }],
+    });
+    await expect(
+      resetPassword(null, { token: 'tok', newPassword: 'newpass123' }, anonContext()),
+    ).rejects.toThrow('Account is disabled');
+  });
+
+  it('updates password and marks token used for valid token', async () => {
+    mockHashResetToken.mockReturnValue('valid-hash');
+    mockHashPassword.mockResolvedValue('new-pw-hash');
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 10, user_id: 5, is_active: true }] }) // valid token
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE password
+      .mockResolvedValueOnce({ rows: [] }) // mark token used
+      .mockResolvedValueOnce({ rows: [] }) // delete other tokens
+      .mockResolvedValueOnce({ rows: [] }); // logAudit
+    const result = await resetPassword(
+      null,
+      { token: 'valid', newPassword: 'newpass123' },
+      anonContext(),
+    );
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('reset successfully');
+  });
+});

--- a/backend/src/__tests__/resolvers/connection-resolvers.test.ts
+++ b/backend/src/__tests__/resolvers/connection-resolvers.test.ts
@@ -1,0 +1,174 @@
+import { mockQuery, authContext, anonContext } from './__helpers';
+import { resolvers } from '../../resolvers';
+
+const { sendConnectionRequest, respondToConnectionRequest, removeConnection } = resolvers.Mutation;
+
+describe('Mutation.sendConnectionRequest', () => {
+  it('creates new pending connection request', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 2 }] }) // target user exists
+      .mockResolvedValueOnce({ rows: [] }) // no reverse request
+      .mockResolvedValueOnce({ rows: [] }) // no forward request
+      .mockResolvedValueOnce({
+        rows: [{ id: 10, created_at: new Date('2024-01-01') }],
+      }) // INSERT
+      .mockResolvedValueOnce({ rows: [] }) // logAudit
+      .mockResolvedValueOnce({
+        rows: [{ id: 2, username: 'bob', display_name: 'Bob' }],
+      }); // other user lookup
+    const result = await sendConnectionRequest(
+      null,
+      { addresseeId: '2' },
+      authContext({ userId: 1 }),
+    );
+    expect(result.status).toBe('pending');
+    expect(result.direction).toBe('sent');
+  });
+
+  it('throws BAD_USER_INPUT for self-connection', async () => {
+    await expect(
+      sendConnectionRequest(null, { addresseeId: '1' }, authContext({ userId: 1 })),
+    ).rejects.toThrow('Cannot connect with yourself');
+  });
+
+  it('unauthenticated throws UNAUTHENTICATED', async () => {
+    await expect(sendConnectionRequest(null, { addresseeId: '2' }, anonContext())).rejects.toThrow(
+      'Not authenticated',
+    );
+  });
+
+  it('target user not found throws NOT_FOUND', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // target not found
+    await expect(
+      sendConnectionRequest(null, { addresseeId: '999' }, authContext({ userId: 1 })),
+    ).rejects.toThrow('User not found');
+  });
+
+  it('auto-accepts reverse pending request', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 2 }] }) // target exists
+      .mockResolvedValueOnce({ rows: [{ id: 5, status: 'pending' }] }) // reverse pending
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE to accepted
+      .mockResolvedValueOnce({ rows: [] }) // logAudit
+      .mockResolvedValueOnce({
+        rows: [{ id: 2, username: 'bob', display_name: 'Bob' }],
+      }); // other user
+    const result = await sendConnectionRequest(
+      null,
+      { addresseeId: '2' },
+      authContext({ userId: 1 }),
+    );
+    expect(result.status).toBe('accepted');
+  });
+
+  it('throws BAD_USER_INPUT when already connected (reverse)', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 2 }] }) // target exists
+      .mockResolvedValueOnce({ rows: [{ id: 5, status: 'accepted' }] }); // reverse accepted
+    await expect(
+      sendConnectionRequest(null, { addresseeId: '2' }, authContext({ userId: 1 })),
+    ).rejects.toThrow('Already connected');
+  });
+
+  it('throws BAD_USER_INPUT when forward request already pending', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 2 }] }) // target exists
+      .mockResolvedValueOnce({ rows: [] }) // no reverse
+      .mockResolvedValueOnce({ rows: [{ id: 6, status: 'pending' }] }); // forward pending
+    await expect(
+      sendConnectionRequest(null, { addresseeId: '2' }, authContext({ userId: 1 })),
+    ).rejects.toThrow('Request already pending');
+  });
+
+  it('re-sends previously rejected request', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 2 }] }) // target exists
+      .mockResolvedValueOnce({ rows: [] }) // no reverse
+      .mockResolvedValueOnce({ rows: [{ id: 6, status: 'rejected' }] }) // forward rejected
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE to pending
+      .mockResolvedValueOnce({ rows: [] }) // logAudit
+      .mockResolvedValueOnce({
+        rows: [{ id: 2, username: 'bob', display_name: 'Bob' }],
+      });
+    const result = await sendConnectionRequest(
+      null,
+      { addresseeId: '2' },
+      authContext({ userId: 1 }),
+    );
+    expect(result.status).toBe('pending');
+  });
+});
+
+describe('Mutation.respondToConnectionRequest', () => {
+  it('accept=true updates to accepted', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 10, requester_id: 2, addressee_id: 1, created_at: new Date() }],
+      }) // SELECT pending
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE
+      .mockResolvedValueOnce({ rows: [] }) // logAudit
+      .mockResolvedValueOnce({
+        rows: [{ id: 2, username: 'bob', display_name: 'Bob' }],
+      }); // other user
+    const result = await respondToConnectionRequest(
+      null,
+      { connectionId: '10', accept: true },
+      authContext({ userId: 1 }),
+    );
+    expect(result.status).toBe('accepted');
+  });
+
+  it('accept=false updates to rejected', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 10, requester_id: 2, addressee_id: 1, created_at: new Date() }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{ id: 2, username: 'bob', display_name: 'Bob' }],
+      });
+    const result = await respondToConnectionRequest(
+      null,
+      { connectionId: '10', accept: false },
+      authContext({ userId: 1 }),
+    );
+    expect(result.status).toBe('rejected');
+  });
+
+  it('unauthenticated throws UNAUTHENTICATED', async () => {
+    await expect(
+      respondToConnectionRequest(null, { connectionId: '10', accept: true }, anonContext()),
+    ).rejects.toThrow('Not authenticated');
+  });
+
+  it('request not found throws NOT_FOUND', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await expect(
+      respondToConnectionRequest(null, { connectionId: '999', accept: true }, authContext()),
+    ).rejects.toThrow('Connection request not found');
+  });
+});
+
+describe('Mutation.removeConnection', () => {
+  it('removes connection', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 10 }] }) // DELETE RETURNING
+      .mockResolvedValueOnce({ rows: [] }); // logAudit
+    const result = await removeConnection(null, { connectionId: '10' }, authContext());
+    expect(result).toBe(true);
+  });
+
+  it('unauthenticated throws UNAUTHENTICATED', async () => {
+    await expect(removeConnection(null, { connectionId: '10' }, anonContext())).rejects.toThrow(
+      'Not authenticated',
+    );
+  });
+
+  it('connection not found throws NOT_FOUND', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await expect(removeConnection(null, { connectionId: '999' }, authContext())).rejects.toThrow(
+      'Connection not found',
+    );
+  });
+});

--- a/backend/src/__tests__/resolvers/field-resolvers.test.ts
+++ b/backend/src/__tests__/resolvers/field-resolvers.test.ts
@@ -1,0 +1,177 @@
+import './__helpers';
+import { resolvers } from '../../resolvers';
+
+describe('Movie field resolvers', () => {
+  describe('Movie.requester', () => {
+    const resolver = resolvers.Movie.requester;
+
+    it('returns user_display_name when requested_by is set', () => {
+      expect(
+        resolver({ requested_by: 1, user_display_name: 'Alice', user_username: 'alice' }),
+      ).toBe('Alice');
+    });
+
+    it('falls back to user_username when no display_name', () => {
+      expect(resolver({ requested_by: 1, user_display_name: null, user_username: 'alice' })).toBe(
+        'alice',
+      );
+    });
+
+    it('falls back to parent.requester when no user data', () => {
+      expect(
+        resolver({
+          requested_by: 1,
+          user_display_name: null,
+          user_username: null,
+          requester: 'legacy_name',
+        }),
+      ).toBe('legacy_name');
+    });
+
+    it('returns Unknown when nothing available', () => {
+      expect(
+        resolver({
+          requested_by: 1,
+          user_display_name: null,
+          user_username: null,
+          requester: null,
+        }),
+      ).toBe('Unknown');
+    });
+
+    it('returns parent.requester when requested_by is null', () => {
+      expect(resolver({ requested_by: null, requester: 'Old User' })).toBe('Old User');
+    });
+
+    it('returns Unknown when requested_by is null and no requester', () => {
+      expect(resolver({ requested_by: null, requester: null })).toBe('Unknown');
+    });
+  });
+
+  describe('Movie.date_submitted', () => {
+    const resolver = resolvers.Movie.date_submitted;
+
+    it('converts Date object to ISO string', () => {
+      const date = new Date('2024-01-15T12:00:00Z');
+      expect(resolver({ date_submitted: date })).toBe('2024-01-15T12:00:00.000Z');
+    });
+
+    it('converts numeric timestamp to ISO string', () => {
+      const ts = new Date('2024-01-15T12:00:00Z').getTime();
+      expect(resolver({ date_submitted: ts })).toBe('2024-01-15T12:00:00.000Z');
+    });
+  });
+
+  describe('Movie.watched_at', () => {
+    const resolver = resolvers.Movie.watched_at;
+
+    it('returns null when watched_at is null', () => {
+      expect(resolver({ watched_at: null })).toBeNull();
+    });
+
+    it('returns null when watched_at is undefined', () => {
+      expect(resolver({ watched_at: undefined })).toBeNull();
+    });
+
+    it('converts Date object to ISO string', () => {
+      const date = new Date('2024-06-01T18:00:00Z');
+      expect(resolver({ watched_at: date })).toBe('2024-06-01T18:00:00.000Z');
+    });
+  });
+
+  describe('Movie.elo_rank', () => {
+    const resolver = resolvers.Movie.elo_rank;
+
+    it('returns number when present', () => {
+      expect(resolver({ elo_rank: '1050.5' })).toBe(1050.5);
+    });
+
+    it('returns null when null', () => {
+      expect(resolver({ elo_rank: null })).toBeNull();
+    });
+
+    it('returns null when undefined', () => {
+      expect(resolver({ elo_rank: undefined })).toBeNull();
+    });
+  });
+});
+
+describe('User field resolvers', () => {
+  describe('User.created_at', () => {
+    const resolver = resolvers.User.created_at;
+
+    it('converts Date to ISO string', () => {
+      const date = new Date('2024-01-01T00:00:00Z');
+      expect(resolver({ created_at: date })).toBe('2024-01-01T00:00:00.000Z');
+    });
+
+    it('converts numeric timestamp to ISO string', () => {
+      const ts = new Date('2024-01-01T00:00:00Z').getTime();
+      expect(resolver({ created_at: ts })).toBe('2024-01-01T00:00:00.000Z');
+    });
+  });
+
+  describe('User.updated_at', () => {
+    const resolver = resolvers.User.updated_at;
+
+    it('converts Date to ISO string', () => {
+      const date = new Date('2024-06-15T12:00:00Z');
+      expect(resolver({ updated_at: date })).toBe('2024-06-15T12:00:00.000Z');
+    });
+  });
+
+  describe('User.last_login_at', () => {
+    const resolver = resolvers.User.last_login_at;
+
+    it('returns null when not set', () => {
+      expect(resolver({ last_login_at: null })).toBeNull();
+    });
+
+    it('converts Date to ISO string', () => {
+      const date = new Date('2024-06-15T12:00:00Z');
+      expect(resolver({ last_login_at: date })).toBe('2024-06-15T12:00:00.000Z');
+    });
+  });
+});
+
+describe('AuditLog field resolvers', () => {
+  describe('AuditLog.created_at', () => {
+    const resolver = resolvers.AuditLog.created_at;
+
+    it('converts Date to ISO string', () => {
+      const date = new Date('2024-03-10T09:30:00Z');
+      expect(resolver({ created_at: date })).toBe('2024-03-10T09:30:00.000Z');
+    });
+  });
+
+  describe('AuditLog.metadata', () => {
+    const resolver = resolvers.AuditLog.metadata;
+
+    it('returns null for null metadata', () => {
+      expect(resolver({ metadata: null })).toBeNull();
+    });
+
+    it('returns null for undefined metadata', () => {
+      expect(resolver({ metadata: undefined })).toBeNull();
+    });
+
+    it('returns string as-is', () => {
+      expect(resolver({ metadata: '{"key":"value"}' })).toBe('{"key":"value"}');
+    });
+
+    it('JSON.stringifies object metadata', () => {
+      expect(resolver({ metadata: { key: 'value' } })).toBe('{"key":"value"}');
+    });
+  });
+});
+
+describe('LoginHistory field resolvers', () => {
+  describe('LoginHistory.created_at', () => {
+    const resolver = resolvers.LoginHistory.created_at;
+
+    it('converts Date to ISO string', () => {
+      const date = new Date('2024-04-20T15:45:00Z');
+      expect(resolver({ created_at: date })).toBe('2024-04-20T15:45:00.000Z');
+    });
+  });
+});

--- a/backend/src/__tests__/resolvers/kometa-resolvers.test.ts
+++ b/backend/src/__tests__/resolvers/kometa-resolvers.test.ts
@@ -1,0 +1,165 @@
+import {
+  mockQuery,
+  mockWriteFile,
+  mockFetch,
+  mockRescheduleKometa,
+  adminContext,
+  authContext,
+} from './__helpers';
+import { resolvers } from '../../resolvers';
+
+const { exportKometa, updateKometaSchedule } = resolvers.Mutation;
+
+describe('Mutation.exportKometa', () => {
+  const origEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env.NODE_ENV = origEnv.NODE_ENV;
+    process.env.KOMETA_COLLECTIONS_PATH = origEnv.KOMETA_COLLECTIONS_PATH;
+    process.env.KOMETA_TRIGGER_URL = origEnv.KOMETA_TRIGGER_URL;
+  });
+
+  it('non-admin throws FORBIDDEN', async () => {
+    await expect(exportKometa(null, {}, authContext())).rejects.toThrow('Not authorized');
+  });
+
+  it('non-production throws FORBIDDEN', async () => {
+    process.env.NODE_ENV = 'development';
+    await expect(exportKometa(null, {}, adminContext())).rejects.toThrow(
+      'Kometa export is disabled outside of production',
+    );
+  });
+
+  it('missing KOMETA_COLLECTIONS_PATH throws INTERNAL_SERVER_ERROR', async () => {
+    process.env.NODE_ENV = 'production';
+    delete process.env.KOMETA_COLLECTIONS_PATH;
+    await expect(exportKometa(null, {}, adminContext())).rejects.toThrow(
+      'KOMETA_COLLECTIONS_PATH is not configured',
+    );
+  });
+
+  it('no TMDB-matched movies throws BAD_USER_INPUT', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.KOMETA_COLLECTIONS_PATH = '/tmp/kometa';
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ title: 'A', tmdb_id: null, elo_rank: null }],
+    });
+    await expect(exportKometa(null, {}, adminContext())).rejects.toThrow(
+      'No movies with TMDB IDs to export',
+    );
+  });
+
+  it('writes YAML file and returns filePath', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.KOMETA_COLLECTIONS_PATH = '/tmp/kometa';
+    delete process.env.KOMETA_TRIGGER_URL;
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { title: 'Inception', tmdb_id: 27205, elo_rank: 1050 },
+        { title: 'Dune', tmdb_id: 438631, elo_rank: 1020 },
+      ],
+    });
+    mockWriteFile.mockResolvedValue(undefined);
+    mockQuery.mockResolvedValue({ rows: [] }); // logAudit
+
+    const result = await exportKometa(null, {}, adminContext());
+    expect(result.filePath).toContain('movienight.yml');
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      expect.stringContaining('movienight.yml'),
+      expect.stringContaining('27205'),
+      'utf8',
+    );
+  });
+
+  it('triggers webhook when KOMETA_TRIGGER_URL is set', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.KOMETA_COLLECTIONS_PATH = '/tmp/kometa';
+    process.env.KOMETA_TRIGGER_URL = 'http://kometa:5000/run';
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ title: 'A', tmdb_id: 100, elo_rank: 1000 }],
+    });
+    mockWriteFile.mockResolvedValue(undefined);
+    mockFetch.mockResolvedValueOnce({ ok: true });
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const result = await exportKometa(null, {}, adminContext());
+    expect(result.triggered).toBe(true);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://kometa:5000/run',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('webhook failure returns triggerError', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.KOMETA_COLLECTIONS_PATH = '/tmp/kometa';
+    process.env.KOMETA_TRIGGER_URL = 'http://kometa:5000/run';
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ title: 'A', tmdb_id: 100, elo_rank: 1000 }],
+    });
+    mockWriteFile.mockResolvedValue(undefined);
+    mockFetch.mockRejectedValueOnce(new Error('Connection refused'));
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const result = await exportKometa(null, {}, adminContext());
+    expect(result.triggered).toBe(false);
+    expect(result.triggerError).toBe('Connection refused');
+  });
+});
+
+describe('Mutation.updateKometaSchedule', () => {
+  const origEnv = { ...process.env };
+  afterEach(() => {
+    process.env.NODE_ENV = origEnv.NODE_ENV;
+  });
+
+  it('non-admin throws FORBIDDEN', async () => {
+    await expect(updateKometaSchedule(null, { enabled: true }, authContext())).rejects.toThrow(
+      'Not authorized',
+    );
+  });
+
+  it('enabling in non-production throws FORBIDDEN', async () => {
+    process.env.NODE_ENV = 'development';
+    await expect(updateKometaSchedule(null, { enabled: true }, adminContext())).rejects.toThrow(
+      'Scheduled Kometa export cannot be enabled outside of production',
+    );
+  });
+
+  it('invalid frequency throws BAD_USER_INPUT', async () => {
+    await expect(
+      updateKometaSchedule(null, { frequency: 'weekly' }, adminContext()),
+    ).rejects.toThrow('frequency must be "hourly" or "daily"');
+  });
+
+  it('invalid dailyTime format throws BAD_USER_INPUT', async () => {
+    await expect(updateKometaSchedule(null, { dailyTime: 'noon' }, adminContext())).rejects.toThrow(
+      'dailyTime must be in HH:MM format',
+    );
+  });
+
+  it('admin can update schedule and calls rescheduleKometa', async () => {
+    process.env.NODE_ENV = 'production';
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            enabled: true,
+            frequency: 'hourly',
+            daily_time: '03:00',
+            collection_name: null,
+            last_run_at: null,
+          },
+        ],
+      }); // SELECT updated
+    const result = await updateKometaSchedule(
+      null,
+      { enabled: true, frequency: 'hourly' },
+      adminContext(),
+    );
+    expect(result.enabled).toBe(true);
+    expect(result.frequency).toBe('hourly');
+    expect(mockRescheduleKometa).toHaveBeenCalledWith(true, 'hourly', '03:00');
+  });
+});

--- a/backend/src/__tests__/resolvers/kometa-resolvers.test.ts
+++ b/backend/src/__tests__/resolvers/kometa-resolvers.test.ts
@@ -71,6 +71,57 @@ describe('Mutation.exportKometa', () => {
     );
   });
 
+  it('sanitizes collection name to prevent YAML injection', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.KOMETA_COLLECTIONS_PATH = '/tmp/kometa';
+    delete process.env.KOMETA_TRIGGER_URL;
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ title: 'Movie', tmdb_id: 1, elo_rank: 1000 }],
+    });
+    mockWriteFile.mockResolvedValue(undefined);
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    await exportKometa(null, { collectionName: 'Evil: {inject}\nmalicious: true' }, adminContext());
+    const writtenYaml = mockWriteFile.mock.calls[0][1];
+    // YAML-special chars (: { } \n) should be stripped
+    expect(writtenYaml).not.toContain('{inject}');
+    expect(writtenYaml).not.toContain('malicious: true');
+    expect(writtenYaml).toContain('Evil inject');
+  });
+
+  it('uses default name when sanitized collectionName is empty', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.KOMETA_COLLECTIONS_PATH = '/tmp/kometa';
+    delete process.env.KOMETA_TRIGGER_URL;
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ title: 'Movie', tmdb_id: 1, elo_rank: 1000 }],
+    });
+    mockWriteFile.mockResolvedValue(undefined);
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    await exportKometa(null, { collectionName: ':::' }, adminContext());
+    const writtenYaml = mockWriteFile.mock.calls[0][1];
+    expect(writtenYaml).toContain('MovieNight Watchlist');
+  });
+
+  it('truncates collection name exceeding 100 characters', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.KOMETA_COLLECTIONS_PATH = '/tmp/kometa';
+    delete process.env.KOMETA_TRIGGER_URL;
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ title: 'Movie', tmdb_id: 1, elo_rank: 1000 }],
+    });
+    mockWriteFile.mockResolvedValue(undefined);
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const longName = 'A'.repeat(150);
+    await exportKometa(null, { collectionName: longName }, adminContext());
+    const writtenYaml = mockWriteFile.mock.calls[0][1];
+    // Name should be truncated to 100 chars
+    expect(writtenYaml).toContain('A'.repeat(100));
+    expect(writtenYaml).not.toContain('A'.repeat(101));
+  });
+
   it('triggers webhook when KOMETA_TRIGGER_URL is set', async () => {
     process.env.NODE_ENV = 'production';
     process.env.KOMETA_COLLECTIONS_PATH = '/tmp/kometa';

--- a/backend/src/__tests__/resolvers/letterboxd-resolvers.test.ts
+++ b/backend/src/__tests__/resolvers/letterboxd-resolvers.test.ts
@@ -1,0 +1,185 @@
+import { mockQuery, mockFetch, adminContext, authContext, anonContext } from './__helpers';
+import { resolvers } from '../../resolvers';
+
+const { importFromLetterboxd } = resolvers.Mutation;
+
+describe('Mutation.importFromLetterboxd', () => {
+  describe('authorization', () => {
+    it('non-admin throws FORBIDDEN', async () => {
+      await expect(
+        importFromLetterboxd(null, { url: 'https://letterboxd.com/user/list/x/' }, authContext()),
+      ).rejects.toThrow('Not authorized');
+    });
+
+    it('unauthenticated throws FORBIDDEN', async () => {
+      await expect(
+        importFromLetterboxd(null, { url: 'https://letterboxd.com/user/list/x/' }, anonContext()),
+      ).rejects.toThrow('Not authorized');
+    });
+  });
+
+  describe('URL validation', () => {
+    it('invalid URL throws BAD_USER_INPUT', async () => {
+      await expect(
+        importFromLetterboxd(null, { url: 'not-a-url' }, adminContext()),
+      ).rejects.toThrow('Invalid URL');
+    });
+
+    it('non-letterboxd hostname throws BAD_USER_INPUT', async () => {
+      await expect(
+        importFromLetterboxd(null, { url: 'https://evil.com/list/x/' }, adminContext()),
+      ).rejects.toThrow('URL must be a letterboxd.com list');
+    });
+
+    it('www.letterboxd.com is accepted', async () => {
+      const html = '<div data-item-name="Test Movie (2024)"></div>';
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => html,
+      });
+      // Second page returns 404 to stop pagination
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+      // Existing movies query
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      // INSERT for the movie
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      // logAudit
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const result = await importFromLetterboxd(
+        null,
+        { url: 'https://www.letterboxd.com/user/list/test/' },
+        adminContext(),
+      );
+      expect(result.imported).toBe(1);
+    });
+  });
+
+  describe('HTML parsing', () => {
+    it('parses data-item-name attributes with year', async () => {
+      const html =
+        '<div data-item-name="Inception (2010)"></div>' +
+        '<div data-item-name="Parasite (2019)"></div>';
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, status: 200, text: async () => html })
+        .mockResolvedValueOnce({ ok: false, status: 404 });
+      mockQuery.mockResolvedValueOnce({ rows: [] }); // existing movies
+      mockQuery.mockResolvedValue({ rows: [] }); // INSERTs + logAudit
+
+      const result = await importFromLetterboxd(
+        null,
+        { url: 'https://letterboxd.com/user/list/x/' },
+        adminContext(),
+      );
+      expect(result.imported).toBe(2);
+    });
+
+    it('handles titles without year', async () => {
+      const html = '<div data-item-name="Some Movie"></div>';
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, status: 200, text: async () => html })
+        .mockResolvedValueOnce({ ok: false, status: 404 });
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      mockQuery.mockResolvedValue({ rows: [] });
+
+      const result = await importFromLetterboxd(
+        null,
+        { url: 'https://letterboxd.com/user/list/x/' },
+        adminContext(),
+      );
+      expect(result.imported).toBe(1);
+    });
+
+    it('decodes HTML entities', async () => {
+      const html = '<div data-item-name="Rock &amp; Roll (2020)"></div>';
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, status: 200, text: async () => html })
+        .mockResolvedValueOnce({ ok: false, status: 404 });
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      mockQuery.mockResolvedValue({ rows: [] });
+
+      const result = await importFromLetterboxd(
+        null,
+        { url: 'https://letterboxd.com/user/list/x/' },
+        adminContext(),
+      );
+      expect(result.imported).toBe(1);
+      // Verify the INSERT was called with decoded title
+      expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO movies'), [
+        'Rock & Roll',
+        expect.any(Number),
+        null,
+      ]);
+    });
+
+    it('stops pagination on 404', async () => {
+      const html = '<div data-item-name="Movie A (2020)"></div>';
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, status: 200, text: async () => html })
+        .mockResolvedValueOnce({ ok: false, status: 404 }); // page 2 = 404
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      mockQuery.mockResolvedValue({ rows: [] });
+
+      await importFromLetterboxd(
+        null,
+        { url: 'https://letterboxd.com/user/list/x/' },
+        adminContext(),
+      );
+      // Should only fetch 2 times (page 1 + page 2 = 404)
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('deduplication', () => {
+    it('skips movies that already exist (case-insensitive)', async () => {
+      const html = '<div data-item-name="Inception (2010)"></div>';
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, status: 200, text: async () => html })
+        .mockResolvedValueOnce({ ok: false, status: 404 });
+      mockQuery.mockResolvedValueOnce({ rows: [{ title: 'inception' }] }); // existing
+      mockQuery.mockResolvedValue({ rows: [] }); // logAudit
+
+      const result = await importFromLetterboxd(
+        null,
+        { url: 'https://letterboxd.com/user/list/x/' },
+        adminContext(),
+      );
+      expect(result.imported).toBe(0);
+      expect(result.skipped).toBe(1);
+    });
+  });
+
+  describe('error handling', () => {
+    it('fetch failure returns errors array', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+      mockQuery.mockResolvedValueOnce({ rows: [] }); // existing movies check isn't reached
+      mockQuery.mockResolvedValue({ rows: [] }); // logAudit
+
+      const result = await importFromLetterboxd(
+        null,
+        { url: 'https://letterboxd.com/user/list/x/' },
+        adminContext(),
+      );
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('no films found returns error message', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => '<html><body>No films here</body></html>',
+      });
+      mockQuery.mockResolvedValue({ rows: [] });
+
+      const result = await importFromLetterboxd(
+        null,
+        { url: 'https://letterboxd.com/user/list/x/' },
+        adminContext(),
+      );
+      expect(result.errors).toContain(
+        'No films found — check that the URL is a public Letterboxd list',
+      );
+    });
+  });
+});

--- a/backend/src/__tests__/resolvers/movie-resolvers.test.ts
+++ b/backend/src/__tests__/resolvers/movie-resolvers.test.ts
@@ -34,6 +34,31 @@ describe('Mutation.addMovie', () => {
     ]);
   });
 
+  it('trims whitespace from title', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1, title: 'Inception' }] })
+      .mockResolvedValueOnce({ rows: [{ username: 'alice' }] })
+      .mockResolvedValueOnce({ rows: [] });
+    await addMovie(null, { title: '  Inception  ' }, authContext());
+    expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO movies'), [
+      'Inception',
+      1,
+      null,
+    ]);
+  });
+
+  it('rejects empty title after trimming', async () => {
+    await expect(addMovie(null, { title: '   ' }, authContext())).rejects.toThrow(
+      'Title must be between 1 and 500 characters',
+    );
+  });
+
+  it('rejects title exceeding 500 characters', async () => {
+    await expect(addMovie(null, { title: 'A'.repeat(501) }, authContext())).rejects.toThrow(
+      'Title must be between 1 and 500 characters',
+    );
+  });
+
   it('unauthenticated throws UNAUTHENTICATED', async () => {
     await expect(addMovie(null, { title: 'X' }, anonContext())).rejects.toThrow(
       'Not authenticated',

--- a/backend/src/__tests__/resolvers/movie-resolvers.test.ts
+++ b/backend/src/__tests__/resolvers/movie-resolvers.test.ts
@@ -1,0 +1,208 @@
+import {
+  mockQuery,
+  mockApplyComparison,
+  mockUpdateGlobalEloRank,
+  authContext,
+  adminContext,
+  anonContext,
+} from './__helpers';
+import { resolvers } from '../../resolvers';
+
+const { addMovie, matchMovie, markWatched, deleteMovie, recordComparison, resetMovieComparisons } =
+  resolvers.Mutation;
+
+describe('Mutation.addMovie', () => {
+  it('authenticated user can add a movie', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1, title: 'Inception', requested_by: 1 }] }) // INSERT
+      .mockResolvedValueOnce({ rows: [{ username: 'alice', display_name: 'Alice' }] }) // user lookup
+      .mockResolvedValueOnce({ rows: [] }); // logAudit
+    const result = await addMovie(null, { title: 'Inception' }, authContext());
+    expect(result.title).toBe('Inception');
+  });
+
+  it('passes tmdb_id when provided', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1, title: 'Inception', tmdb_id: 27205 }] })
+      .mockResolvedValueOnce({ rows: [{ username: 'a', display_name: null }] })
+      .mockResolvedValueOnce({ rows: [] });
+    await addMovie(null, { title: 'Inception', tmdb_id: 27205 }, authContext());
+    expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO movies'), [
+      'Inception',
+      1,
+      27205,
+    ]);
+  });
+
+  it('unauthenticated throws UNAUTHENTICATED', async () => {
+    await expect(addMovie(null, { title: 'X' }, anonContext())).rejects.toThrow(
+      'Not authenticated',
+    );
+  });
+});
+
+describe('Mutation.matchMovie', () => {
+  it('owner can match their own movie', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          { id: 1, requested_by: 1, title: 'Old', user_username: 'a', user_display_name: 'A' },
+        ],
+      }) // SELECT movie
+      .mockResolvedValueOnce({
+        rows: [{ id: 1, tmdb_id: 100, title: 'New' }],
+      }) // UPDATE
+      .mockResolvedValueOnce({ rows: [] }); // logAudit
+    const result = await matchMovie(
+      null,
+      { id: '1', tmdb_id: 100, title: 'New' },
+      authContext({ userId: 1 }),
+    );
+    expect(result.title).toBe('New');
+  });
+
+  it('admin can match any movie', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          { id: 1, requested_by: 99, title: 'Old', user_username: 'x', user_display_name: null },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ id: 1, tmdb_id: 100, title: 'New' }] })
+      .mockResolvedValueOnce({ rows: [] });
+    const result = await matchMovie(null, { id: '1', tmdb_id: 100, title: 'New' }, adminContext());
+    expect(result.title).toBe('New');
+  });
+
+  it('non-owner non-admin throws FORBIDDEN', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 1, requested_by: 99, title: 'X' }],
+    });
+    await expect(
+      matchMovie(null, { id: '1', tmdb_id: 1, title: 'X' }, authContext({ userId: 2 })),
+    ).rejects.toThrow('Not authorized');
+  });
+
+  it('nonexistent movie throws NOT_FOUND', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await expect(
+      matchMovie(null, { id: '999', tmdb_id: 1, title: 'X' }, authContext()),
+    ).rejects.toThrow('Movie not found');
+  });
+
+  it('unauthenticated throws UNAUTHENTICATED', async () => {
+    await expect(
+      matchMovie(null, { id: '1', tmdb_id: 1, title: 'X' }, anonContext()),
+    ).rejects.toThrow('Not authenticated');
+  });
+});
+
+describe('Mutation.markWatched', () => {
+  it('owner can mark their movie watched', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1, requested_by: 1 }] }) // SELECT
+      .mockResolvedValueOnce({
+        rows: [{ id: 1, title: 'M', requested_by: 1, watched_at: new Date() }],
+      }) // UPDATE
+      .mockResolvedValueOnce({ rows: [{ username: 'a', display_name: 'A' }] }) // user lookup
+      .mockResolvedValueOnce({ rows: [] }); // logAudit
+    const result = await markWatched(null, { id: '1' }, authContext({ userId: 1 }));
+    expect(result.watched_at).toBeTruthy();
+  });
+
+  it('admin can mark any movie watched', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1, requested_by: 99 }] })
+      .mockResolvedValueOnce({
+        rows: [{ id: 1, title: 'M', requested_by: 99, watched_at: new Date() }],
+      })
+      .mockResolvedValueOnce({ rows: [{ username: 'x', display_name: null }] })
+      .mockResolvedValueOnce({ rows: [] });
+    await markWatched(null, { id: '1' }, adminContext());
+  });
+
+  it('non-owner non-admin throws FORBIDDEN', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1, requested_by: 99 }] });
+    await expect(markWatched(null, { id: '1' }, authContext({ userId: 2 }))).rejects.toThrow(
+      'Not authorized',
+    );
+  });
+
+  it('nonexistent movie throws NOT_FOUND', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await expect(markWatched(null, { id: '999' }, authContext())).rejects.toThrow(
+      'Movie not found',
+    );
+  });
+
+  it('unauthenticated throws UNAUTHENTICATED', async () => {
+    await expect(markWatched(null, { id: '1' }, anonContext())).rejects.toThrow(
+      'Not authenticated',
+    );
+  });
+});
+
+describe('Mutation.deleteMovie', () => {
+  it('admin can delete a movie', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ title: 'Deleted' }] }) // SELECT title
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] }) // DELETE
+      .mockResolvedValueOnce({ rows: [] }); // logAudit
+    const result = await deleteMovie(null, { id: '1' }, adminContext());
+    expect(result).toBe(true);
+  });
+
+  it('non-admin throws FORBIDDEN', async () => {
+    await expect(deleteMovie(null, { id: '1' }, authContext())).rejects.toThrow('Not authorized');
+  });
+
+  it('returns false when movie does not exist', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // SELECT (not found)
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] }); // DELETE
+    const result = await deleteMovie(null, { id: '999' }, adminContext());
+    expect(result).toBe(false);
+  });
+});
+
+describe('Mutation.recordComparison', () => {
+  it('authenticated user records comparison', async () => {
+    mockApplyComparison.mockResolvedValue({ winnerElo: 1016, loserElo: 984 });
+    mockQuery.mockResolvedValue({ rows: [] }); // logAudit
+    const result = await recordComparison(null, { winnerId: '1', loserId: '2' }, authContext());
+    expect(result.winnerElo).toBe(1016);
+    expect(result.loserElo).toBe(984);
+  });
+
+  it('unauthenticated throws UNAUTHENTICATED', async () => {
+    await expect(
+      recordComparison(null, { winnerId: '1', loserId: '2' }, anonContext()),
+    ).rejects.toThrow('Not authenticated');
+  });
+});
+
+describe('Mutation.resetMovieComparisons', () => {
+  it('authenticated user resets comparisons for a movie', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 5, title: 'Test' }] }) // SELECT movie
+      .mockResolvedValueOnce({ rows: [] }) // DELETE comparisons
+      .mockResolvedValueOnce({ rows: [] }) // DELETE elo entry
+      .mockResolvedValueOnce({ rows: [] }); // logAudit
+    mockUpdateGlobalEloRank.mockResolvedValue(undefined);
+    const result = await resetMovieComparisons(null, { movieId: '5' }, authContext());
+    expect(result).toBe(true);
+  });
+
+  it('nonexistent movie throws NOT_FOUND', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await expect(resetMovieComparisons(null, { movieId: '999' }, authContext())).rejects.toThrow(
+      'Movie not found',
+    );
+  });
+
+  it('unauthenticated throws UNAUTHENTICATED', async () => {
+    await expect(resetMovieComparisons(null, { movieId: '5' }, anonContext())).rejects.toThrow(
+      'Not authenticated',
+    );
+  });
+});

--- a/backend/src/__tests__/resolvers/query-resolvers.test.ts
+++ b/backend/src/__tests__/resolvers/query-resolvers.test.ts
@@ -180,7 +180,7 @@ describe('Query.searchTmdb', () => {
         results: [{ id: 1, title: 'Movie', release_date: '2024-01-01', overview: 'desc' }],
       }),
     });
-    const result = await Query.searchTmdb(null, { query: 'Movie' });
+    const result = await Query.searchTmdb(null, { query: 'Movie' }, authContext());
     expect(result).toHaveLength(1);
     expect(result[0].tmdb_id).toBe(1);
     expect(result[0].release_year).toBe('2024');
@@ -188,8 +188,15 @@ describe('Query.searchTmdb', () => {
 
   it('throws when no TMDB_API_KEY', async () => {
     delete process.env.TMDB_API_KEY;
-    await expect(Query.searchTmdb(null, { query: 'X' })).rejects.toThrow(
+    await expect(Query.searchTmdb(null, { query: 'X' }, authContext())).rejects.toThrow(
       'TMDB API key not configured',
+    );
+  });
+
+  it('unauthenticated throws UNAUTHENTICATED', async () => {
+    process.env.TMDB_API_KEY = 'test-key';
+    await expect(Query.searchTmdb(null, { query: 'Movie' }, anonContext())).rejects.toThrow(
+      'Not authenticated',
     );
   });
 });
@@ -214,6 +221,12 @@ describe('Query.searchUsers', () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 2, username: 'bob' }] });
     const result = await Query.searchUsers(null, { query: 'bob' }, authContext());
     expect(result[0].username).toBe('bob');
+  });
+
+  it('escapes SQL wildcard characters in query', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await Query.searchUsers(null, { query: 'test%_\\' }, authContext());
+    expect(mockQuery).toHaveBeenCalledWith(expect.any(String), [1, '%test\\%\\_\\\\%']);
   });
 
   it('unauthenticated throws UNAUTHENTICATED', async () => {

--- a/backend/src/__tests__/resolvers/query-resolvers.test.ts
+++ b/backend/src/__tests__/resolvers/query-resolvers.test.ts
@@ -1,0 +1,262 @@
+import {
+  mockQuery,
+  mockSelectPair,
+  mockFetch,
+  authContext,
+  adminContext,
+  anonContext,
+} from './__helpers';
+import { resolvers } from '../../resolvers';
+
+const Query = resolvers.Query;
+
+describe('Query.appInfo', () => {
+  const origEnv = process.env.NODE_ENV;
+  afterEach(() => {
+    process.env.NODE_ENV = origEnv;
+  });
+
+  it('non-production: returns isProduction=false with quickLoginUsers', () => {
+    process.env.NODE_ENV = 'development';
+    const result = Query.appInfo();
+    expect(result.isProduction).toBe(false);
+    expect(result.quickLoginUsers.length).toBeGreaterThan(0);
+  });
+
+  it('production: returns isProduction=true with empty quickLoginUsers', () => {
+    process.env.NODE_ENV = 'production';
+    const result = Query.appInfo();
+    expect(result.isProduction).toBe(true);
+    expect(result.quickLoginUsers).toEqual([]);
+  });
+});
+
+describe('Query.me', () => {
+  it('authenticated returns user data', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1, username: 'alice' }] });
+    const result = await Query.me(null, null, authContext());
+    expect(result.username).toBe('alice');
+  });
+
+  it('unauthenticated throws UNAUTHENTICATED', async () => {
+    await expect(Query.me(null, null, anonContext())).rejects.toThrow('Not authenticated');
+  });
+});
+
+describe('Query.users', () => {
+  it('admin returns all users', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }, { id: 2 }] });
+    const result = await Query.users(null, null, adminContext());
+    expect(result).toHaveLength(2);
+  });
+
+  it('non-admin throws FORBIDDEN', async () => {
+    await expect(Query.users(null, null, authContext())).rejects.toThrow('Not authorized');
+  });
+});
+
+describe('Query.user', () => {
+  it('admin returns user by ID', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 5, username: 'bob' }] });
+    const result = await Query.user(null, { id: '5' }, adminContext());
+    expect(result.username).toBe('bob');
+  });
+
+  it('non-admin throws FORBIDDEN', async () => {
+    await expect(Query.user(null, { id: '5' }, authContext())).rejects.toThrow('Not authorized');
+  });
+});
+
+describe('Query.movie', () => {
+  it('returns single movie by ID', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 3, title: 'Inception' }] });
+    const result = await (Query.movie as any)(null, { id: '3' });
+    expect(result.title).toBe('Inception');
+  });
+});
+
+describe('Query.movies', () => {
+  it('authenticated queries with user Elo join', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1, title: 'A' }] });
+    await Query.movies(null, null, authContext());
+    expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('user_movie_elo'), [1]);
+  });
+
+  it('unauthenticated queries global elo_rank', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1, title: 'A' }] });
+    await Query.movies(null, null, anonContext());
+    expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('ORDER BY m.elo_rank'));
+  });
+});
+
+describe('Query.auditLogs', () => {
+  it('admin returns logs with capped limit', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await Query.auditLogs(null, { limit: 1000, offset: 0 }, adminContext());
+    // Should cap at 500
+    expect(mockQuery).toHaveBeenCalledWith(expect.any(String), [500, 0]);
+  });
+
+  it('non-admin throws FORBIDDEN', async () => {
+    await expect(Query.auditLogs(null, { limit: 10, offset: 0 }, authContext())).rejects.toThrow(
+      'Not authorized',
+    );
+  });
+});
+
+describe('Query.loginHistory', () => {
+  it('admin with userId filter returns filtered results', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }] });
+    await Query.loginHistory(null, { userId: '5', limit: 50 }, adminContext());
+    expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('WHERE lh.user_id'), ['5', 50]);
+  });
+
+  it('admin without filter returns all', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await Query.loginHistory(null, { limit: 50 }, adminContext());
+    expect(mockQuery).toHaveBeenCalledWith(expect.any(String), [50]);
+  });
+
+  it('non-admin throws FORBIDDEN', async () => {
+    await expect(Query.loginHistory(null, { limit: 10 }, authContext())).rejects.toThrow(
+      'Not authorized',
+    );
+  });
+
+  it('caps limit at 500', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await Query.loginHistory(null, { limit: 999 }, adminContext());
+    expect(mockQuery).toHaveBeenCalledWith(expect.any(String), [500]);
+  });
+});
+
+describe('Query.thisOrThat', () => {
+  it('authenticated returns movieA and movieB', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { id: 1, title: 'A', tmdb_id: null, user_comparison_count: '0', elo_rating: '1000' },
+        { id: 2, title: 'B', tmdb_id: null, user_comparison_count: '0', elo_rating: '1000' },
+      ],
+    });
+    mockSelectPair.mockReturnValue([
+      { id: 1, title: 'A', tmdb_id: null, userComparisonCount: 0, elo_rating: 1000 },
+      { id: 2, title: 'B', tmdb_id: null, userComparisonCount: 0, elo_rating: 1000 },
+    ]);
+    const result = await Query.thisOrThat(null, {}, authContext());
+    expect(result.movieA.title).toBe('A');
+    expect(result.movieB.title).toBe('B');
+  });
+
+  it('unauthenticated throws UNAUTHENTICATED', async () => {
+    await expect(Query.thisOrThat(null, {}, anonContext())).rejects.toThrow('Not authenticated');
+  });
+
+  it('less than 2 movies throws BAD_USER_INPUT', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 1, title: 'A', tmdb_id: null, user_comparison_count: '0', elo_rating: '1000' }],
+    });
+    // Retry without exclusion also returns < 2
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 1, title: 'A', tmdb_id: null, user_comparison_count: '0', elo_rating: '1000' }],
+    });
+    await expect(Query.thisOrThat(null, {}, authContext())).rejects.toThrow(
+      'Add more movies to start comparing',
+    );
+  });
+});
+
+describe('Query.searchTmdb', () => {
+  const origKey = process.env.TMDB_API_KEY;
+  afterEach(() => {
+    if (origKey) process.env.TMDB_API_KEY = origKey;
+    else delete process.env.TMDB_API_KEY;
+  });
+
+  it('returns mapped TMDB results', async () => {
+    process.env.TMDB_API_KEY = 'test-key';
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [{ id: 1, title: 'Movie', release_date: '2024-01-01', overview: 'desc' }],
+      }),
+    });
+    const result = await Query.searchTmdb(null, { query: 'Movie' });
+    expect(result).toHaveLength(1);
+    expect(result[0].tmdb_id).toBe(1);
+    expect(result[0].release_year).toBe('2024');
+  });
+
+  it('throws when no TMDB_API_KEY', async () => {
+    delete process.env.TMDB_API_KEY;
+    await expect(Query.searchTmdb(null, { query: 'X' })).rejects.toThrow(
+      'TMDB API key not configured',
+    );
+  });
+});
+
+describe('Query.myRankings', () => {
+  it('authenticated returns user rankings', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 1, title: 'A', elo_rating: '1050', comparison_count: '10' }],
+    });
+    const result = await Query.myRankings(null, null, authContext());
+    expect(result[0].eloRating).toBe(1050);
+    expect(result[0].comparisonCount).toBe(10);
+  });
+
+  it('unauthenticated throws UNAUTHENTICATED', async () => {
+    await expect(Query.myRankings(null, null, anonContext())).rejects.toThrow('Not authenticated');
+  });
+});
+
+describe('Query.searchUsers', () => {
+  it('authenticated returns matching users', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 2, username: 'bob' }] });
+    const result = await Query.searchUsers(null, { query: 'bob' }, authContext());
+    expect(result[0].username).toBe('bob');
+  });
+
+  it('unauthenticated throws UNAUTHENTICATED', async () => {
+    await expect(Query.searchUsers(null, { query: 'x' }, anonContext())).rejects.toThrow(
+      'Not authenticated',
+    );
+  });
+});
+
+describe('Query.kometaSchedule', () => {
+  it('admin returns schedule data', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          enabled: true,
+          frequency: 'daily',
+          daily_time: '03:00',
+          collection_name: null,
+          last_run_at: null,
+        },
+      ],
+    });
+    const result = await Query.kometaSchedule(null, null, adminContext());
+    expect(result.enabled).toBe(true);
+    expect(result.frequency).toBe('daily');
+  });
+
+  it('non-admin throws FORBIDDEN', async () => {
+    await expect(Query.kometaSchedule(null, null, authContext())).rejects.toThrow('Not authorized');
+  });
+});
+
+describe('Query.combinedList', () => {
+  it('unauthenticated throws UNAUTHENTICATED', async () => {
+    await expect(Query.combinedList(null, { connectionId: '1' }, anonContext())).rejects.toThrow(
+      'Not authenticated',
+    );
+  });
+
+  it('connection not found throws NOT_FOUND', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await expect(Query.combinedList(null, { connectionId: '999' }, authContext())).rejects.toThrow(
+      'Connection not found',
+    );
+  });
+});

--- a/backend/src/__tests__/scheduler.test.ts
+++ b/backend/src/__tests__/scheduler.test.ts
@@ -1,0 +1,102 @@
+jest.mock('../db', () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}));
+
+// Mock fs before importing scheduler
+jest.mock('fs', () => ({
+  promises: { writeFile: jest.fn() },
+}));
+
+import pool from '../db';
+import { initScheduler, rescheduleKometa } from '../scheduler';
+
+const mockQuery = pool.query as jest.Mock;
+
+describe('initScheduler', () => {
+  const origEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = origEnv;
+    jest.clearAllTimers();
+  });
+
+  it('non-production: logs disabled, does not query DB', async () => {
+    process.env.NODE_ENV = 'development';
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    await initScheduler();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Disabled (non-production environment)'),
+    );
+    expect(mockQuery).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('production + no schedule row: returns without scheduling', async () => {
+    process.env.NODE_ENV = 'production';
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await initScheduler();
+    // No error thrown
+  });
+
+  it('production + disabled schedule: logs disabled', async () => {
+    process.env.NODE_ENV = 'production';
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ enabled: false, frequency: 'daily', daily_time: '03:00' }],
+    });
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    await initScheduler();
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Disabled, not starting'));
+    consoleSpy.mockRestore();
+  });
+
+  it('production + enabled: starts scheduling', async () => {
+    jest.useFakeTimers();
+    process.env.NODE_ENV = 'production';
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ enabled: true, frequency: 'hourly', daily_time: '03:00' }],
+    });
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    await initScheduler();
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Starting'));
+    consoleSpy.mockRestore();
+    jest.useRealTimers();
+  });
+});
+
+describe('rescheduleKometa', () => {
+  const origEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = origEnv;
+    jest.clearAllTimers();
+  });
+
+  it('non-production: logs skip', () => {
+    process.env.NODE_ENV = 'development';
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    rescheduleKometa(true, 'hourly', '03:00');
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Reschedule skipped'));
+    consoleSpy.mockRestore();
+  });
+
+  it('production + disabled: logs disabled', () => {
+    jest.useFakeTimers();
+    process.env.NODE_ENV = 'production';
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    rescheduleKometa(false, 'daily', '03:00');
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Disabled'));
+    consoleSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it('production + enabled: schedules new export', () => {
+    jest.useFakeTimers();
+    process.env.NODE_ENV = 'production';
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    rescheduleKometa(true, 'hourly', '03:00');
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Rescheduling'));
+    consoleSpy.mockRestore();
+    jest.useRealTimers();
+  });
+});

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -16,10 +16,7 @@ export async function hashPassword(password: string): Promise<string> {
   return bcrypt.hash(password, SALT_ROUNDS);
 }
 
-export async function comparePassword(
-  password: string,
-  hash: string
-): Promise<boolean> {
+export async function comparePassword(password: string, hash: string): Promise<boolean> {
   return bcrypt.compare(password, hash);
 }
 

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -1,7 +1,7 @@
 import { Pool } from 'pg';
 import path from 'path';
 // node-pg-migrate v8 is ESM-only; use dynamic import in CJS
-const loadMigrate = () => import('node-pg-migrate').then(m => m.runner);
+const loadMigrate = () => import('node-pg-migrate').then((m) => m.runner);
 import { hashPassword } from './auth';
 
 const pool = new Pool({
@@ -21,7 +21,7 @@ const seedAdminUser = async () => {
       `INSERT INTO users (username, email, password_hash, is_admin)
        VALUES ($1, $2, $3, $4)
        ON CONFLICT (username) DO UPDATE SET password_hash = EXCLUDED.password_hash, is_admin = EXCLUDED.is_admin`,
-      ['admin', 'admin@movienight.local', passwordHash, true]
+      ['admin', 'admin@movienight.local', passwordHash, true],
     );
 
     console.log('✅ Admin user ensured (username: admin)');
@@ -40,7 +40,7 @@ const seedTestUser = async () => {
       `INSERT INTO users (username, email, password_hash, display_name, is_admin)
        VALUES ($1, $2, $3, $4, $5)
        ON CONFLICT (username) DO UPDATE SET password_hash = EXCLUDED.password_hash`,
-      [username, `${username}@movienight.local`, passwordHash, 'Test User', false]
+      [username, `${username}@movienight.local`, passwordHash, 'Test User', false],
     );
 
     console.log(`✅ Test user ensured (username: ${username})`);

--- a/backend/src/elo.ts
+++ b/backend/src/elo.ts
@@ -17,13 +17,15 @@ export async function getOrCreateElo(userId: number, movieId: number): Promise<n
      VALUES ($1, $2, $3, 0)
      ON CONFLICT (user_id, movie_id) DO UPDATE SET user_id = EXCLUDED.user_id
      RETURNING elo_rating`,
-    [userId, movieId, BASE_RATING]
+    [userId, movieId, BASE_RATING],
   );
   return Number(res.rows[0].elo_rating);
 }
 
 export async function applyComparison(
-  userId: number, winnerId: number, loserId: number
+  userId: number,
+  winnerId: number,
+  loserId: number,
 ): Promise<{ winnerElo: number; loserElo: number }> {
   const [rW, rL] = await Promise.all([
     getOrCreateElo(userId, winnerId),
@@ -37,27 +39,24 @@ export async function applyComparison(
       `UPDATE user_movie_elo
        SET elo_rating = $1, comparison_count = comparison_count + 1, updated_at = NOW()
        WHERE user_id = $2 AND movie_id = $3`,
-      [newA, userId, winnerId]
+      [newA, userId, winnerId],
     ),
     pool.query(
       `UPDATE user_movie_elo
        SET elo_rating = $1, comparison_count = comparison_count + 1, updated_at = NOW()
        WHERE user_id = $2 AND movie_id = $3`,
-      [newB, userId, loserId]
+      [newB, userId, loserId],
     ),
   ]);
 
   // Record comparison log
   await pool.query(
     'INSERT INTO movie_comparisons (user_id, winner_id, loser_id) VALUES ($1, $2, $3)',
-    [userId, winnerId, loserId]
+    [userId, winnerId, loserId],
   );
 
   // Recompute global elo_rank for both movies
-  await Promise.all([
-    updateGlobalEloRank(winnerId),
-    updateGlobalEloRank(loserId),
-  ]);
+  await Promise.all([updateGlobalEloRank(winnerId), updateGlobalEloRank(loserId)]);
 
   return { winnerElo: newA, loserElo: newB };
 }
@@ -67,6 +66,6 @@ export async function updateGlobalEloRank(movieId: number): Promise<void> {
     `UPDATE movies SET elo_rank = (
        SELECT AVG(elo_rating) FROM user_movie_elo WHERE movie_id = $1
      ) WHERE id = $1`,
-    [movieId]
+    [movieId],
   );
 }

--- a/backend/src/email.ts
+++ b/backend/src/email.ts
@@ -16,10 +16,7 @@ const transporter = nodemailer.createTransport({
 
 const FROM_ADDRESS = process.env.SMTP_FROM || 'noreply@movienight.local';
 
-export async function sendPasswordResetEmail(
-  to: string,
-  resetToken: string
-): Promise<void> {
+export async function sendPasswordResetEmail(to: string, resetToken: string): Promise<void> {
   const appUrl = process.env.APP_URL || 'http://localhost:3000';
   const resetLink = `${appUrl}?resetToken=${resetToken}`;
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -36,10 +36,9 @@ async function startServer() {
         // Revalidate JWT claims against DB to catch demoted/deactivated users
         if (user) {
           try {
-            const dbUser = await pool.query(
-              'SELECT is_admin, is_active FROM users WHERE id = $1',
-              [user.userId]
-            );
+            const dbUser = await pool.query('SELECT is_admin, is_active FROM users WHERE id = $1', [
+              user.userId,
+            ]);
             if (dbUser.rows.length === 0 || !dbUser.rows[0].is_active) {
               user = null; // User deleted or deactivated
             } else {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -51,26 +51,27 @@ async function startServer() {
         }
 
         const ipAddress =
-          (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
-          req.ip ||
-          'unknown';
+          (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() || req.ip || 'unknown';
         const userAgent = (req.headers['user-agent'] as string) || 'unknown';
         return { user, ipAddress, userAgent };
       },
-    })
+    }),
   );
 
   await initializeDatabase();
   await initScheduler();
 
   // Clean up expired password reset tokens every hour
-  setInterval(async () => {
-    try {
-      await pool.query('DELETE FROM password_reset_tokens WHERE expires_at < NOW()');
-    } catch (err) {
-      console.error('Failed to clean expired reset tokens:', err);
-    }
-  }, 60 * 60 * 1000).unref();
+  setInterval(
+    async () => {
+      try {
+        await pool.query('DELETE FROM password_reset_tokens WHERE expires_at < NOW()');
+      } catch (err) {
+        console.error('Failed to clean expired reset tokens:', err);
+      }
+    },
+    60 * 60 * 1000,
+  ).unref();
 
   app.listen(PORT, () => {
     console.log(`🚀 GraphQL server ready at http://localhost:${PORT}/graphql`);

--- a/backend/src/pairSelection.ts
+++ b/backend/src/pairSelection.ts
@@ -1,5 +1,5 @@
-const K = 5;               // established threshold
-const EP_POOL_MIN = 5;     // minimum EP candidate pool size
+const K = 5; // established threshold
+const EP_POOL_MIN = 5; // minimum EP candidate pool size
 const SEED_ELO_BAND = 150; // +/- Elo around median for seeded "peer" pick
 
 export interface MovieCandidate {
@@ -16,32 +16,31 @@ export function selectPair(movies: MovieCandidate[]): [MovieCandidate, MovieCand
   const epPoolSize = Math.max(EP_POOL_MIN, Math.floor(movies.length * 0.1));
 
   // Tier 1: IFW first pick
-  const weights = movies.map(m => 1 / (m.userComparisonCount + 1));
+  const weights = movies.map((m) => 1 / (m.userComparisonCount + 1));
   const first = weightedRandomPick(movies, weights);
 
-  const rest = movies.filter(m => m.id !== first.id);
-  const established = rest.filter(m => m.userComparisonCount >= K);
+  const rest = movies.filter((m) => m.id !== first.id);
+  const established = rest.filter((m) => m.userComparisonCount >= K);
 
   let second: MovieCandidate;
 
   if (first.userComparisonCount < K && established.length >= K) {
     // Tier 2: seeded pick
     const median = medianElo(established);
-    const peers = established.filter(m => Math.abs(m.elo_rating - median) <= SEED_ELO_BAND);
+    const peers = established.filter((m) => Math.abs(m.elo_rating - median) <= SEED_ELO_BAND);
     const peerPool = peers.length > 0 ? peers : established;
     const rangerPool = established;
-    second = Math.random() < 0.5
-      ? randomPick(peerPool)
-      : randomPick(rangerPool);
+    second = Math.random() < 0.5 ? randomPick(peerPool) : randomPick(rangerPool);
   } else if (first.userComparisonCount >= K && established.length > 0) {
     // Tier 3: Elo-proximity pick
     const sorted = [...rest].sort(
-      (a, b) => Math.abs(a.elo_rating - first.elo_rating) - Math.abs(b.elo_rating - first.elo_rating)
+      (a, b) =>
+        Math.abs(a.elo_rating - first.elo_rating) - Math.abs(b.elo_rating - first.elo_rating),
     );
     second = randomPick(sorted.slice(0, epPoolSize));
   } else {
     // Fallback: IFW from remaining
-    const restWeights = rest.map(m => 1 / (m.userComparisonCount + 1));
+    const restWeights = rest.map((m) => 1 / (m.userComparisonCount + 1));
     second = weightedRandomPick(rest, restWeights);
   }
 
@@ -63,7 +62,7 @@ function randomPick<T>(items: T[]): T {
 }
 
 function medianElo(movies: MovieCandidate[]): number {
-  const sorted = [...movies].map(m => m.elo_rating).sort((a, b) => a - b);
+  const sorted = [...movies].map((m) => m.elo_rating).sort((a, b) => a - b);
   const mid = Math.floor(sorted.length / 2);
   return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
 }

--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -884,7 +884,11 @@ export const resolvers = {
 
       // Sanitize collection name: strip control chars, YAML-special chars, and limit length
       const rawName = collectionName || 'MovieNight Watchlist';
-      const name = rawName.replace(/[:\n\r\t\\#%@`|>!&*?{}\[\]]/g, '').trim().slice(0, 100) || 'MovieNight Watchlist';
+      const name =
+        rawName
+          .replace(/[:\n\r\t\\#%@`|>!&*?{}\[\]]/g, '')
+          .trim()
+          .slice(0, 100) || 'MovieNight Watchlist';
       const today = new Date().toISOString().split('T')[0];
       const idLines = matched.map((m: any) => `      - ${m.tmdb_id}`).join('\n');
       const yaml =
@@ -1309,7 +1313,14 @@ export const resolvers = {
       { username, password }: { username: string; password: string },
       context: any,
     ) => {
-      if (!checkRateLimit(loginRateLimiter, context.ipAddress, LOGIN_RATE_LIMIT_MAX, LOGIN_RATE_LIMIT_WINDOW)) {
+      if (
+        !checkRateLimit(
+          loginRateLimiter,
+          context.ipAddress,
+          LOGIN_RATE_LIMIT_MAX,
+          LOGIN_RATE_LIMIT_WINDOW,
+        )
+      ) {
         await logLoginHistory(null, context.ipAddress, context.userAgent, false);
         throw new GraphQLError('Too many login attempts. Please try again later.', {
           extensions: { code: 'TOO_MANY_REQUESTS' },
@@ -1367,13 +1378,19 @@ export const resolvers = {
         });
       }
       if (!args.username || args.username.length > 100) {
-        throw new GraphQLError('Username must be between 1 and 100 characters', { extensions: { code: 'BAD_USER_INPUT' } });
+        throw new GraphQLError('Username must be between 1 and 100 characters', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
       }
       if (!args.email || args.email.length > 255) {
-        throw new GraphQLError('Email must be between 1 and 255 characters', { extensions: { code: 'BAD_USER_INPUT' } });
+        throw new GraphQLError('Email must be between 1 and 255 characters', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
       }
       if (!args.password || args.password.length < 6 || args.password.length > 128) {
-        throw new GraphQLError('Password must be between 6 and 128 characters', { extensions: { code: 'BAD_USER_INPUT' } });
+        throw new GraphQLError('Password must be between 6 and 128 characters', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
       }
       const passwordHash = await hashPassword(args.password);
       const isActive = args.is_active !== false;

--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -1,7 +1,13 @@
 import fs from 'fs';
 import path from 'path';
 import pool from './db';
-import { hashPassword, comparePassword, generateToken, generateResetToken, hashResetToken } from './auth';
+import {
+  hashPassword,
+  comparePassword,
+  generateToken,
+  generateResetToken,
+  hashResetToken,
+} from './auth';
 import { sendPasswordResetEmail } from './email';
 import { User, CreateUserInput, UpdateUserInput } from './models/User';
 import { GraphQLError } from 'graphql';
@@ -18,12 +24,12 @@ async function logAudit(
   targetType: string | null,
   targetId: string | null,
   metadata: object | null,
-  ipAddress: string
+  ipAddress: string,
 ): Promise<void> {
   try {
     await pool.query(
       'INSERT INTO audit_logs (actor_id, action, target_type, target_id, metadata, ip_address) VALUES ($1, $2, $3, $4, $5, $6)',
-      [actorId, action, targetType, targetId, metadata, ipAddress]
+      [actorId, action, targetType, targetId, metadata, ipAddress],
     );
   } catch (err) {
     console.error('Failed to write audit log:', err);
@@ -34,12 +40,12 @@ async function logLoginHistory(
   userId: number | null,
   ipAddress: string,
   userAgent: string,
-  succeeded: boolean
+  succeeded: boolean,
 ): Promise<void> {
   try {
     await pool.query(
       'INSERT INTO login_history (user_id, ip_address, user_agent, succeeded) VALUES ($1, $2, $3, $4)',
-      [userId, ipAddress, userAgent, succeeded]
+      [userId, ipAddress, userAgent, succeeded],
     );
   } catch (err) {
     console.error('Failed to write login history:', err);
@@ -49,24 +55,32 @@ async function logLoginHistory(
 const isProduction = () => process.env.NODE_ENV === 'production';
 
 // ── Rate limiter ─────────────────────────────────────────────────────────────
-interface RateLimitEntry { count: number; resetAt: number }
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
 
 const ipRateLimiter = new Map<string, RateLimitEntry>();
 const emailRateLimiter = new Map<string, RateLimitEntry>();
 const loginRateLimiter = new Map<string, RateLimitEntry>();
 
-const IP_RATE_LIMIT_WINDOW = 15 * 60 * 1000;   // 15 minutes
-const IP_RATE_LIMIT_MAX = 5;                     // max 5 requests per window per IP
+const IP_RATE_LIMIT_WINDOW = 15 * 60 * 1000; // 15 minutes
+const IP_RATE_LIMIT_MAX = 5; // max 5 requests per window per IP
 const EMAIL_RATE_LIMIT_WINDOW = 60 * 60 * 1000; // 1 hour
-const EMAIL_RATE_LIMIT_MAX = 3;                  // max 3 emails per hour per address
+const EMAIL_RATE_LIMIT_MAX = 3; // max 3 emails per hour per address
 const GLOBAL_RATE_LIMIT_WINDOW = 60 * 60 * 1000; // 1 hour
-const GLOBAL_RATE_LIMIT_MAX = 50;                // max 50 reset emails per hour total
+const GLOBAL_RATE_LIMIT_MAX = 50; // max 50 reset emails per hour total
 let globalResetCount = { count: 0, resetAt: Date.now() + GLOBAL_RATE_LIMIT_WINDOW };
 
 const LOGIN_RATE_LIMIT_WINDOW = 15 * 60 * 1000; // 15 minutes
-const LOGIN_RATE_LIMIT_MAX = 10;                 // max 10 login attempts per IP per window
+const LOGIN_RATE_LIMIT_MAX = 10; // max 10 login attempts per IP per window
 
-function checkRateLimit(limiter: Map<string, RateLimitEntry>, key: string, max: number, window: number): boolean {
+function checkRateLimit(
+  limiter: Map<string, RateLimitEntry>,
+  key: string,
+  max: number,
+  window: number,
+): boolean {
   const now = Date.now();
   const entry = limiter.get(key);
   if (!entry || now > entry.resetAt) {
@@ -90,18 +104,21 @@ function checkGlobalResetLimit(): boolean {
 }
 
 // Evict stale entries periodically to prevent memory growth
-setInterval(() => {
-  const now = Date.now();
-  for (const [key, entry] of ipRateLimiter) {
-    if (now > entry.resetAt) ipRateLimiter.delete(key);
-  }
-  for (const [key, entry] of emailRateLimiter) {
-    if (now > entry.resetAt) emailRateLimiter.delete(key);
-  }
-  for (const [key, entry] of loginRateLimiter) {
-    if (now > entry.resetAt) loginRateLimiter.delete(key);
-  }
-}, 15 * 60 * 1000).unref();
+setInterval(
+  () => {
+    const now = Date.now();
+    for (const [key, entry] of ipRateLimiter) {
+      if (now > entry.resetAt) ipRateLimiter.delete(key);
+    }
+    for (const [key, entry] of emailRateLimiter) {
+      if (now > entry.resetAt) emailRateLimiter.delete(key);
+    }
+    for (const [key, entry] of loginRateLimiter) {
+      if (now > entry.resetAt) loginRateLimiter.delete(key);
+    }
+  },
+  15 * 60 * 1000,
+).unref();
 
 // ── TMDB enrichment cache ────────────────────────────────────────────────────
 
@@ -133,23 +150,23 @@ async function enrichWithTmdb(tmdbId: number): Promise<TmdbEnrichment> {
   try {
     const [movieRes, creditsRes, keywordsRes] = await Promise.all([
       fetch(`https://api.themoviedb.org/3/movie/${tmdbId}?api_key=${apiKey}&language=en-US`),
-      fetch(`https://api.themoviedb.org/3/movie/${tmdbId}/credits?api_key=${apiKey}&language=en-US`),
+      fetch(
+        `https://api.themoviedb.org/3/movie/${tmdbId}/credits?api_key=${apiKey}&language=en-US`,
+      ),
       fetch(`https://api.themoviedb.org/3/movie/${tmdbId}/keywords?api_key=${apiKey}`),
     ]);
 
-    const movie = movieRes.ok ? await movieRes.json() as any : null;
-    const credits = creditsRes.ok ? await creditsRes.json() as any : null;
-    const keywords = keywordsRes.ok ? await keywordsRes.json() as any : null;
+    const movie = movieRes.ok ? ((await movieRes.json()) as any) : null;
+    const credits = creditsRes.ok ? ((await creditsRes.json()) as any) : null;
+    const keywords = keywordsRes.ok ? ((await keywordsRes.json()) as any) : null;
 
     const genres: string[] = movie?.genres?.map((g: any) => g.name) ?? [];
     const keywordNames: string[] = keywords?.keywords?.map((k: any) => k.name) ?? [];
     // Fill tags: genres first, then keywords, up to 5
-    const tags = [...genres, ...keywordNames.filter(k => !genres.includes(k))].slice(0, 5);
+    const tags = [...genres, ...keywordNames.filter((k) => !genres.includes(k))].slice(0, 5);
 
     const data: TmdbEnrichment = {
-      poster_url: movie?.poster_path
-        ? `https://image.tmdb.org/t/p/w342${movie.poster_path}`
-        : null,
+      poster_url: movie?.poster_path ? `https://image.tmdb.org/t/p/w342${movie.poster_path}` : null,
       release_year: movie?.release_date ? movie.release_date.split('-')[0] : null,
       director: credits?.crew?.find((c: any) => c.job === 'Director')?.name ?? null,
       cast: (credits?.cast ?? []).slice(0, 3).map((c: any) => c.name),
@@ -168,18 +185,20 @@ export const resolvers = {
   Query: {
     appInfo: () => ({
       isProduction: isProduction(),
-      quickLoginUsers: isProduction() ? [] : [
-        {
-          label: 'Admin',
-          username: 'admin',
-          password: process.env.ADMIN_PASSWORD || 'admin123',
-        },
-        {
-          label: 'Test User',
-          username: process.env.TEST_USER_USERNAME || 'testuser',
-          password: process.env.TEST_USER_PASSWORD || 'testpass',
-        },
-      ],
+      quickLoginUsers: isProduction()
+        ? []
+        : [
+            {
+              label: 'Admin',
+              username: 'admin',
+              password: process.env.ADMIN_PASSWORD || 'admin123',
+            },
+            {
+              label: 'Test User',
+              username: process.env.TEST_USER_USERNAME || 'testuser',
+              password: process.env.TEST_USER_PASSWORD || 'testpass',
+            },
+          ],
     }),
     searchTmdb: async (_: any, { query }: { query: string }, context: any) => {
       if (!context.user) {
@@ -200,7 +219,7 @@ export const resolvers = {
           extensions: { code: 'INTERNAL_SERVER_ERROR' },
         });
       }
-      const data = await response.json() as any;
+      const data = (await response.json()) as any;
       return (data.results as any[]).slice(0, 10).map((movie: any) => ({
         tmdb_id: movie.id,
         title: movie.title,
@@ -220,7 +239,7 @@ export const resolvers = {
            LEFT JOIN user_movie_elo ume ON ume.movie_id = m.id AND ume.user_id = $1
            WHERE m.watched_at IS NULL
            ORDER BY ume.elo_rating DESC NULLS LAST, m.date_submitted ASC`,
-          [context.user.userId]
+          [context.user.userId],
         );
         return result.rows;
       }
@@ -232,7 +251,7 @@ export const resolvers = {
          FROM movies m
          LEFT JOIN users u ON m.requested_by = u.id
          WHERE m.watched_at IS NULL
-         ORDER BY m.elo_rank DESC NULLS LAST, m.date_submitted ASC`
+         ORDER BY m.elo_rank DESC NULLS LAST, m.date_submitted ASC`,
       );
       return result.rows;
     },
@@ -244,7 +263,7 @@ export const resolvers = {
          FROM movies m
          LEFT JOIN users u ON m.requested_by = u.id
          WHERE m.id = $1`,
-        [id]
+        [id],
       );
       return result.rows[0];
     },
@@ -254,10 +273,9 @@ export const resolvers = {
           extensions: { code: 'UNAUTHENTICATED' },
         });
       }
-      const result = await pool.query(
-        `SELECT ${USER_COLS} FROM users WHERE id = $1`,
-        [context.user.userId]
-      );
+      const result = await pool.query(`SELECT ${USER_COLS} FROM users WHERE id = $1`, [
+        context.user.userId,
+      ]);
       return result.rows[0];
     },
     users: async (_: any, __: any, context: any) => {
@@ -266,9 +284,7 @@ export const resolvers = {
           extensions: { code: 'FORBIDDEN' },
         });
       }
-      const result = await pool.query(
-        `SELECT ${USER_COLS} FROM users ORDER BY created_at DESC`
-      );
+      const result = await pool.query(`SELECT ${USER_COLS} FROM users ORDER BY created_at DESC`);
       return result.rows;
     },
     user: async (_: any, { id }: { id: string }, context: any) => {
@@ -277,16 +293,13 @@ export const resolvers = {
           extensions: { code: 'FORBIDDEN' },
         });
       }
-      const result = await pool.query(
-        `SELECT ${USER_COLS} FROM users WHERE id = $1`,
-        [id]
-      );
+      const result = await pool.query(`SELECT ${USER_COLS} FROM users WHERE id = $1`, [id]);
       return result.rows[0];
     },
     auditLogs: async (
       _: any,
       { limit = 100, offset = 0 }: { limit?: number; offset?: number },
-      context: any
+      context: any,
     ) => {
       if (!context.user?.isAdmin) {
         throw new GraphQLError('Not authorized', {
@@ -300,14 +313,14 @@ export const resolvers = {
          LEFT JOIN users u ON al.actor_id = u.id
          ORDER BY al.created_at DESC
          LIMIT $1 OFFSET $2`,
-        [Math.min(limit, 500), offset]
+        [Math.min(limit, 500), offset],
       );
       return result.rows;
     },
     loginHistory: async (
       _: any,
       { userId, limit = 100 }: { userId?: string; limit?: number },
-      context: any
+      context: any,
     ) => {
       if (!context.user?.isAdmin) {
         throw new GraphQLError('Not authorized', {
@@ -324,7 +337,7 @@ export const resolvers = {
            WHERE lh.user_id = $1
            ORDER BY lh.created_at DESC
            LIMIT $2`,
-          [userId, cap]
+          [userId, cap],
         );
         return result.rows;
       }
@@ -335,7 +348,7 @@ export const resolvers = {
          LEFT JOIN users u ON lh.user_id = u.id
          ORDER BY lh.created_at DESC
          LIMIT $1`,
-        [cap]
+        [cap],
       );
       return result.rows;
     },
@@ -347,7 +360,13 @@ export const resolvers = {
       }
       const result = await pool.query('SELECT * FROM kometa_schedule WHERE id = 1');
       if (result.rows.length === 0) {
-        return { enabled: false, frequency: 'daily', dailyTime: '03:00', collectionName: null, lastRunAt: null };
+        return {
+          enabled: false,
+          frequency: 'daily',
+          dailyTime: '03:00',
+          collectionName: null,
+          lastRunAt: null,
+        };
       }
       const row = result.rows[0];
       return {
@@ -355,7 +374,11 @@ export const resolvers = {
         frequency: row.frequency,
         dailyTime: row.daily_time,
         collectionName: row.collection_name ?? null,
-        lastRunAt: row.last_run_at ? (row.last_run_at instanceof Date ? row.last_run_at.toISOString() : new Date(row.last_run_at).toISOString()) : null,
+        lastRunAt: row.last_run_at
+          ? row.last_run_at instanceof Date
+            ? row.last_run_at.toISOString()
+            : new Date(row.last_run_at).toISOString()
+          : null,
       };
     },
     thisOrThat: async (_: any, { excludeIds }: { excludeIds?: string[] }, context: any) => {
@@ -366,7 +389,7 @@ export const resolvers = {
       }
 
       const userId = context.user.userId;
-      const excludeIntIds = (excludeIds ?? []).map(Number).filter(n => !isNaN(n));
+      const excludeIntIds = (excludeIds ?? []).map(Number).filter((n) => !isNaN(n));
 
       // Fetch candidates, excluding recently seen
       let candidatesResult = await pool.query(
@@ -377,7 +400,7 @@ export const resolvers = {
          LEFT JOIN user_movie_elo ume ON ume.movie_id = m.id AND ume.user_id = $1
          WHERE m.watched_at IS NULL
            AND m.id != ALL($2::int[])`,
-        [userId, excludeIntIds]
+        [userId, excludeIntIds],
       );
 
       // If exclusion leaves < 2 candidates, retry without exclusion
@@ -389,7 +412,7 @@ export const resolvers = {
            FROM movies m
            LEFT JOIN user_movie_elo ume ON ume.movie_id = m.id AND ume.user_id = $1
            WHERE m.watched_at IS NULL`,
-          [userId]
+          [userId],
         );
       }
 
@@ -411,8 +434,24 @@ export const resolvers = {
 
       // Enrich both movies with TMDB data
       const [enrichA, enrichB] = await Promise.all([
-        first.tmdb_id ? enrichWithTmdb(first.tmdb_id) : Promise.resolve({ poster_url: null, release_year: null, director: null, cast: [], tags: [] }),
-        second.tmdb_id ? enrichWithTmdb(second.tmdb_id) : Promise.resolve({ poster_url: null, release_year: null, director: null, cast: [], tags: [] }),
+        first.tmdb_id
+          ? enrichWithTmdb(first.tmdb_id)
+          : Promise.resolve({
+              poster_url: null,
+              release_year: null,
+              director: null,
+              cast: [],
+              tags: [],
+            }),
+        second.tmdb_id
+          ? enrichWithTmdb(second.tmdb_id)
+          : Promise.resolve({
+              poster_url: null,
+              release_year: null,
+              director: null,
+              cast: [],
+              tags: [],
+            }),
       ]);
 
       return {
@@ -447,7 +486,7 @@ export const resolvers = {
          LEFT JOIN users u ON m.requested_by = u.id
          WHERE ume.user_id = $1 AND m.watched_at IS NULL
          ORDER BY ume.elo_rating DESC`,
-        [context.user.userId]
+        [context.user.userId],
       );
 
       return result.rows.map((r: any) => ({
@@ -468,7 +507,7 @@ export const resolvers = {
          WHERE is_active = true AND id <> $1
            AND (username ILIKE $2 OR display_name ILIKE $2)
          ORDER BY username ASC LIMIT 10`,
-        [context.user.userId, `%${escapedQuery}%`]
+        [context.user.userId, `%${escapedQuery}%`],
       );
       return result.rows;
     },
@@ -485,7 +524,7 @@ export const resolvers = {
          JOIN users other ON other.id = CASE WHEN uc.requester_id = $1 THEN uc.addressee_id ELSE uc.requester_id END
          WHERE uc.status = 'accepted' AND (uc.requester_id = $1 OR uc.addressee_id = $1)
          ORDER BY uc.updated_at DESC`,
-        [context.user.userId]
+        [context.user.userId],
       );
       return result.rows.map((r: any) => ({
         id: r.id,
@@ -508,7 +547,7 @@ export const resolvers = {
          JOIN users other ON other.id = CASE WHEN uc.requester_id = $1 THEN uc.addressee_id ELSE uc.requester_id END
          WHERE uc.status = 'pending' AND (uc.requester_id = $1 OR uc.addressee_id = $1)
          ORDER BY uc.created_at DESC`,
-        [context.user.userId]
+        [context.user.userId],
       );
       return result.rows.map((r: any) => ({
         id: r.id,
@@ -532,10 +571,12 @@ export const resolvers = {
          JOIN users other ON other.id = CASE WHEN uc.requester_id = $1 THEN uc.addressee_id ELSE uc.requester_id END
          WHERE uc.id = $2 AND uc.status = 'accepted'
            AND (uc.requester_id = $1 OR uc.addressee_id = $1)`,
-        [userId, connectionId]
+        [userId, connectionId],
       );
       if (conn.rows.length === 0) {
-        throw new GraphQLError('Connection not found or not accepted', { extensions: { code: 'NOT_FOUND' } });
+        throw new GraphQLError('Connection not found or not accepted', {
+          extensions: { code: 'NOT_FOUND' },
+        });
       }
 
       const otherUserId = conn.rows[0].other_user_id;
@@ -560,7 +601,7 @@ export const resolvers = {
          WHERE m.watched_at IS NULL
            AND (ume_a.elo_rating IS NOT NULL OR ume_b.elo_rating IS NOT NULL)
          ORDER BY both_rated DESC, combined_elo DESC`,
-        [userId, otherUserId]
+        [userId, otherUserId],
       );
 
       const connection = {
@@ -584,7 +625,11 @@ export const resolvers = {
     },
   },
   Mutation: {
-    addMovie: async (_: any, { title, tmdb_id }: { title: string; tmdb_id?: number }, context: any) => {
+    addMovie: async (
+      _: any,
+      { title, tmdb_id }: { title: string; tmdb_id?: number },
+      context: any,
+    ) => {
       if (!context.user) {
         throw new GraphQLError('Not authenticated', {
           extensions: { code: 'UNAUTHENTICATED' },
@@ -598,12 +643,11 @@ export const resolvers = {
       }
       const insertResult = await pool.query(
         'INSERT INTO movies (title, requested_by, rank, tmdb_id) VALUES ($1, $2, 0, $3) RETURNING *',
-        [trimmedTitle, context.user.userId, tmdb_id ?? null]
+        [trimmedTitle, context.user.userId, tmdb_id ?? null],
       );
-      const userRow = await pool.query(
-        'SELECT username, display_name FROM users WHERE id = $1',
-        [context.user.userId]
-      );
+      const userRow = await pool.query('SELECT username, display_name FROM users WHERE id = $1', [
+        context.user.userId,
+      ]);
       const requesterName =
         userRow.rows[0]?.display_name || userRow.rows[0]?.username || context.user.username;
       await logAudit(
@@ -612,7 +656,7 @@ export const resolvers = {
         'movie',
         String(insertResult.rows[0].id),
         { title, requester: requesterName },
-        context.ipAddress
+        context.ipAddress,
       );
       return {
         ...insertResult.rows[0],
@@ -620,7 +664,11 @@ export const resolvers = {
         user_display_name: userRow.rows[0]?.display_name,
       };
     },
-    matchMovie: async (_: any, { id, tmdb_id, title }: { id: string; tmdb_id: number; title: string }, context: any) => {
+    matchMovie: async (
+      _: any,
+      { id, tmdb_id, title }: { id: string; tmdb_id: number; title: string },
+      context: any,
+    ) => {
       if (!context.user) {
         throw new GraphQLError('Not authenticated', {
           extensions: { code: 'UNAUTHENTICATED' },
@@ -631,7 +679,7 @@ export const resolvers = {
          FROM movies m
          LEFT JOIN users u ON m.requested_by = u.id
          WHERE m.id = $1`,
-        [id]
+        [id],
       );
       const movie = movieResult.rows[0];
       if (!movie) {
@@ -647,7 +695,7 @@ export const resolvers = {
       const result = await pool.query(
         `UPDATE movies SET tmdb_id = $1, title = $2 WHERE id = $3
          RETURNING *`,
-        [tmdb_id, title, id]
+        [tmdb_id, title, id],
       );
       await logAudit(
         context.user.userId,
@@ -655,7 +703,7 @@ export const resolvers = {
         'movie',
         String(id),
         { original_title: movie.title, matched_title: title, tmdb_id },
-        context.ipAddress ?? 'unknown'
+        context.ipAddress ?? 'unknown',
       );
       return {
         ...result.rows[0],
@@ -683,7 +731,7 @@ export const resolvers = {
       const result = await pool.query(
         `UPDATE movies SET watched_at = NOW() WHERE id = $1
          RETURNING *`,
-        [id]
+        [id],
       );
       if (result.rows.length === 0) {
         throw new GraphQLError('Movie not found', {
@@ -691,17 +739,16 @@ export const resolvers = {
         });
       }
       const movie = result.rows[0];
-      const userRow = await pool.query(
-        'SELECT username, display_name FROM users WHERE id = $1',
-        [movie.requested_by]
-      );
+      const userRow = await pool.query('SELECT username, display_name FROM users WHERE id = $1', [
+        movie.requested_by,
+      ]);
       await logAudit(
         context.user.userId,
         'MOVIE_WATCHED',
         'movie',
         String(id),
         { title: movie.title },
-        context.ipAddress ?? 'unknown'
+        context.ipAddress ?? 'unknown',
       );
       return {
         ...movie,
@@ -725,7 +772,7 @@ export const resolvers = {
           'movie',
           id,
           movie ? { title: movie.title } : null,
-          context.ipAddress ?? 'unknown'
+          context.ipAddress ?? 'unknown',
         );
       }
       return (result.rowCount ?? 0) > 0;
@@ -733,7 +780,7 @@ export const resolvers = {
     recordComparison: async (
       _: any,
       { winnerId, loserId }: { winnerId: string; loserId: string },
-      context: any
+      context: any,
     ) => {
       if (!context.user) {
         throw new GraphQLError('Not authenticated', {
@@ -743,7 +790,9 @@ export const resolvers = {
 
       const userId = context.user.userId;
       const { winnerElo, loserElo } = await applyComparison(
-        userId, Number(winnerId), Number(loserId)
+        userId,
+        Number(winnerId),
+        Number(loserId),
       );
 
       await logAudit(
@@ -752,16 +801,12 @@ export const resolvers = {
         'movie',
         String(winnerId),
         { winnerId, loserId, winnerElo, loserElo },
-        context.ipAddress ?? 'unknown'
+        context.ipAddress ?? 'unknown',
       );
 
       return { winnerId, loserId, winnerElo, loserElo };
     },
-    resetMovieComparisons: async (
-      _: any,
-      { movieId }: { movieId: string },
-      context: any
-    ) => {
+    resetMovieComparisons: async (_: any, { movieId }: { movieId: string }, context: any) => {
       if (!context.user) {
         throw new GraphQLError('Not authenticated', {
           extensions: { code: 'UNAUTHENTICATED' },
@@ -782,14 +827,14 @@ export const resolvers = {
       // Delete comparisons involving this movie for this user
       await pool.query(
         'DELETE FROM movie_comparisons WHERE user_id = $1 AND (winner_id = $2 OR loser_id = $2)',
-        [userId, mid]
+        [userId, mid],
       );
 
       // Delete the user's Elo entry for this movie
-      await pool.query(
-        'DELETE FROM user_movie_elo WHERE user_id = $1 AND movie_id = $2',
-        [userId, mid]
-      );
+      await pool.query('DELETE FROM user_movie_elo WHERE user_id = $1 AND movie_id = $2', [
+        userId,
+        mid,
+      ]);
 
       // Recompute global elo_rank (becomes NULL if no other users have data)
       await updateGlobalEloRank(mid);
@@ -800,16 +845,12 @@ export const resolvers = {
         'movie',
         String(movieId),
         { title: movieResult.rows[0].title },
-        context.ipAddress ?? 'unknown'
+        context.ipAddress ?? 'unknown',
       );
 
       return true;
     },
-    exportKometa: async (
-      _: any,
-      { collectionName }: { collectionName?: string },
-      context: any
-    ) => {
+    exportKometa: async (_: any, { collectionName }: { collectionName?: string }, context: any) => {
       if (!context.user?.isAdmin) {
         throw new GraphQLError('Not authorized', {
           extensions: { code: 'FORBIDDEN' },
@@ -830,7 +871,7 @@ export const resolvers = {
       }
 
       const moviesResult = await pool.query(
-        'SELECT title, tmdb_id, elo_rank FROM movies WHERE watched_at IS NULL ORDER BY elo_rank DESC NULLS LAST, date_submitted ASC'
+        'SELECT title, tmdb_id, elo_rank FROM movies WHERE watched_at IS NULL ORDER BY elo_rank DESC NULLS LAST, date_submitted ASC',
       );
       const movies = moviesResult.rows;
       const matched = movies.filter((m: any) => m.tmdb_id != null);
@@ -887,20 +928,25 @@ export const resolvers = {
         'kometa',
         filePath,
         { count: matched.length, skipped: movies.length - matched.length, triggered, triggerError },
-        context.ipAddress ?? 'unknown'
+        context.ipAddress ?? 'unknown',
       );
 
       return { filePath, triggered, triggerError: triggerError ?? null };
     },
     updateKometaSchedule: async (
       _: any,
-      { enabled, frequency, dailyTime, collectionName }: {
+      {
+        enabled,
+        frequency,
+        dailyTime,
+        collectionName,
+      }: {
         enabled?: boolean;
         frequency?: string;
         dailyTime?: string;
         collectionName?: string;
       },
-      context: any
+      context: any,
     ) => {
       if (!context.user?.isAdmin) {
         throw new GraphQLError('Not authorized', {
@@ -930,17 +976,26 @@ export const resolvers = {
       const values: any[] = [];
       let i = 1;
 
-      if (enabled !== undefined) { sets.push(`enabled = $${i++}`); values.push(enabled); }
-      if (frequency !== undefined) { sets.push(`frequency = $${i++}`); values.push(frequency); }
-      if (dailyTime !== undefined) { sets.push(`daily_time = $${i++}`); values.push(dailyTime); }
-      if (collectionName !== undefined) { sets.push(`collection_name = $${i++}`); values.push(collectionName || null); }
+      if (enabled !== undefined) {
+        sets.push(`enabled = $${i++}`);
+        values.push(enabled);
+      }
+      if (frequency !== undefined) {
+        sets.push(`frequency = $${i++}`);
+        values.push(frequency);
+      }
+      if (dailyTime !== undefined) {
+        sets.push(`daily_time = $${i++}`);
+        values.push(dailyTime);
+      }
+      if (collectionName !== undefined) {
+        sets.push(`collection_name = $${i++}`);
+        values.push(collectionName || null);
+      }
       sets.push(`updated_at = NOW()`);
       values.push(1);
 
-      await pool.query(
-        `UPDATE kometa_schedule SET ${sets.join(', ')} WHERE id = $${i}`,
-        values
-      );
+      await pool.query(`UPDATE kometa_schedule SET ${sets.join(', ')} WHERE id = $${i}`, values);
 
       const result = await pool.query('SELECT * FROM kometa_schedule WHERE id = 1');
       const row = result.rows[0];
@@ -952,7 +1007,11 @@ export const resolvers = {
         frequency: row.frequency,
         dailyTime: row.daily_time,
         collectionName: row.collection_name ?? null,
-        lastRunAt: row.last_run_at ? (row.last_run_at instanceof Date ? row.last_run_at.toISOString() : new Date(row.last_run_at).toISOString()) : null,
+        lastRunAt: row.last_run_at
+          ? row.last_run_at instanceof Date
+            ? row.last_run_at.toISOString()
+            : new Date(row.last_run_at).toISOString()
+          : null,
       };
     },
     importFromLetterboxd: async (_: any, { url }: { url: string }, context: any) => {
@@ -1009,7 +1068,7 @@ export const resolvers = {
             headers: {
               'User-Agent':
                 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
-              'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+              Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
               'Accept-Language': 'en-US,en;q=0.5',
             },
           });
@@ -1046,7 +1105,7 @@ export const resolvers = {
           });
           const res = await fetch(`https://api.themoviedb.org/3/search/movie?${params}`);
           if (!res.ok) return null;
-          const data = await res.json() as any;
+          const data = (await res.json()) as any;
           return data.results?.[0]?.id ?? null;
         } catch {
           return null;
@@ -1070,7 +1129,7 @@ export const resolvers = {
         try {
           await pool.query(
             'INSERT INTO movies (title, requested_by, rank, tmdb_id) VALUES ($1, $2, 0, $3)',
-            [title, context.user.userId, tmdbId]
+            [title, context.user.userId, tmdbId],
           );
           existingTitles.add(title.toLowerCase());
           imported++;
@@ -1085,28 +1144,34 @@ export const resolvers = {
         'movie',
         null,
         { url, imported, skipped, tmdb_matched, errors: errors.length },
-        context.ipAddress ?? 'unknown'
+        context.ipAddress ?? 'unknown',
       );
 
       return { imported, skipped, tmdb_matched, errors };
     },
-    requestPasswordReset: async (
-      _: any,
-      { email }: { email: string },
-      context: any
-    ) => {
-      const genericMessage = 'If an account exists with that email, a password reset link has been sent.';
+    requestPasswordReset: async (_: any, { email }: { email: string }, context: any) => {
+      const genericMessage =
+        'If an account exists with that email, a password reset link has been sent.';
 
       try {
         const normalizedEmail = email.trim().toLowerCase();
 
         // Check per-IP rate limit
-        if (!checkRateLimit(ipRateLimiter, context.ipAddress, IP_RATE_LIMIT_MAX, IP_RATE_LIMIT_WINDOW)) {
+        if (
+          !checkRateLimit(ipRateLimiter, context.ipAddress, IP_RATE_LIMIT_MAX, IP_RATE_LIMIT_WINDOW)
+        ) {
           return { success: true, message: genericMessage };
         }
 
         // Check per-email rate limit (prevents targeting one user from many IPs)
-        if (!checkRateLimit(emailRateLimiter, normalizedEmail, EMAIL_RATE_LIMIT_MAX, EMAIL_RATE_LIMIT_WINDOW)) {
+        if (
+          !checkRateLimit(
+            emailRateLimiter,
+            normalizedEmail,
+            EMAIL_RATE_LIMIT_MAX,
+            EMAIL_RATE_LIMIT_WINDOW,
+          )
+        ) {
           return { success: true, message: genericMessage };
         }
 
@@ -1117,12 +1182,19 @@ export const resolvers = {
 
         const result = await pool.query(
           'SELECT id, email, is_active FROM users WHERE LOWER(email) = LOWER($1)',
-          [normalizedEmail]
+          [normalizedEmail],
         );
         const user = result.rows[0];
 
         if (!user || !user.is_active) {
-          await logAudit(null, 'PASSWORD_RESET_REQUEST', 'user', null, { email: normalizedEmail }, context.ipAddress);
+          await logAudit(
+            null,
+            'PASSWORD_RESET_REQUEST',
+            'user',
+            null,
+            { email: normalizedEmail },
+            context.ipAddress,
+          );
           return { success: true, message: genericMessage };
         }
 
@@ -1135,7 +1207,7 @@ export const resolvers = {
 
         await pool.query(
           'INSERT INTO password_reset_tokens (user_id, token_hash, expires_at) VALUES ($1, $2, $3)',
-          [user.id, tokenHash, expiresAt]
+          [user.id, tokenHash, expiresAt],
         );
 
         try {
@@ -1144,7 +1216,14 @@ export const resolvers = {
           console.error('Failed to send password reset email:', emailErr);
         }
 
-        await logAudit(null, 'PASSWORD_RESET_REQUEST', 'user', String(user.id), null, context.ipAddress);
+        await logAudit(
+          null,
+          'PASSWORD_RESET_REQUEST',
+          'user',
+          String(user.id),
+          null,
+          context.ipAddress,
+        );
       } catch (err) {
         console.error('Password reset request error:', err);
       }
@@ -1154,7 +1233,7 @@ export const resolvers = {
     resetPassword: async (
       _: any,
       { token, newPassword }: { token: string; newPassword: string },
-      context: any
+      context: any,
     ) => {
       if (!newPassword || newPassword.length < 6) {
         throw new GraphQLError('Password must be at least 6 characters', {
@@ -1171,13 +1250,20 @@ export const resolvers = {
          WHERE prt.token_hash = $1
            AND prt.expires_at > NOW()
            AND prt.used_at IS NULL`,
-        [tokenHash]
+        [tokenHash],
       );
 
       const resetRecord = result.rows[0];
 
       if (!resetRecord) {
-        await logAudit(null, 'PASSWORD_RESET_FAILURE', null, null, { reason: 'invalid_or_expired_token' }, context.ipAddress);
+        await logAudit(
+          null,
+          'PASSWORD_RESET_FAILURE',
+          null,
+          null,
+          { reason: 'invalid_or_expired_token' },
+          context.ipAddress,
+        );
         throw new GraphQLError('Invalid or expired reset token', {
           extensions: { code: 'BAD_USER_INPUT' },
         });
@@ -1190,14 +1276,19 @@ export const resolvers = {
       }
 
       const passwordHash = await hashPassword(newPassword);
-      await pool.query(
-        'UPDATE users SET password_hash = $1, updated_at = NOW() WHERE id = $2',
-        [passwordHash, resetRecord.user_id]
-      );
+      await pool.query('UPDATE users SET password_hash = $1, updated_at = NOW() WHERE id = $2', [
+        passwordHash,
+        resetRecord.user_id,
+      ]);
 
       // Mark token as used and delete others
-      await pool.query('UPDATE password_reset_tokens SET used_at = NOW() WHERE id = $1', [resetRecord.id]);
-      await pool.query('DELETE FROM password_reset_tokens WHERE user_id = $1 AND id != $2', [resetRecord.user_id, resetRecord.id]);
+      await pool.query('UPDATE password_reset_tokens SET used_at = NOW() WHERE id = $1', [
+        resetRecord.id,
+      ]);
+      await pool.query('DELETE FROM password_reset_tokens WHERE user_id = $1 AND id != $2', [
+        resetRecord.user_id,
+        resetRecord.id,
+      ]);
 
       await logAudit(
         resetRecord.user_id,
@@ -1205,15 +1296,18 @@ export const resolvers = {
         'user',
         String(resetRecord.user_id),
         null,
-        context.ipAddress
+        context.ipAddress,
       );
 
-      return { success: true, message: 'Password has been reset successfully. You can now log in.' };
+      return {
+        success: true,
+        message: 'Password has been reset successfully. You can now log in.',
+      };
     },
     login: async (
       _: any,
       { username, password }: { username: string; password: string },
-      context: any
+      context: any,
     ) => {
       if (!checkRateLimit(loginRateLimiter, context.ipAddress, LOGIN_RATE_LIMIT_MAX, LOGIN_RATE_LIMIT_WINDOW)) {
         await logLoginHistory(null, context.ipAddress, context.userAgent, false);
@@ -1294,7 +1388,7 @@ export const resolvers = {
           args.display_name || null,
           args.is_admin || false,
           isActive,
-        ]
+        ],
       );
       await logAudit(
         context.user.userId,
@@ -1302,7 +1396,7 @@ export const resolvers = {
         'user',
         String(result.rows[0].id),
         { username: args.username, email: args.email, is_admin: args.is_admin || false },
-        context.ipAddress
+        context.ipAddress,
       );
       return result.rows[0];
     },
@@ -1355,7 +1449,7 @@ export const resolvers = {
 
       const result = await pool.query(
         `UPDATE users SET ${updates.join(', ')} WHERE id = $${paramCount} RETURNING ${USER_COLS}`,
-        values
+        values,
       );
       await logAudit(
         context.user.userId,
@@ -1363,7 +1457,7 @@ export const resolvers = {
         'user',
         String(args.id),
         changes,
-        context.ipAddress
+        context.ipAddress,
       );
       return result.rows[0];
     },
@@ -1379,10 +1473,9 @@ export const resolvers = {
         });
       }
 
-      const targetResult = await pool.query(
-        'SELECT username, email FROM users WHERE id = $1',
-        [id]
-      );
+      const targetResult = await pool.query('SELECT username, email FROM users WHERE id = $1', [
+        id,
+      ]);
       const targetUser = targetResult.rows[0];
 
       const result = await pool.query('DELETE FROM users WHERE id = $1', [id]);
@@ -1393,7 +1486,7 @@ export const resolvers = {
           'user',
           id,
           { username: targetUser.username, email: targetUser.email },
-          context.ipAddress
+          context.ipAddress,
         );
       }
       return (result.rowCount ?? 0) > 0;
@@ -1452,7 +1545,7 @@ export const resolvers = {
       for (const movie of SEED_MOVIES) {
         await pool.query(
           'INSERT INTO movies (title, requested_by, rank, tmdb_id) VALUES ($1, $2, 0, $3)',
-          [movie.title, context.user.userId, movie.tmdb_id]
+          [movie.title, context.user.userId, movie.tmdb_id],
         );
       }
 
@@ -1462,13 +1555,17 @@ export const resolvers = {
         'movie',
         null,
         { count: SEED_MOVIES.length },
-        context.ipAddress ?? 'unknown'
+        context.ipAddress ?? 'unknown',
       );
 
       return SEED_MOVIES.length;
     },
 
-    sendConnectionRequest: async (_: any, { addresseeId }: { addresseeId: string }, context: any) => {
+    sendConnectionRequest: async (
+      _: any,
+      { addresseeId }: { addresseeId: string },
+      context: any,
+    ) => {
       if (!context.user) {
         throw new GraphQLError('Not authenticated', { extensions: { code: 'UNAUTHENTICATED' } });
       }
@@ -1476,10 +1573,15 @@ export const resolvers = {
       const addrId = parseInt(addresseeId);
 
       if (requesterId === addrId) {
-        throw new GraphQLError('Cannot connect with yourself', { extensions: { code: 'BAD_USER_INPUT' } });
+        throw new GraphQLError('Cannot connect with yourself', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
       }
 
-      const targetUser = await pool.query('SELECT id FROM users WHERE id = $1 AND is_active = true', [addrId]);
+      const targetUser = await pool.query(
+        'SELECT id FROM users WHERE id = $1 AND is_active = true',
+        [addrId],
+      );
       if (targetUser.rows.length === 0) {
         throw new GraphQLError('User not found', { extensions: { code: 'NOT_FOUND' } });
       }
@@ -1487,7 +1589,7 @@ export const resolvers = {
       // Check if reverse pending request exists — auto-accept
       const reverseRow = await pool.query(
         `SELECT id, status FROM user_connections WHERE requester_id = $1 AND addressee_id = $2`,
-        [addrId, requesterId]
+        [addrId, requesterId],
       );
       if (reverseRow.rows.length > 0) {
         const rev = reverseRow.rows[0];
@@ -1497,10 +1599,20 @@ export const resolvers = {
         if (rev.status === 'pending') {
           await pool.query(
             `UPDATE user_connections SET status = 'accepted', updated_at = NOW() WHERE id = $1`,
-            [rev.id]
+            [rev.id],
           );
-          await logAudit(requesterId, 'CONNECTION_AUTO_ACCEPT', 'user_connection', String(rev.id), { addresseeId: addrId }, context.ipAddress ?? 'unknown');
-          const other = await pool.query('SELECT id, username, display_name FROM users WHERE id = $1', [addrId]);
+          await logAudit(
+            requesterId,
+            'CONNECTION_AUTO_ACCEPT',
+            'user_connection',
+            String(rev.id),
+            { addresseeId: addrId },
+            context.ipAddress ?? 'unknown',
+          );
+          const other = await pool.query(
+            'SELECT id, username, display_name FROM users WHERE id = $1',
+            [addrId],
+          );
           return {
             id: rev.id,
             user: other.rows[0],
@@ -1514,12 +1626,14 @@ export const resolvers = {
       // Check if forward request already exists
       const existingRow = await pool.query(
         `SELECT id, status FROM user_connections WHERE requester_id = $1 AND addressee_id = $2`,
-        [requesterId, addrId]
+        [requesterId, addrId],
       );
       if (existingRow.rows.length > 0) {
         const ex = existingRow.rows[0];
         if (ex.status === 'pending') {
-          throw new GraphQLError('Request already pending', { extensions: { code: 'BAD_USER_INPUT' } });
+          throw new GraphQLError('Request already pending', {
+            extensions: { code: 'BAD_USER_INPUT' },
+          });
         }
         if (ex.status === 'accepted') {
           throw new GraphQLError('Already connected', { extensions: { code: 'BAD_USER_INPUT' } });
@@ -1527,10 +1641,20 @@ export const resolvers = {
         // Previously rejected — re-send
         await pool.query(
           `UPDATE user_connections SET status = 'pending', updated_at = NOW() WHERE id = $1`,
-          [ex.id]
+          [ex.id],
         );
-        await logAudit(requesterId, 'CONNECTION_REQUEST', 'user_connection', String(ex.id), { addresseeId: addrId }, context.ipAddress ?? 'unknown');
-        const other = await pool.query('SELECT id, username, display_name FROM users WHERE id = $1', [addrId]);
+        await logAudit(
+          requesterId,
+          'CONNECTION_REQUEST',
+          'user_connection',
+          String(ex.id),
+          { addresseeId: addrId },
+          context.ipAddress ?? 'unknown',
+        );
+        const other = await pool.query(
+          'SELECT id, username, display_name FROM users WHERE id = $1',
+          [addrId],
+        );
         return {
           id: ex.id,
           user: other.rows[0],
@@ -1544,46 +1668,76 @@ export const resolvers = {
       const result = await pool.query(
         `INSERT INTO user_connections (requester_id, addressee_id, status)
          VALUES ($1, $2, 'pending') RETURNING id, created_at`,
-        [requesterId, addrId]
+        [requesterId, addrId],
       );
-      await logAudit(requesterId, 'CONNECTION_REQUEST', 'user_connection', String(result.rows[0].id), { addresseeId: addrId }, context.ipAddress ?? 'unknown');
-      const other = await pool.query('SELECT id, username, display_name FROM users WHERE id = $1', [addrId]);
+      await logAudit(
+        requesterId,
+        'CONNECTION_REQUEST',
+        'user_connection',
+        String(result.rows[0].id),
+        { addresseeId: addrId },
+        context.ipAddress ?? 'unknown',
+      );
+      const other = await pool.query('SELECT id, username, display_name FROM users WHERE id = $1', [
+        addrId,
+      ]);
       return {
         id: result.rows[0].id,
         user: other.rows[0],
         status: 'pending',
         direction: 'sent',
-        created_at: result.rows[0].created_at instanceof Date ? result.rows[0].created_at.toISOString() : result.rows[0].created_at,
+        created_at:
+          result.rows[0].created_at instanceof Date
+            ? result.rows[0].created_at.toISOString()
+            : result.rows[0].created_at,
       };
     },
 
-    respondToConnectionRequest: async (_: any, { connectionId, accept }: { connectionId: string; accept: boolean }, context: any) => {
+    respondToConnectionRequest: async (
+      _: any,
+      { connectionId, accept }: { connectionId: string; accept: boolean },
+      context: any,
+    ) => {
       if (!context.user) {
         throw new GraphQLError('Not authenticated', { extensions: { code: 'UNAUTHENTICATED' } });
       }
       const conn = await pool.query(
         `SELECT * FROM user_connections WHERE id = $1 AND addressee_id = $2 AND status = 'pending'`,
-        [connectionId, context.user.userId]
+        [connectionId, context.user.userId],
       );
       if (conn.rows.length === 0) {
-        throw new GraphQLError('Connection request not found', { extensions: { code: 'NOT_FOUND' } });
+        throw new GraphQLError('Connection request not found', {
+          extensions: { code: 'NOT_FOUND' },
+        });
       }
 
       const newStatus = accept ? 'accepted' : 'rejected';
       await pool.query(
         `UPDATE user_connections SET status = $1, updated_at = NOW() WHERE id = $2`,
-        [newStatus, connectionId]
+        [newStatus, connectionId],
       );
       const action = accept ? 'CONNECTION_ACCEPT' : 'CONNECTION_REJECT';
-      await logAudit(context.user.userId, action, 'user_connection', connectionId, { requesterId: conn.rows[0].requester_id }, context.ipAddress ?? 'unknown');
+      await logAudit(
+        context.user.userId,
+        action,
+        'user_connection',
+        connectionId,
+        { requesterId: conn.rows[0].requester_id },
+        context.ipAddress ?? 'unknown',
+      );
 
-      const other = await pool.query('SELECT id, username, display_name FROM users WHERE id = $1', [conn.rows[0].requester_id]);
+      const other = await pool.query('SELECT id, username, display_name FROM users WHERE id = $1', [
+        conn.rows[0].requester_id,
+      ]);
       return {
         id: connectionId,
         user: other.rows[0],
         status: newStatus,
         direction: 'received',
-        created_at: conn.rows[0].created_at instanceof Date ? conn.rows[0].created_at.toISOString() : conn.rows[0].created_at,
+        created_at:
+          conn.rows[0].created_at instanceof Date
+            ? conn.rows[0].created_at.toISOString()
+            : conn.rows[0].created_at,
       };
     },
 
@@ -1593,12 +1747,19 @@ export const resolvers = {
       }
       const result = await pool.query(
         `DELETE FROM user_connections WHERE id = $1 AND (requester_id = $2 OR addressee_id = $2) RETURNING id`,
-        [connectionId, context.user.userId]
+        [connectionId, context.user.userId],
       );
       if (result.rows.length === 0) {
         throw new GraphQLError('Connection not found', { extensions: { code: 'NOT_FOUND' } });
       }
-      await logAudit(context.user.userId, 'CONNECTION_REMOVE', 'user_connection', connectionId, null, context.ipAddress ?? 'unknown');
+      await logAudit(
+        context.user.userId,
+        'CONNECTION_REMOVE',
+        'user_connection',
+        connectionId,
+        null,
+        context.ipAddress ?? 'unknown',
+      );
       return true;
     },
   },
@@ -1619,9 +1780,7 @@ export const resolvers = {
     watched_at: (parent: any) => {
       if (!parent.watched_at) return null;
       const date =
-        parent.watched_at instanceof Date
-          ? parent.watched_at
-          : new Date(parent.watched_at);
+        parent.watched_at instanceof Date ? parent.watched_at : new Date(parent.watched_at);
       return date.toISOString();
     },
     elo_rank: (parent: any) => {
@@ -1631,16 +1790,12 @@ export const resolvers = {
   User: {
     created_at: (parent: any) => {
       const date =
-        parent.created_at instanceof Date
-          ? parent.created_at
-          : new Date(Number(parent.created_at));
+        parent.created_at instanceof Date ? parent.created_at : new Date(Number(parent.created_at));
       return date.toISOString();
     },
     updated_at: (parent: any) => {
       const date =
-        parent.updated_at instanceof Date
-          ? parent.updated_at
-          : new Date(Number(parent.updated_at));
+        parent.updated_at instanceof Date ? parent.updated_at : new Date(Number(parent.updated_at));
       return date.toISOString();
     },
     last_login_at: (parent: any) => {
@@ -1655,9 +1810,7 @@ export const resolvers = {
   AuditLog: {
     created_at: (parent: any) => {
       const date =
-        parent.created_at instanceof Date
-          ? parent.created_at
-          : new Date(Number(parent.created_at));
+        parent.created_at instanceof Date ? parent.created_at : new Date(Number(parent.created_at));
       return date.toISOString();
     },
     metadata: (parent: any) => {
@@ -1670,9 +1823,7 @@ export const resolvers = {
   LoginHistory: {
     created_at: (parent: any) => {
       const date =
-        parent.created_at instanceof Date
-          ? parent.created_at
-          : new Date(Number(parent.created_at));
+        parent.created_at instanceof Date ? parent.created_at : new Date(Number(parent.created_at));
       return date.toISOString();
     },
   },

--- a/backend/src/scheduler.ts
+++ b/backend/src/scheduler.ts
@@ -19,7 +19,7 @@ async function runKometaExportScheduled(): Promise<void> {
     const settings = settingsResult.rows[0];
 
     const moviesResult = await pool.query(
-      'SELECT title, tmdb_id, elo_rank FROM movies WHERE watched_at IS NULL ORDER BY elo_rank DESC NULLS LAST, date_submitted ASC'
+      'SELECT title, tmdb_id, elo_rank FROM movies WHERE watched_at IS NULL ORDER BY elo_rank DESC NULLS LAST, date_submitted ASC',
     );
     const movies = moviesResult.rows;
     const matched = movies.filter((m: any) => m.tmdb_id != null);
@@ -57,9 +57,13 @@ async function runKometaExportScheduled(): Promise<void> {
           'KOMETA_SCHEDULE_EXPORT',
           'kometa',
           filePath,
-          JSON.stringify({ count: matched.length, skipped: movies.length - matched.length, scheduled: true }),
+          JSON.stringify({
+            count: matched.length,
+            skipped: movies.length - matched.length,
+            scheduled: true,
+          }),
           'scheduler',
-        ]
+        ],
       );
 
       console.log(`[Kometa Scheduler] Exported ${matched.length} movies to ${filePath}`);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}']
       interval: 10s
       timeout: 5s
       retries: 5
@@ -45,7 +45,7 @@ services:
       SMTP_FROM: ${SMTP_FROM:-noreply@movienight.local}
       APP_URL: ${APP_URL:-http://localhost:3000}
     ports:
-      - "${BACKEND_EXTERNAL_PORT}:${BACKEND_PORT}"
+      - '${BACKEND_EXTERNAL_PORT}:${BACKEND_PORT}'
     depends_on:
       db:
         condition: service_healthy
@@ -63,7 +63,7 @@ services:
     environment:
       REACT_APP_GRAPHQL_URL: ${REACT_APP_GRAPHQL_URL:-}
     ports:
-      - "${FRONTEND_EXTERNAL_PORT}:3000"
+      - '${FRONTEND_EXTERNAL_PORT}:3000'
     depends_on:
       - backend
     volumes:
@@ -84,7 +84,7 @@ services:
     container_name: movienight
     restart: unless-stopped
     ports:
-      - "8080:80"
+      - '8080:80'
     environment:
       - TZ=America/New_York
       - NODE_ENV=production
@@ -93,10 +93,10 @@ services:
     networks:
       - frontend
     labels:
-      - "com.movienight.app=true"
-      - "com.movienight.version=1.0"
+      - 'com.movienight.app=true'
+      - 'com.movienight.version=1.0'
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost/"]
+      test: ['CMD', 'wget', '--quiet', '--tries=1', '--spider', 'http://localhost/']
       interval: 30s
       timeout: 10s
       retries: 3

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,10 @@
         "@babel/plugin-proposal-private-property-in-object": "7.21.11",
         "@babel/preset-env": "7.22.5",
         "@types/md5": "^2.3.5",
-        "gh-pages": "^6.1.1"
+        "gh-pages": "^6.1.1",
+        "husky": "^9.1.7",
+        "lint-staged": "^16.4.0",
+        "prettier": "^3.8.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -6327,6 +6330,85 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -7695,6 +7777,19 @@
       "license": "BSD-2-Clause",
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/error-ex": {
@@ -9367,6 +9462,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -10061,6 +10169,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -12347,6 +12471,179 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/lint-staged": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.3",
+        "listr2": "^9.0.5",
+        "picomatch": "^4.0.3",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.0.4",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/lint-staged/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/lint-staged/node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/loader-runner": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
@@ -12424,6 +12721,160 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -12630,6 +13081,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -14789,6 +15253,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -15578,6 +16058,52 @@
         "node": ">=10"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -15596,6 +16122,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -16223,6 +16756,52 @@
         "node": ">=8"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/sockjs": {
       "version": "0.3.24",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -16413,6 +16992,16 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string-length": {
@@ -17286,6 +17875,16 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,18 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx}": [
+      "prettier --write"
+    ],
+    "*.{json,md,yml,yaml,css}": [
+      "prettier --write"
+    ]
   },
   "eslintConfig": {
     "extends": [
@@ -67,6 +78,9 @@
     "@babel/plugin-proposal-private-property-in-object": "7.21.11",
     "@babel/preset-env": "7.22.5",
     "@types/md5": "^2.3.5",
-    "gh-pages": "^6.1.1"
+    "gh-pages": "^6.1.1",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.4.0",
+    "prettier": "^3.8.3"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1,15 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" type="image/svg+xml" href="%PUBLIC_URL%/favicon.svg">
-    <link rel="alternate icon" href="%PUBLIC_URL%/favicon.ico">
+    <link rel="icon" type="image/svg+xml" href="%PUBLIC_URL%/favicon.svg" />
+    <link rel="alternate icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#0d0f1a" />
-    <meta
-      name="description"
-      content="Movie Night List"
-    />
+    <meta name="description" content="Movie Night List" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/specs/this-or-that.spec.md
+++ b/specs/this-or-that.spec.md
@@ -11,6 +11,7 @@ A dedicated screen presenting two randomly selected unwatched movies side-by-sid
 Drag-to-rank (Borda count) and pairwise Elo both answer "which movie should we watch?" through different UX patterns. Keeping both creates two competing signals with no defined winner and doubles the ranking infrastructure. The choice between them reduces to one question: _do you want a ranking you deliberately set in one session, or one that emerges from casual use over time?_
 
 Pairwise comparison wins here because:
+
 - Adding a new movie to a drag list requires consciously re-evaluating its position against every other film — a mental effort most users skip, leaving new movies perpetually unranked
 - Pairwise picks happen naturally and remain accurate as the list grows
 - A single source of truth makes the homepage unambiguous
@@ -19,27 +20,27 @@ The only capability lost is explicit top-of-list placement. This is acceptable g
 
 ### What is removed
 
-| Removed | Location | Reason |
-|---|---|---|
-| `user_movie_rankings` table | Migration | Replaced by `user_movie_elo` |
-| `reorderMyMovie` mutation | `schema.ts`, `resolvers.ts` | Drag-to-rank is gone |
-| `combinedRankings` query | `schema.ts`, `resolvers.ts` | Borda-specific; not used in frontend; unauthenticated list now uses `movies.elo_rank` |
-| `recalculateBordaRanks()` | `scheduler.ts` | Borda removed |
-| `scheduleBordaRecalculation()` | `scheduler.ts` | Borda removed |
-| Borda periodic interval (5 min) | `scheduler.ts` `initScheduler()` | Borda removed |
-| `REORDER_MY_MOVIE` gql doc | `queries.ts` | Mutation removed |
-| `@dnd-kit` drag-and-drop | `Homepage.tsx` | No more drag-to-rank |
-| Drag handle column + `#` rank column | `Homepage.tsx` | No rank indicators on homepage |
-| `movies.rank` references in Kometa export | `resolvers.ts`, `scheduler.ts` | Must use `elo_rank` instead |
+| Removed                                   | Location                         | Reason                                                                                |
+| ----------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------- |
+| `user_movie_rankings` table               | Migration                        | Replaced by `user_movie_elo`                                                          |
+| `reorderMyMovie` mutation                 | `schema.ts`, `resolvers.ts`      | Drag-to-rank is gone                                                                  |
+| `combinedRankings` query                  | `schema.ts`, `resolvers.ts`      | Borda-specific; not used in frontend; unauthenticated list now uses `movies.elo_rank` |
+| `recalculateBordaRanks()`                 | `scheduler.ts`                   | Borda removed                                                                         |
+| `scheduleBordaRecalculation()`            | `scheduler.ts`                   | Borda removed                                                                         |
+| Borda periodic interval (5 min)           | `scheduler.ts` `initScheduler()` | Borda removed                                                                         |
+| `REORDER_MY_MOVIE` gql doc                | `queries.ts`                     | Mutation removed                                                                      |
+| `@dnd-kit` drag-and-drop                  | `Homepage.tsx`                   | No more drag-to-rank                                                                  |
+| Drag handle column + `#` rank column      | `Homepage.tsx`                   | No rank indicators on homepage                                                        |
+| `movies.rank` references in Kometa export | `resolvers.ts`, `scheduler.ts`   | Must use `elo_rank` instead                                                           |
 
 `movies.rank` column itself is left in place (stale, unused) to allow safe rollback.
 
 ### Ranking signals after this change
 
-| Signal | Table | Global cache | Homepage sort |
-|---|---|---|---|
-| Pairwise Elo | `user_movie_elo` | `movies.elo_rank` | Auth: personal `elo_rating`; Unauth: `elo_rank` |
-| ~~Drag-to-rank~~ | ~~`user_movie_rankings`~~ | ~~`movies.rank` (Borda)~~ | ~~removed~~ |
+| Signal           | Table                     | Global cache              | Homepage sort                                   |
+| ---------------- | ------------------------- | ------------------------- | ----------------------------------------------- |
+| Pairwise Elo     | `user_movie_elo`          | `movies.elo_rank`         | Auth: personal `elo_rating`; Unauth: `elo_rank` |
+| ~~Drag-to-rank~~ | ~~`user_movie_rankings`~~ | ~~`movies.rank` (Borda)~~ | ~~removed~~                                     |
 
 ---
 
@@ -58,10 +59,12 @@ Loser update:    R_B' = R_B + 32 × (0 − (1 − E_A))
 **Global Elo (`movies.elo_rank`)** = arithmetic average of all users' current Elo ratings for that movie. Recomputed after every comparison and every reset. Null when no comparisons have been recorded.
 
 **Homepage sort:**
+
 - Authenticated users: ordered by their own `user_movie_elo.elo_rating DESC NULLS LAST, date_submitted ASC`
 - Unauthenticated users: ordered by `movies.elo_rank DESC NULLS LAST, date_submitted ASC`
 
 **`Movie.elo_rank` field semantics:**
+
 - For authenticated queries: returns the user's personal Elo for that movie (from `user_movie_elo.elo_rating`), falling back to the global `movies.elo_rank` if the user has no personal data
 - For unauthenticated queries: returns the global `movies.elo_rank`
 - Null when no comparisons have been recorded for the movie
@@ -75,6 +78,7 @@ Random pair selection is naïve and has two failure modes for this use case: new
 ### Three-tier selection
 
 **Constants:**
+
 - `K = 5` — comparison threshold between "new" and "established" for the current user
 - `EP_POOL = max(5, floor(totalMovies × 0.1))` — candidate pool size for Elo-proximity matching
 
@@ -91,6 +95,7 @@ A new movie (count = 0) has weight 1.0; a movie with 10 comparisons has weight 0
 #### Tier 2 — Select the second movie: seeded mode (first movie has count < K)
 
 New movies must be anchored against movies with established ratings, not against other new movies (pairing two 1000-rated movies produces no useful signal). Pick the second movie from the established pool (count ≥ K) using a two-band approach:
+
 - One candidate from within 150 Elo of the established median (a "peer" comparison)
 - One candidate sampled uniformly from the full established range (a "ranging" comparison)
 - Choose randomly between the two
@@ -108,14 +113,14 @@ second_movie = random pick from candidates
 
 ### Why this works for the specific constraints
 
-| Problem | Mechanism that solves it |
-|---|---|
-| New movie added: doesn't appear for many sessions | IFW weight = 1.0 on first pick; highest possible priority |
-| New movie added: compared against other new movies | Seeded mode forces anchor against established pool |
-| Multiple new movies added at once | All share IFW priority equally; seeding ensures each anchors correctly |
-| Same pair appears repeatedly | EP_POOL randomisation breaks nearest-neighbour lock |
-| Established movies drift apart in comparison count | IFW decay brings lagging movies back up naturally |
-| Pool has < 2 movies | Caught by minimum pool guard (FR-TOT-010) before algorithm runs |
+| Problem                                            | Mechanism that solves it                                               |
+| -------------------------------------------------- | ---------------------------------------------------------------------- |
+| New movie added: doesn't appear for many sessions  | IFW weight = 1.0 on first pick; highest possible priority              |
+| New movie added: compared against other new movies | Seeded mode forces anchor against established pool                     |
+| Multiple new movies added at once                  | All share IFW priority equally; seeding ensures each anchors correctly |
+| Same pair appears repeatedly                       | EP_POOL randomisation breaks nearest-neighbour lock                    |
+| Established movies drift apart in comparison count | IFW decay brings lagging movies back up naturally                      |
+| Pool has < 2 movies                                | Caught by minimum pool guard (FR-TOT-010) before algorithm runs        |
 
 ### Algorithm summary (pseudocode)
 
@@ -152,13 +157,17 @@ function selectPair(userId, excludeIds):
 ## Functional Requirements
 
 ### FR-TOT-001: Navigation
+
 While logged in, when the user clicks "This or That" in the nav, the system shall display the comparison screen.
 
 ### FR-TOT-002: Pair selection
+
 When a pair is needed, the system shall select two distinct unwatched movies using the three-tier algorithm described above, excluding IDs in `excludeIds` where possible. If fewer than 2 unwatched movies remain after exclusion, the exclusion filter shall be ignored. If fewer than 2 unwatched movies exist at all, the system shall return a `BAD_USER_INPUT` error.
 
 ### FR-TOT-003: Movie card content
+
 For each movie in a pair, the system shall display:
+
 - Poster image (TMDB `w342` URL if `tmdb_id` is set, else a placeholder)
 - Title
 - Release year (from TMDB)
@@ -168,47 +177,62 @@ For each movie in a pair, the system shall display:
 - Movies without a `tmdb_id`: title only with a "No TMDB match" note; no layout break
 
 ### FR-TOT-004: TMDB fetch and cache
+
 When enriching a movie card, the system shall call three TMDB endpoints in parallel (`/movie/{id}`, `/movie/{id}/credits`, `/movie/{id}/keywords`) and cache the result in an in-memory Map keyed by `tmdb_id` with a 24-hour TTL. On cache hit the TMDB API shall not be called.
 
 ### FR-TOT-005: Record comparison
+
 When the user picks a movie, the system shall:
+
 1. Insert a row into `movie_comparisons` (winner_id, loser_id, user_id)
 2. Upsert Elo ratings in `user_movie_elo` for both movies using the Elo formula
 3. Update `movies.elo_rank` for both movies to `AVG(elo_rating)` across all users
 4. Return the new Elo values in `ComparisonResult`
 
 ### FR-TOT-006: Exclude recent pair
+
 The system shall accept `excludeIds: [ID!]` and apply the exclusion before pair selection. The client sends both IDs from the previous pair to avoid an immediate repeat.
 
 ### FR-TOT-007: Session counter
+
 While the comparison screen is active, the system shall display a running count of comparisons completed in the current session.
 
 ### FR-TOT-008: Personal Elo rankings
+
 When the user views the "My Rankings" tab, the system shall return all unwatched movies where the user has at least one comparison, sorted by their personal Elo rating descending, including the Elo score and comparison count.
 
 ### FR-TOT-009: Reset a movie
+
 When the user resets a movie, the system shall:
+
 1. Delete all `movie_comparisons` rows for that user involving that movie (as winner or loser)
 2. Delete the `user_movie_elo` row for that user + movie
 3. Recompute `movies.elo_rank` for the affected movie (becomes NULL if no other users have data)
 
 ### FR-TOT-010: Minimum pool guard
+
 When fewer than 2 unwatched movies exist, the system shall return a `BAD_USER_INPUT` error and the frontend shall display "Add more movies to start comparing."
 
 ### FR-TOT-011: Homepage sort order
+
 The `movies` query resolver shall sort by Elo instead of Borda:
+
 - Authenticated: `LEFT JOIN user_movie_elo ume ON ume.movie_id = m.id AND ume.user_id = $1`, `ORDER BY ume.elo_rating DESC NULLS LAST, m.date_submitted ASC`
 - Unauthenticated: `ORDER BY m.elo_rank DESC NULLS LAST, m.date_submitted ASC`
 
 The `Movie.elo_rank` field shall be populated from the joined elo data:
+
 - Auth: `SELECT COALESCE(ume.elo_rating, m.elo_rank) AS elo_rank`
 - Unauth: `SELECT m.elo_rank`
 
 ### FR-TOT-012: Auth guard
+
 All `thisOrThat`, `myRankings`, `recordComparison`, and `resetMovieComparisons` operations shall require authentication and return `UNAUTHENTICATED` otherwise.
 
 ### FR-TOT-013: Remove old ranking system
+
 The following shall be removed:
+
 - `reorderMyMovie` mutation (schema + resolver)
 - `combinedRankings` query (schema + resolver) — not used in frontend; unauthenticated list uses `movies.elo_rank` directly
 - Borda recalculation code (`recalculateBordaRanks`, `scheduleBordaRecalculation`, `bordaDebounceTimer`, periodic interval) from `scheduler.ts`
@@ -218,17 +242,22 @@ The following shall be removed:
 - Drag handle column and `#` rank column from the movie table UI
 
 ### FR-TOT-014: Homepage no-Elo-data experience
+
 When an authenticated user has zero personal Elo data (no rows in `user_movie_elo` for that user), the homepage shall:
+
 1. Show movies sorted by global `elo_rank DESC NULLS LAST, date_submitted ASC` (same as unauthenticated)
 2. Display a banner above the movie list: "Rate some movies to get your personal ranking" with a link to the This or That screen
 
 ### FR-TOT-015: Kometa export ordering
+
 Both the `exportKometa` mutation and the Kometa scheduled export in `scheduler.ts` shall sort movies by `elo_rank DESC NULLS LAST, date_submitted ASC` instead of `rank DESC`. The `SELECT` shall include `elo_rank` instead of `rank`.
 
 ### FR-TOT-016: Rename `Movie.rank` to `Movie.elo_rank`
+
 The `Movie` GraphQL type shall replace `rank: Float!` with `elo_rank: Float` (nullable). All frontend queries (`GET_MOVIES`, `GET_MOVIE`, `ADD_MOVIE`, `MATCH_MOVIE`) shall reference `elo_rank` instead of `rank`. The frontend `Movie` TypeScript type shall change from `rank: number` to `elo_rank: number | null`.
 
 ### FR-TOT-017: Comparison loading transition
+
 When the user taps a card and a new pair is being fetched, the current cards shall fade out immediately and a skeleton/spinner shall be shown until the new pair arrives.
 
 ---
@@ -247,6 +276,7 @@ When the user taps a card and a new pair is being fetched, the current cards sha
 ## Acceptance Criteria
 
 ### AC-001: Happy-path comparison
+
 ```
 Given a logged-in user on the comparison screen with ≥ 2 unwatched movies
 When they tap a movie card
@@ -257,6 +287,7 @@ And the session counter increments by 1
 ```
 
 ### AC-002: New movie gets fast placement
+
 ```
 Given a movie was just added (0 comparisons for the current user)
 When the user starts a This or That session
@@ -266,6 +297,7 @@ And its opponent has at least K=5 comparisons (is established),
 ```
 
 ### AC-003: Immediate-repeat pair avoided
+
 ```
 Given the user just compared Movie A vs Movie B
 When the next pair is requested with excludeIds = [A, B]
@@ -274,6 +306,7 @@ Then the returned pair contains neither Movie A nor Movie B
 ```
 
 ### AC-004: Homepage sorted by Elo
+
 ```
 Given several movies have Elo data and others do not
 When an authenticated user with personal Elo data views the homepage
@@ -283,6 +316,7 @@ And no rank numbers or drag handles are shown
 ```
 
 ### AC-005: Homepage for user with no Elo data
+
 ```
 Given a user has never used This or That
 When they view the homepage
@@ -292,6 +326,7 @@ And a banner "Rate some movies to get your personal ranking" is shown
 ```
 
 ### AC-006: Reset
+
 ```
 Given a user has made 8 comparisons involving Movie X
 When they click Reset on Movie X and confirm
@@ -302,6 +337,7 @@ And Movie X disappears from their My Rankings tab
 ```
 
 ### AC-007: Minimum pool guard
+
 ```
 Given only 1 unwatched movie exists
 When the user navigates to the comparison screen
@@ -310,6 +346,7 @@ And no movie cards are rendered
 ```
 
 ### AC-008: Drag-to-rank fully removed
+
 ```
 Given a user is on the homepage
 Then no drag handles are visible
@@ -318,6 +355,7 @@ And the movie list is sorted by Elo (or date if no Elo data)
 ```
 
 ### AC-009: Movie.elo_rank field returns personal Elo for auth users
+
 ```
 Given User A has Elo 1200 for Movie X and User B has Elo 900 for Movie X
 When User A queries GET_MOVIES
@@ -329,6 +367,7 @@ Then Movie X has elo_rank = 1050 (global average)
 ```
 
 ### AC-010: Kometa export uses Elo ordering
+
 ```
 Given movies have elo_rank values
 When a Kometa export runs (manual or scheduled)
@@ -339,13 +378,13 @@ Then movies are ordered by elo_rank DESC, not by stale movies.rank
 
 ## Error Handling
 
-| Condition | Server response | User message |
-|---|---|---|
-| TMDB_API_KEY missing | Return movie without TMDB fields | "Movie details unavailable" |
-| TMDB API error / timeout | Log server-side; null fields | "Movie details unavailable" |
-| < 2 unwatched movies | `BAD_USER_INPUT` | "Add more movies to start comparing" |
-| Unauthenticated | `UNAUTHENTICATED` | Redirect to login |
-| Movie not found on reset | `NOT_FOUND` | "Movie not found" |
+| Condition                | Server response                  | User message                         |
+| ------------------------ | -------------------------------- | ------------------------------------ |
+| TMDB_API_KEY missing     | Return movie without TMDB fields | "Movie details unavailable"          |
+| TMDB API error / timeout | Log server-side; null fields     | "Movie details unavailable"          |
+| < 2 unwatched movies     | `BAD_USER_INPUT`                 | "Add more movies to start comparing" |
+| Unauthenticated          | `UNAUTHENTICATED`                | Redirect to login                    |
+| Movie not found on reset | `NOT_FOUND`                      | "Movie not found"                    |
 
 ---
 
@@ -364,10 +403,10 @@ exports.up = (pgm) => {
 
   // Append-only log of every pairwise pick
   pgm.createTable('movie_comparisons', {
-    id:         { type: 'serial', primaryKey: true },
-    user_id:    { type: 'integer', notNull: true, references: '"users"',  onDelete: 'CASCADE' },
-    winner_id:  { type: 'integer', notNull: true, references: '"movies"', onDelete: 'CASCADE' },
-    loser_id:   { type: 'integer', notNull: true, references: '"movies"', onDelete: 'CASCADE' },
+    id: { type: 'serial', primaryKey: true },
+    user_id: { type: 'integer', notNull: true, references: '"users"', onDelete: 'CASCADE' },
+    winner_id: { type: 'integer', notNull: true, references: '"movies"', onDelete: 'CASCADE' },
+    loser_id: { type: 'integer', notNull: true, references: '"movies"', onDelete: 'CASCADE' },
     created_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
   });
   pgm.createIndex('movie_comparisons', 'user_id');
@@ -376,11 +415,11 @@ exports.up = (pgm) => {
 
   // Per-user, per-movie Elo rating
   pgm.createTable('user_movie_elo', {
-    user_id:          { type: 'integer', notNull: true, references: '"users"',  onDelete: 'CASCADE' },
-    movie_id:         { type: 'integer', notNull: true, references: '"movies"', onDelete: 'CASCADE' },
-    elo_rating:       { type: 'numeric(10,4)', notNull: true, default: 1000 },
+    user_id: { type: 'integer', notNull: true, references: '"users"', onDelete: 'CASCADE' },
+    movie_id: { type: 'integer', notNull: true, references: '"movies"', onDelete: 'CASCADE' },
+    elo_rating: { type: 'numeric(10,4)', notNull: true, default: 1000 },
     comparison_count: { type: 'integer', notNull: true, default: 0 },
-    updated_at:       { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
   });
   pgm.addConstraint('user_movie_elo', 'user_movie_elo_pkey', 'PRIMARY KEY (user_id, movie_id)');
 
@@ -396,26 +435,30 @@ exports.down = (pgm) => {
   pgm.dropTable('movie_comparisons');
   pgm.dropColumn('movies', 'elo_rank');
   pgm.createTable('user_movie_rankings', {
-    user_id:    { type: 'integer', notNull: true, references: '"users"',  onDelete: 'CASCADE' },
-    movie_id:   { type: 'integer', notNull: true, references: '"movies"', onDelete: 'CASCADE' },
-    rank:       { type: 'numeric(20,10)', notNull: false },
+    user_id: { type: 'integer', notNull: true, references: '"users"', onDelete: 'CASCADE' },
+    movie_id: { type: 'integer', notNull: true, references: '"movies"', onDelete: 'CASCADE' },
+    rank: { type: 'numeric(20,10)', notNull: false },
     created_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
     updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
   });
-  pgm.addConstraint('user_movie_rankings', 'user_movie_rankings_pkey', 'PRIMARY KEY (user_id, movie_id)');
+  pgm.addConstraint(
+    'user_movie_rankings',
+    'user_movie_rankings_pkey',
+    'PRIMARY KEY (user_id, movie_id)',
+  );
   pgm.createIndex('user_movie_rankings', ['user_id', 'rank']);
 };
 ```
 
 ### DB state after migration
 
-| Table | Status | Purpose |
-|---|---|---|
-| `movie_comparisons` | **New** | Append-only log of This-or-That picks |
-| `user_movie_elo` | **New** | Per-user Elo rating per movie |
-| `user_movie_rankings` | **Dropped** | Was drag-to-rank fractional index |
-| `movies.elo_rank` | **New column** | Global Elo average cache |
-| `movies.rank` | Stale, unused | Was Borda count — left for safe rollback |
+| Table                 | Status         | Purpose                                  |
+| --------------------- | -------------- | ---------------------------------------- |
+| `movie_comparisons`   | **New**        | Append-only log of This-or-That picks    |
+| `user_movie_elo`      | **New**        | Per-user Elo rating per movie            |
+| `user_movie_rankings` | **Dropped**    | Was drag-to-rank fractional index        |
+| `movies.elo_rank`     | **New column** | Global Elo average cache                 |
+| `movies.rank`         | Stale, unused  | Was Borda count — left for safe rollback |
 
 ---
 
@@ -431,7 +474,7 @@ type Movie {
   requester: String!
   requested_by: ID
   date_submitted: String!
-  rank: Float!              # ← removed
+  rank: Float! # ← removed
   tmdb_id: Int
   watched_at: String
 }
@@ -443,7 +486,7 @@ type Movie {
   requester: String!
   requested_by: ID
   date_submitted: String!
-  elo_rank: Float            # ← renamed, now nullable
+  elo_rank: Float # ← renamed, now nullable
   tmdb_id: Int
   watched_at: String
 }
@@ -531,13 +574,15 @@ export async function getOrCreateElo(userId: number, movieId: number): Promise<n
      VALUES ($1, $2)
      ON CONFLICT (user_id, movie_id) DO UPDATE SET user_id = EXCLUDED.user_id
      RETURNING elo_rating`,
-    [userId, movieId]
+    [userId, movieId],
   );
   return Number(res.rows[0].elo_rating);
 }
 
 export async function applyComparison(
-  userId: number, winnerId: number, loserId: number
+  userId: number,
+  winnerId: number,
+  loserId: number,
 ): Promise<{ winnerElo: number; loserElo: number }> {
   const [rW, rL] = await Promise.all([
     getOrCreateElo(userId, winnerId),
@@ -549,17 +594,17 @@ export async function applyComparison(
     `UPDATE user_movie_elo
      SET elo_rating = $1, comparison_count = comparison_count + 1, updated_at = NOW()
      WHERE user_id = $2 AND movie_id = $3`,
-    [newA, userId, winnerId]
+    [newA, userId, winnerId],
   );
   await pool.query(
     `UPDATE user_movie_elo
      SET elo_rating = $1, comparison_count = comparison_count + 1, updated_at = NOW()
      WHERE user_id = $2 AND movie_id = $3`,
-    [newB, userId, loserId]
+    [newB, userId, loserId],
   );
   await pool.query(
     'INSERT INTO movie_comparisons (user_id, winner_id, loser_id) VALUES ($1, $2, $3)',
-    [userId, winnerId, loserId]
+    [userId, winnerId, loserId],
   );
 
   // AVG returns NULL when no rows match — correctly nullifies elo_rank after reset
@@ -568,7 +613,7 @@ export async function applyComparison(
       `UPDATE movies SET elo_rank = (
          SELECT AVG(elo_rating) FROM user_movie_elo WHERE movie_id = $1
        ) WHERE id = $1`,
-      [mid]
+      [mid],
     );
   }
 
@@ -581,16 +626,16 @@ export async function applyComparison(
 Implements the three-tier algorithm. Receives the candidate movie list (already filtered by `watched_at IS NULL` and `excludeIds`) with per-user comparison counts and Elo ratings.
 
 ```typescript
-const K = 5;                       // established threshold
-const EP_POOL_MIN = 5;             // minimum EP candidate pool size
-const SEED_ELO_BAND = 150;         // ±Elo around median for seeded "peer" pick
+const K = 5; // established threshold
+const EP_POOL_MIN = 5; // minimum EP candidate pool size
+const SEED_ELO_BAND = 150; // ±Elo around median for seeded "peer" pick
 
 interface MovieCandidate {
   id: number;
   title: string;
   tmdb_id: number | null;
-  userComparisonCount: number;      // from user_movie_elo for current user, default 0
-  elo_rating: number;               // from user_movie_elo for current user, default 1000
+  userComparisonCount: number; // from user_movie_elo for current user, default 0
+  elo_rating: number; // from user_movie_elo for current user, default 1000
 }
 
 export function selectPair(movies: MovieCandidate[]): [MovieCandidate, MovieCandidate] {
@@ -599,32 +644,31 @@ export function selectPair(movies: MovieCandidate[]): [MovieCandidate, MovieCand
   const epPoolSize = Math.max(EP_POOL_MIN, Math.floor(movies.length * 0.1));
 
   // Tier 1: IFW first pick
-  const weights = movies.map(m => 1 / (m.userComparisonCount + 1));
+  const weights = movies.map((m) => 1 / (m.userComparisonCount + 1));
   const first = weightedRandomPick(movies, weights);
 
-  const rest = movies.filter(m => m.id !== first.id);
-  const established = rest.filter(m => m.userComparisonCount >= K);
+  const rest = movies.filter((m) => m.id !== first.id);
+  const established = rest.filter((m) => m.userComparisonCount >= K);
 
   let second: MovieCandidate;
 
   if (first.userComparisonCount < K && established.length >= K) {
     // Tier 2: seeded pick
     const median = medianElo(established);
-    const peers = established.filter(m => Math.abs(m.elo_rating - median) <= SEED_ELO_BAND);
+    const peers = established.filter((m) => Math.abs(m.elo_rating - median) <= SEED_ELO_BAND);
     const peerPool = peers.length > 0 ? peers : established;
     const rangerPool = established;
-    second = Math.random() < 0.5
-      ? randomPick(peerPool)
-      : randomPick(rangerPool);
+    second = Math.random() < 0.5 ? randomPick(peerPool) : randomPick(rangerPool);
   } else if (first.userComparisonCount >= K && established.length > 0) {
     // Tier 3: Elo-proximity pick
     const sorted = [...established].sort(
-      (a, b) => Math.abs(a.elo_rating - first.elo_rating) - Math.abs(b.elo_rating - first.elo_rating)
+      (a, b) =>
+        Math.abs(a.elo_rating - first.elo_rating) - Math.abs(b.elo_rating - first.elo_rating),
     );
     second = randomPick(sorted.slice(0, epPoolSize));
   } else {
     // Fallback: IFW from remaining
-    const restWeights = rest.map(m => 1 / (m.userComparisonCount + 1));
+    const restWeights = rest.map((m) => 1 / (m.userComparisonCount + 1));
     second = weightedRandomPick(rest, restWeights);
   }
 
@@ -646,7 +690,7 @@ function randomPick<T>(items: T[]): T {
 }
 
 function medianElo(movies: MovieCandidate[]): number {
-  const sorted = [...movies].map(m => m.elo_rating).sort((a, b) => a - b);
+  const sorted = [...movies].map((m) => m.elo_rating).sort((a, b) => a - b);
   const mid = Math.floor(sorted.length / 2);
   return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
 }
@@ -670,6 +714,7 @@ Fetch all candidates (not just 2) so `selectPair` can apply weights. Typically 2
 ### Updated `movies` resolver — full SQL change
 
 **Authenticated (userId available):**
+
 ```sql
 SELECT m.id, m.title, m.requested_by, m.date_submitted, m.rank, m.tmdb_id, m.watched_at,
        COALESCE(ume.elo_rating, m.elo_rank) AS elo_rank,
@@ -684,6 +729,7 @@ ORDER BY ume.elo_rating DESC NULLS LAST, m.date_submitted ASC
 Note: `elo_rank` alias uses `COALESCE(ume.elo_rating, m.elo_rank)` so the field resolver returns personal Elo when available, global when not.
 
 **Unauthenticated:**
+
 ```sql
 SELECT m.id, m.title, m.requested_by, m.date_submitted, m.rank, m.tmdb_id, m.watched_at,
        m.elo_rank,
@@ -697,6 +743,7 @@ ORDER BY m.elo_rank DESC NULLS LAST, m.date_submitted ASC
 ### `scheduler.ts` — changes
 
 **Remove (Borda):**
+
 - `recalculateBordaRanks()` function
 - `scheduleBordaRecalculation()` export
 - `bordaDebounceTimer` variable
@@ -705,10 +752,13 @@ ORDER BY m.elo_rank DESC NULLS LAST, m.date_submitted ASC
 
 **Update (Kometa):**
 Change the Kometa export query in `runKometaExportScheduled()` from:
+
 ```sql
 SELECT title, tmdb_id, rank FROM movies WHERE watched_at IS NULL ORDER BY rank DESC NULLS LAST, date_submitted ASC
 ```
+
 To:
+
 ```sql
 SELECT title, tmdb_id, elo_rank FROM movies WHERE watched_at IS NULL ORDER BY elo_rank DESC NULLS LAST, date_submitted ASC
 ```
@@ -728,24 +778,26 @@ In-memory `Map<number, { data, expiresAt }>` with 24-hour TTL. Three parallel TM
 ## Frontend Changes
 
 ### Removed
+
 - `@dnd-kit` imports, `DndContext`, `SortableContext`, `useSortable`, `SortableRow` component, drag handle icon, `handleDragEnd`, `localMovies` state, `sensors` from `Homepage.tsx`
 - `REORDER_MY_MOVIE` from `queries.ts`
 - Drag handle column and `#` rank number column from the movie table
 - `rank` field references in all gql documents and `Movie` TypeScript type
 
 ### New files
+
 - `src/components/home/MovieCompareCard.tsx` — poster, title, year, director, cast, tag chips; full-card click
 - `src/components/home/ThisOrThat.tsx` — Compare tab + My Rankings tab
 
 ### Changed files
 
-| File | Change |
-|---|---|
-| `src/graphql/queries.ts` | Remove `REORDER_MY_MOVIE`; rename `rank` → `elo_rank` in `GET_MOVIES`, `GET_MOVIE`, `ADD_MOVIE`, `MATCH_MOVIE`; add `THIS_OR_THAT`, `MY_RANKINGS`, `RECORD_COMPARISON`, `RESET_MOVIE_COMPARISONS` |
-| `src/models/Movies.ts` | `rank: number` → `elo_rank: number \| null` |
-| `src/App.tsx` | `showUserManagement: boolean` → `currentView: 'movies' \| 'this-or-that' \| 'admin'`; render `<ThisOrThat />` for new view |
-| `src/components/common/Navbar.tsx` | Replace `showUserManagement: boolean` prop with `currentView`; add "This or That" nav button for all authenticated users |
-| `src/components/home/Homepage.tsx` | Remove all `@dnd-kit` code; remove drag column + rank column; render static sorted list; add Elo nudge banner for users with no Elo data |
+| File                               | Change                                                                                                                                                                                            |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/graphql/queries.ts`           | Remove `REORDER_MY_MOVIE`; rename `rank` → `elo_rank` in `GET_MOVIES`, `GET_MOVIE`, `ADD_MOVIE`, `MATCH_MOVIE`; add `THIS_OR_THAT`, `MY_RANKINGS`, `RECORD_COMPARISON`, `RESET_MOVIE_COMPARISONS` |
+| `src/models/Movies.ts`             | `rank: number` → `elo_rank: number \| null`                                                                                                                                                       |
+| `src/App.tsx`                      | `showUserManagement: boolean` → `currentView: 'movies' \| 'this-or-that' \| 'admin'`; render `<ThisOrThat />` for new view                                                                        |
+| `src/components/common/Navbar.tsx` | Replace `showUserManagement: boolean` prop with `currentView`; add "This or That" nav button for all authenticated users                                                                          |
+| `src/components/home/Homepage.tsx` | Remove all `@dnd-kit` code; remove drag column + rank column; render static sorted list; add Elo nudge banner for users with no Elo data                                                          |
 
 ### `ThisOrThat.tsx` key behaviour
 
@@ -762,6 +814,7 @@ In-memory `Map<number, { data, expiresAt }>` with 24-hour TTL. Three parallel TM
 ## Implementation TODO
 
 ### Backend — remove old ranking system
+
 - [ ] Remove `recalculateBordaRanks`, `scheduleBordaRecalculation`, `bordaDebounceTimer` from `scheduler.ts`
 - [ ] Remove the `await recalculateBordaRanks()` call and `setInterval` from `initScheduler()` in `scheduler.ts`
 - [ ] Remove `reorderMyMovie` resolver from `resolvers.ts`
@@ -774,6 +827,7 @@ In-memory `Map<number, { data, expiresAt }>` with 24-hour TTL. Three parallel TM
 - [ ] Update `runKometaExportScheduled` in `scheduler.ts`: change `rank` → `elo_rank` in SELECT and ORDER BY
 
 ### Backend — add Elo system
+
 - [ ] Create migration `1745600000000_add-elo-ranking-drop-borda.js`
 - [ ] Create `backend/src/elo.ts` (`calculateElo`, `getOrCreateElo`, `applyComparison`)
 - [ ] Create `backend/src/pairSelection.ts` (three-tier algorithm, `selectPair`)
@@ -787,6 +841,7 @@ In-memory `Map<number, { data, expiresAt }>` with 24-hour TTL. Three parallel TM
 - [ ] Implement `resetMovieComparisons` resolver (auth → delete rows → recompute → audit log `MOVIE_COMPARISON_RESET`)
 
 ### Frontend — remove old ranking
+
 - [ ] Remove all `@dnd-kit` code, `SortableRow`, `DragHandleIcon`, drag/rank columns from `Homepage.tsx`
 - [ ] Remove `REORDER_MY_MOVIE` from `queries.ts`
 - [ ] Rename `rank` → `elo_rank` in `GET_MOVIES`, `GET_MOVIE`, `ADD_MOVIE`, `MATCH_MOVIE` in `queries.ts`
@@ -794,6 +849,7 @@ In-memory `Map<number, { data, expiresAt }>` with 24-hour TTL. Three parallel TM
 - [ ] Add Elo nudge banner to `Homepage.tsx` for users with no personal Elo data
 
 ### Frontend — add This or That
+
 - [ ] Add `THIS_OR_THAT`, `MY_RANKINGS`, `RECORD_COMPARISON`, `RESET_MOVIE_COMPARISONS` to `queries.ts`
 - [ ] Create `MovieCompareCard.tsx`
 - [ ] Create `ThisOrThat.tsx` (with fade-out/skeleton transition on pick)

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,54 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// Mock all heavy dependencies
+jest.mock('@apollo/client', () => ({
+  ...jest.requireActual('@apollo/client'),
+  useLazyQuery: () => [jest.fn().mockResolvedValue({ data: null })],
+  useApolloClient: () => ({ clearStore: jest.fn() }),
+  useQuery: () => ({ data: null, loading: false }),
+  useMutation: () => [jest.fn(), { loading: false }],
+  gql: (strings: TemplateStringsArray) => strings[0],
+}));
+
+jest.mock('./contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: null,
+    isAuthenticated: false,
+    isLoading: false,
+    login: jest.fn(),
+    logout: jest.fn(),
+    refreshUser: jest.fn(),
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('./components/home/Homepage', () => () => <div data-testid="homepage">Homepage</div>);
+jest.mock('./components/home/ThisOrThat', () => () => <div>ThisOrThat</div>);
+jest.mock('./components/home/CombinedList', () => () => <div>CombinedList</div>);
+jest.mock('./components/auth/Login', () => ({ Login: () => <div>Login</div> }));
+jest.mock('./components/auth/ForgotPassword', () => ({
+  ForgotPassword: () => <div>ForgotPassword</div>,
+}));
+jest.mock('./components/auth/ResetPassword', () => ({
+  ResetPassword: () => <div>ResetPassword</div>,
+}));
+jest.mock('./components/admin/AdminPanel', () => ({ AdminPanel: () => <div>AdminPanel</div> }));
+jest.mock('./components/common/Navbar', () => ({ Navbar: () => <div>Navbar</div> }));
+jest.mock('./components/common/Footer', () => ({ Footer: () => <div>Footer</div> }));
+
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+describe('App', () => {
+  it('renders without crashing', () => {
+    render(<App />);
+    expect(screen.getByTestId('homepage')).toBeInTheDocument();
+  });
+
+  it('renders Navbar and Footer', () => {
+    render(<App />);
+    expect(screen.getByText('Navbar')).toBeInTheDocument();
+    expect(screen.getByText('Footer')).toBeInTheDocument();
+  });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,18 @@
-import React from "react";
+import React from 'react';
 import { Box, Typography, CircularProgress } from '@mui/joy';
-import HomePage from "./components/home/Homepage";
-import ThisOrThat from "./components/home/ThisOrThat";
-import CombinedList from "./components/home/CombinedList";
-import { Login } from "./components/auth/Login";
-import { ForgotPassword } from "./components/auth/ForgotPassword";
-import { ResetPassword } from "./components/auth/ResetPassword";
-import { AdminPanel } from "./components/admin/AdminPanel";
-import { Navbar } from "./components/common/Navbar";
-import { Footer } from "./components/common/Footer";
-import { useAuth } from "./contexts/AuthContext";
+import HomePage from './components/home/Homepage';
+import ThisOrThat from './components/home/ThisOrThat';
+import CombinedList from './components/home/CombinedList';
+import { Login } from './components/auth/Login';
+import { ForgotPassword } from './components/auth/ForgotPassword';
+import { ResetPassword } from './components/auth/ResetPassword';
+import { AdminPanel } from './components/admin/AdminPanel';
+import { Navbar } from './components/common/Navbar';
+import { Footer } from './components/common/Footer';
+import { useAuth } from './contexts/AuthContext';
 
 const GIT_BRANCH = process.env.REACT_APP_GIT_BRANCH;
-const IS_TEST_ENV = GIT_BRANCH && GIT_BRANCH !== "master";
+const IS_TEST_ENV = GIT_BRANCH && GIT_BRANCH !== 'master';
 
 type ViewName = 'movies' | 'this-or-that' | 'combined-list' | 'admin';
 

--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -9,16 +9,10 @@ import { LetterboxdImport } from './LetterboxdImport';
 export const AdminPanel: React.FC = () => {
   return (
     <Box>
-      <Typography
-        level="h3"
-        sx={{ fontWeight: 800, mb: 3, letterSpacing: '-0.02em' }}
-      >
+      <Typography level="h3" sx={{ fontWeight: 800, mb: 3, letterSpacing: '-0.02em' }}>
         Admin
       </Typography>
-      <Tabs
-        defaultValue="users"
-        sx={{ bgcolor: 'transparent' }}
-      >
+      <Tabs defaultValue="users" sx={{ bgcolor: 'transparent' }}>
         <TabList
           sx={{
             bgcolor: 'background.surface',

--- a/src/components/admin/AuditLog.tsx
+++ b/src/components/admin/AuditLog.tsx
@@ -84,13 +84,19 @@ export const AuditLog: React.FC = () => {
               {data?.auditLogs.map((log: AuditLogEntry) => (
                 <tr key={log.id}>
                   <td>
-                    <Typography level="body-xs" sx={{ color: 'text.secondary', fontVariantNumeric: 'tabular-nums' }}>
+                    <Typography
+                      level="body-xs"
+                      sx={{ color: 'text.secondary', fontVariantNumeric: 'tabular-nums' }}
+                    >
                       {new Date(log.created_at).toLocaleString()}
                     </Typography>
                   </td>
                   <td>
-                    <Typography level="body-sm" fontWeight={log.actor_username ? 600 : 400}
-                      sx={{ color: log.actor_username ? 'text.primary' : 'text.tertiary' }}>
+                    <Typography
+                      level="body-sm"
+                      fontWeight={log.actor_username ? 600 : 400}
+                      sx={{ color: log.actor_username ? 'text.primary' : 'text.tertiary' }}
+                    >
                       {log.actor_username || '—'}
                     </Typography>
                   </td>
@@ -105,7 +111,9 @@ export const AuditLog: React.FC = () => {
                         {log.target_type}:{log.target_id}
                       </Typography>
                     ) : (
-                      <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>—</Typography>
+                      <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+                        —
+                      </Typography>
                     )}
                   </td>
                   <td>
@@ -124,7 +132,10 @@ export const AuditLog: React.FC = () => {
                     </Typography>
                   </td>
                   <td>
-                    <Typography level="body-xs" sx={{ color: 'text.secondary', fontFamily: 'monospace' }}>
+                    <Typography
+                      level="body-xs"
+                      sx={{ color: 'text.secondary', fontFamily: 'monospace' }}
+                    >
                       {log.ip_address || '—'}
                     </Typography>
                   </td>

--- a/src/components/admin/KometaExport.tsx
+++ b/src/components/admin/KometaExport.tsx
@@ -70,11 +70,15 @@ export const KometaExport: React.FC = () => {
   const [updateSchedule, { loading: savingSchedule }] = useMutation(UPDATE_KOMETA_SCHEDULE);
 
   const [copied, setCopied] = useState(false);
-  const [exportResult, setExportResult] = useState<{
-    path: string;
-    triggered: boolean;
-    triggerError?: string;
-  } | { error: string } | null>(null);
+  const [exportResult, setExportResult] = useState<
+    | {
+        path: string;
+        triggered: boolean;
+        triggerError?: string;
+      }
+    | { error: string }
+    | null
+  >(null);
 
   // Local form state for schedule
   const [schedEnabled, setSchedEnabled] = useState(false);
@@ -94,9 +98,7 @@ export const KometaExport: React.FC = () => {
 
   const collectionName = 'MovieNight Watchlist';
 
-  const movies: Movie[] = [...(data?.movies ?? [])].sort(
-    (a: Movie, b: Movie) => a.rank - b.rank
-  );
+  const movies: Movie[] = [...(data?.movies ?? [])].sort((a: Movie, b: Movie) => a.rank - b.rank);
   const matched = movies.filter((m) => m.tmdb_id != null);
   const unmatched = movies.filter((m) => m.tmdb_id == null);
   const yaml = movies.length > 0 ? generateKometaYaml(movies, collectionName) : '';
@@ -164,9 +166,8 @@ export const KometaExport: React.FC = () => {
       </Typography>
 
       <Typography level="body-sm" sx={{ color: 'text.tertiary', mb: 2 }}>
-        Generates a Kometa collection file using{' '}
-        <code>tmdb_movie</code> + <code>collection_order: release</code> sorted
-        by release date.{' '}
+        Generates a Kometa collection file using <code>tmdb_movie</code> +{' '}
+        <code>collection_order: release</code> sorted by release date.{' '}
         <strong>Write to Kometa</strong> writes directly to the configured{' '}
         <code>KOMETA_COLLECTIONS_PATH</code> on the server.
       </Typography>
@@ -185,10 +186,7 @@ export const KometaExport: React.FC = () => {
       )}
 
       {exportResult && (
-        <Alert
-          color={'error' in exportResult ? 'danger' : 'success'}
-          sx={{ mb: 2 }}
-        >
+        <Alert color={'error' in exportResult ? 'danger' : 'success'} sx={{ mb: 2 }}>
           {'error' in exportResult ? (
             exportResult.error
           ) : (
@@ -220,8 +218,8 @@ export const KometaExport: React.FC = () => {
 
       {matched.length === 0 ? (
         <Alert color="danger" sx={{ mb: 2 }}>
-          No movies have TMDB IDs. Use the TMDB match feature on the homepage to
-          link movies before exporting.
+          No movies have TMDB IDs. Use the TMDB match feature on the homepage to link movies before
+          exporting.
         </Alert>
       ) : (
         <>
@@ -236,12 +234,7 @@ export const KometaExport: React.FC = () => {
             >
               Write to Kometa
             </Button>
-            <Button
-              size="sm"
-              variant="outlined"
-              color="neutral"
-              onClick={handleDownload}
-            >
+            <Button size="sm" variant="outlined" color="neutral" onClick={handleDownload}>
               Download .yml
             </Button>
             <Button
@@ -336,10 +329,7 @@ export const KometaExport: React.FC = () => {
           )}
 
           {schedSaveResult && (
-            <Alert
-              color={schedSaveResult === 'saved' ? 'success' : 'danger'}
-              size="sm"
-            >
+            <Alert color={schedSaveResult === 'saved' ? 'success' : 'danger'} size="sm">
               {schedSaveResult === 'saved'
                 ? 'Schedule saved'
                 : (schedSaveResult as { error: string }).error}

--- a/src/components/admin/LetterboxdImport.tsx
+++ b/src/components/admin/LetterboxdImport.tsx
@@ -1,15 +1,6 @@
 import React, { useState } from 'react';
 import { useMutation } from '@apollo/client';
-import {
-  Box,
-  Button,
-  Input,
-  Typography,
-  Alert,
-  CircularProgress,
-  List,
-  ListItem,
-} from '@mui/joy';
+import { Box, Button, Input, Typography, Alert, CircularProgress, List, ListItem } from '@mui/joy';
 import { IMPORT_FROM_LETTERBOXD, GET_MOVIES } from '../../graphql/queries';
 
 interface ImportResult {
@@ -52,11 +43,7 @@ export const LetterboxdImport: React.FC = () => {
         skipped.
       </Typography>
 
-      <Box
-        component="form"
-        onSubmit={handleSubmit}
-        sx={{ display: 'flex', gap: 1, mb: 3 }}
-      >
+      <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', gap: 1, mb: 3 }}>
         <Input
           value={url}
           onChange={(e) => setUrl(e.target.value)}

--- a/src/components/admin/LoginHistory.tsx
+++ b/src/components/admin/LoginHistory.tsx
@@ -73,28 +73,32 @@ export const LoginHistory: React.FC = () => {
               {data?.loginHistory.map((entry: LoginHistoryEntry) => (
                 <tr key={entry.id}>
                   <td>
-                    <Typography level="body-xs" sx={{ color: 'text.secondary', fontVariantNumeric: 'tabular-nums' }}>
+                    <Typography
+                      level="body-xs"
+                      sx={{ color: 'text.secondary', fontVariantNumeric: 'tabular-nums' }}
+                    >
                       {new Date(entry.created_at).toLocaleString()}
                     </Typography>
                   </td>
                   <td>
-                    <Typography level="body-sm"
+                    <Typography
+                      level="body-sm"
                       fontWeight={entry.username ? 600 : 400}
-                      sx={{ color: entry.username ? 'text.primary' : 'text.tertiary' }}>
+                      sx={{ color: entry.username ? 'text.primary' : 'text.tertiary' }}
+                    >
                       {entry.username || 'unknown'}
                     </Typography>
                   </td>
                   <td>
-                    <Chip
-                      size="sm"
-                      color={entry.succeeded ? 'success' : 'danger'}
-                      variant="soft"
-                    >
+                    <Chip size="sm" color={entry.succeeded ? 'success' : 'danger'} variant="soft">
                       {entry.succeeded ? 'Success' : 'Failed'}
                     </Chip>
                   </td>
                   <td>
-                    <Typography level="body-xs" sx={{ color: 'text.secondary', fontFamily: 'monospace' }}>
+                    <Typography
+                      level="body-xs"
+                      sx={{ color: 'text.secondary', fontFamily: 'monospace' }}
+                    >
                       {entry.ip_address || '—'}
                     </Typography>
                   </td>

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -51,12 +51,18 @@ export const UserManagement: React.FC = () => {
   const { data, loading, refetch } = useQuery(GET_USERS);
 
   const [createUser, { loading: creating }] = useMutation(CREATE_USER, {
-    onCompleted: () => { refetch(); handleClose(); },
+    onCompleted: () => {
+      refetch();
+      handleClose();
+    },
     onError: (err) => setError(err.message),
   });
 
   const [updateUser, { loading: updating }] = useMutation(UPDATE_USER, {
-    onCompleted: () => { refetch(); handleClose(); },
+    onCompleted: () => {
+      refetch();
+      handleClose();
+    },
     onError: (err) => setError(err.message),
   });
 
@@ -78,7 +84,14 @@ export const UserManagement: React.FC = () => {
       });
     } else {
       setEditingUser(null);
-      setFormData({ username: '', email: '', display_name: '', password: '', is_admin: false, is_active: true });
+      setFormData({
+        username: '',
+        email: '',
+        display_name: '',
+        password: '',
+        is_admin: false,
+        is_active: true,
+      });
     }
     setError('');
     setOpen(true);
@@ -87,7 +100,14 @@ export const UserManagement: React.FC = () => {
   const handleClose = () => {
     setOpen(false);
     setEditingUser(null);
-    setFormData({ username: '', email: '', display_name: '', password: '', is_admin: false, is_active: true });
+    setFormData({
+      username: '',
+      email: '',
+      display_name: '',
+      password: '',
+      is_admin: false,
+      is_active: true,
+    });
     setError('');
   };
 
@@ -106,8 +126,13 @@ export const UserManagement: React.FC = () => {
         if (formData.is_active !== editingUser.is_active) variables.is_active = formData.is_active;
         await updateUser({ variables });
       } else {
-        if (!formData.password) { setError('Password is required for new users'); return; }
-        await createUser({ variables: { ...formData, display_name: formData.display_name || null } });
+        if (!formData.password) {
+          setError('Password is required for new users');
+          return;
+        }
+        await createUser({
+          variables: { ...formData, display_name: formData.display_name || null },
+        });
       }
     } catch {
       // handled by onError
@@ -198,15 +223,21 @@ export const UserManagement: React.FC = () => {
                     {user.display_name ? (
                       <Typography level="body-sm">{user.display_name}</Typography>
                     ) : (
-                      <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>—</Typography>
+                      <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+                        —
+                      </Typography>
                     )}
                   </td>
                   <td>
-                    <Typography level="body-xs" sx={{ color: 'text.secondary' }}>{user.email}</Typography>
+                    <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
+                      {user.email}
+                    </Typography>
                   </td>
                   <td>
                     {user.is_admin && (
-                      <Chip size="sm" color="warning" variant="soft">Admin</Chip>
+                      <Chip size="sm" color="warning" variant="soft">
+                        Admin
+                      </Chip>
                     )}
                   </td>
                   <td>
@@ -216,9 +247,7 @@ export const UserManagement: React.FC = () => {
                   </td>
                   <td>
                     <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
-                      {user.last_login_at
-                        ? new Date(user.last_login_at).toLocaleDateString()
-                        : '—'}
+                      {user.last_login_at ? new Date(user.last_login_at).toLocaleDateString() : '—'}
                     </Typography>
                   </td>
                   <td>
@@ -228,7 +257,12 @@ export const UserManagement: React.FC = () => {
                   </td>
                   <td>
                     <Box sx={{ display: 'flex', gap: 0.5, justifyContent: 'flex-end', pr: 1 }}>
-                      <Button size="sm" variant="soft" color="neutral" onClick={() => handleOpen(user)}>
+                      <Button
+                        size="sm"
+                        variant="soft"
+                        color="neutral"
+                        onClick={() => handleOpen(user)}
+                      >
                         Edit
                       </Button>
                       <IconButton
@@ -302,7 +336,10 @@ export const UserManagement: React.FC = () => {
 
             <FormControl sx={{ mb: 2 }}>
               <FormLabel sx={{ fontSize: '0.8rem', fontWeight: 600, color: 'text.secondary' }}>
-                Password {editingUser && <span style={{ fontWeight: 400, opacity: 0.6 }}>(leave blank to keep)</span>}
+                Password{' '}
+                {editingUser && (
+                  <span style={{ fontWeight: 400, opacity: 0.6 }}>(leave blank to keep)</span>
+                )}
               </FormLabel>
               <Input
                 type="password"

--- a/src/components/auth/ForgotPassword.tsx
+++ b/src/components/auth/ForgotPassword.tsx
@@ -1,14 +1,6 @@
 import React, { useState } from 'react';
 import { useMutation } from '@apollo/client';
-import {
-  Box,
-  Button,
-  FormControl,
-  FormLabel,
-  Input,
-  Typography,
-  Alert,
-} from '@mui/joy';
+import { Box, Button, FormControl, FormLabel, Input, Typography, Alert } from '@mui/joy';
 import { REQUEST_PASSWORD_RESET } from '../../graphql/queries';
 
 interface ForgotPasswordProps {
@@ -111,10 +103,7 @@ export const ForgotPassword: React.FC<ForgotPasswordProps> = ({ onBackToLogin })
         {/* Mobile logo */}
         <Box sx={{ display: { xs: 'block', md: 'none' }, mb: 4, textAlign: 'center' }}>
           <Typography sx={{ fontSize: '3rem', lineHeight: 1 }}>🎬</Typography>
-          <Typography
-            level="h3"
-            sx={{ fontWeight: 800, color: 'primary.400', mt: 1 }}
-          >
+          <Typography level="h3" sx={{ fontWeight: 800, color: 'primary.400', mt: 1 }}>
             MovieNight
           </Typography>
         </Box>
@@ -126,7 +115,8 @@ export const ForgotPassword: React.FC<ForgotPasswordProps> = ({ onBackToLogin })
                 Check your email
               </Typography>
               <Alert color="success" variant="soft" sx={{ mb: 3, mt: 2 }}>
-                If an account exists with that email, a password reset link has been sent. Check your inbox.
+                If an account exists with that email, a password reset link has been sent. Check
+                your inbox.
               </Alert>
               <Button
                 onClick={onBackToLogin}

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -1,14 +1,6 @@
 import React, { useState } from 'react';
 import { useMutation, useQuery } from '@apollo/client';
-import {
-  Box,
-  Button,
-  FormControl,
-  FormLabel,
-  Input,
-  Typography,
-  Alert,
-} from '@mui/joy';
+import { Box, Button, FormControl, FormLabel, Input, Typography, Alert } from '@mui/joy';
 import { LOGIN, GET_APP_INFO } from '../../graphql/queries';
 import { useAuth } from '../../contexts/AuthContext';
 
@@ -144,10 +136,7 @@ export const Login: React.FC<LoginProps> = ({ onForgotPassword }) => {
         {/* Mobile logo */}
         <Box sx={{ display: { xs: 'block', md: 'none' }, mb: 4, textAlign: 'center' }}>
           <Typography sx={{ fontSize: '3rem', lineHeight: 1 }}>🎬</Typography>
-          <Typography
-            level="h3"
-            sx={{ fontWeight: 800, color: 'primary.400', mt: 1 }}
-          >
+          <Typography level="h3" sx={{ fontWeight: 800, color: 'primary.400', mt: 1 }}>
             MovieNight
           </Typography>
         </Box>

--- a/src/components/auth/ResetPassword.tsx
+++ b/src/components/auth/ResetPassword.tsx
@@ -1,14 +1,6 @@
 import React, { useState } from 'react';
 import { useMutation } from '@apollo/client';
-import {
-  Box,
-  Button,
-  FormControl,
-  FormLabel,
-  Input,
-  Typography,
-  Alert,
-} from '@mui/joy';
+import { Box, Button, FormControl, FormLabel, Input, Typography, Alert } from '@mui/joy';
 import { RESET_PASSWORD } from '../../graphql/queries';
 
 interface ResetPasswordProps {
@@ -124,10 +116,7 @@ export const ResetPassword: React.FC<ResetPasswordProps> = ({ token, onComplete 
         {/* Mobile logo */}
         <Box sx={{ display: { xs: 'block', md: 'none' }, mb: 4, textAlign: 'center' }}>
           <Typography sx={{ fontSize: '3rem', lineHeight: 1 }}>🎬</Typography>
-          <Typography
-            level="h3"
-            sx={{ fontWeight: 800, color: 'primary.400', mt: 1 }}
-          >
+          <Typography level="h3" sx={{ fontWeight: 800, color: 'primary.400', mt: 1 }}>
             MovieNight
           </Typography>
         </Box>

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { Box, Typography } from "@mui/joy";
+import React from 'react';
+import { Box, Typography } from '@mui/joy';
 
 const GIT_BRANCH = process.env.REACT_APP_GIT_BRANCH;
 const GIT_HASH = process.env.REACT_APP_GIT_HASH;
@@ -9,12 +9,12 @@ function formatDeployTime(iso: string): string {
   const d = new Date(iso);
   if (isNaN(d.getTime())) return iso;
   return d.toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    timeZoneName: "short",
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZoneName: 'short',
   });
 }
 
@@ -24,27 +24,28 @@ export const Footer: React.FC = () => {
   const parts: string[] = [];
   if (GIT_BRANCH) parts.push(`branch: ${GIT_BRANCH}`);
   if (GIT_HASH) parts.push(`commit: ${GIT_HASH.slice(0, 7)}`);
-  if (DEPLOY_TIME && DEPLOY_TIME !== "unknown") parts.push(`deployed: ${formatDeployTime(DEPLOY_TIME)}`);
+  if (DEPLOY_TIME && DEPLOY_TIME !== 'unknown')
+    parts.push(`deployed: ${formatDeployTime(DEPLOY_TIME)}`);
 
   return (
     <Box
       component="footer"
       sx={{
-        mt: "auto",
+        mt: 'auto',
         py: 2.5,
         px: { xs: 2, sm: 3 },
-        textAlign: "center",
-        borderTop: "1px solid",
-        borderColor: "divider",
-        bgcolor: "background.surface",
+        textAlign: 'center',
+        borderTop: '1px solid',
+        borderColor: 'divider',
+        bgcolor: 'background.surface',
       }}
     >
-      <Typography level="body-xs" sx={{ color: "text.tertiary" }}>
+      <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
         &copy; {year} MovieNight
       </Typography>
       {parts.length > 0 && (
-        <Typography level="body-xs" sx={{ color: "text.tertiary", mt: 0.25, opacity: 0.5 }}>
-          {parts.join(" · ")}
+        <Typography level="body-xs" sx={{ color: 'text.tertiary', mt: 0.25, opacity: 0.5 }}>
+          {parts.join(' · ')}
         </Typography>
       )}
     </Box>

--- a/src/components/common/Navbar.tsx
+++ b/src/components/common/Navbar.tsx
@@ -31,7 +31,10 @@ export const Navbar: React.FC<NavbarProps> = ({
         variant={currentView === 'movies' ? 'soft' : 'plain'}
         color="neutral"
         size="sm"
-        onClick={() => { onShowMovies(); setMobileOpen(false); }}
+        onClick={() => {
+          onShowMovies();
+          setMobileOpen(false);
+        }}
         sx={{
           fontWeight: 600,
           color: currentView === 'movies' ? 'primary.400' : 'text.secondary',
@@ -45,7 +48,10 @@ export const Navbar: React.FC<NavbarProps> = ({
           variant={currentView === 'this-or-that' ? 'soft' : 'plain'}
           color="neutral"
           size="sm"
-          onClick={() => { onShowThisOrThat(); setMobileOpen(false); }}
+          onClick={() => {
+            onShowThisOrThat();
+            setMobileOpen(false);
+          }}
           sx={{
             fontWeight: 600,
             color: currentView === 'this-or-that' ? 'primary.400' : 'text.secondary',
@@ -60,7 +66,10 @@ export const Navbar: React.FC<NavbarProps> = ({
           variant={currentView === 'combined-list' ? 'soft' : 'plain'}
           color="neutral"
           size="sm"
-          onClick={() => { onShowCombinedList(); setMobileOpen(false); }}
+          onClick={() => {
+            onShowCombinedList();
+            setMobileOpen(false);
+          }}
           sx={{
             fontWeight: 600,
             color: currentView === 'combined-list' ? 'primary.400' : 'text.secondary',
@@ -75,7 +84,10 @@ export const Navbar: React.FC<NavbarProps> = ({
           variant={currentView === 'admin' ? 'soft' : 'plain'}
           color="neutral"
           size="sm"
-          onClick={() => { onShowAdmin(); setMobileOpen(false); }}
+          onClick={() => {
+            onShowAdmin();
+            setMobileOpen(false);
+          }}
           sx={{
             fontWeight: 600,
             color: currentView === 'admin' ? 'primary.400' : 'text.secondary',
@@ -120,14 +132,15 @@ export const Navbar: React.FC<NavbarProps> = ({
               cursor: 'pointer',
               userSelect: 'none',
             }}
-            onClick={() => { onShowMovies(); setMobileOpen(false); }}
+            onClick={() => {
+              onShowMovies();
+              setMobileOpen(false);
+            }}
           >
             MovieNight
           </Typography>
           {/* Desktop nav links */}
-          <Box sx={{ display: { xs: 'none', sm: 'flex' }, gap: 0.5 }}>
-            {navItems}
-          </Box>
+          <Box sx={{ display: { xs: 'none', sm: 'flex' }, gap: 0.5 }}>{navItems}</Box>
         </Box>
 
         {/* Right side */}
@@ -182,7 +195,10 @@ export const Navbar: React.FC<NavbarProps> = ({
               variant="solid"
               color="primary"
               size="sm"
-              onClick={() => { onShowLogin(); setMobileOpen(false); }}
+              onClick={() => {
+                onShowLogin();
+                setMobileOpen(false);
+              }}
               sx={{ fontWeight: 700, color: '#0d0f1a' }}
             >
               Sign In
@@ -226,7 +242,12 @@ export const Navbar: React.FC<NavbarProps> = ({
                   <img
                     src={getGravatarUrl(user.email, 32)}
                     alt={user.display_name || user.username}
-                    style={{ width: 32, height: 32, borderRadius: '50%', border: '2px solid rgba(245, 197, 24, 0.3)' }}
+                    style={{
+                      width: 32,
+                      height: 32,
+                      borderRadius: '50%',
+                      border: '2px solid rgba(245, 197, 24, 0.3)',
+                    }}
                   />
                 )}
                 <Box>

--- a/src/components/home/CombinedList.tsx
+++ b/src/components/home/CombinedList.tsx
@@ -1,8 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useQuery, useLazyQuery, useMutation } from '@apollo/client';
-import {
-  Box, Typography, Button, Sheet, Chip, Input, CircularProgress, Alert,
-} from '@mui/joy';
+import { Box, Typography, Button, Sheet, Chip, Input, CircularProgress, Alert } from '@mui/joy';
 import {
   SEARCH_USERS,
   MY_CONNECTIONS,
@@ -68,13 +66,18 @@ const CombinedList: React.FC = () => {
   // Auto-clear alerts
   useEffect(() => {
     if (error || success) {
-      const timer = setTimeout(() => { setError(null); setSuccess(null); }, 4000);
+      const timer = setTimeout(() => {
+        setError(null);
+        setSuccess(null);
+      }, 4000);
       return () => clearTimeout(timer);
     }
   }, [error, success]);
 
-  const incomingPending = pendingData?.pendingConnectionRequests?.filter((r: any) => r.direction === 'received') || [];
-  const outgoingPending = pendingData?.pendingConnectionRequests?.filter((r: any) => r.direction === 'sent') || [];
+  const incomingPending =
+    pendingData?.pendingConnectionRequests?.filter((r: any) => r.direction === 'received') || [];
+  const outgoingPending =
+    pendingData?.pendingConnectionRequests?.filter((r: any) => r.direction === 'sent') || [];
   const connections = connectionsData?.myConnections || [];
 
   return (
@@ -99,12 +102,25 @@ const CombinedList: React.FC = () => {
         </Box>
 
         {/* Alerts */}
-        {error && <Alert color="danger" sx={{ mb: 2 }}>{error}</Alert>}
-        {success && <Alert color="success" sx={{ mb: 2 }}>{success}</Alert>}
+        {error && (
+          <Alert color="danger" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+        {success && (
+          <Alert color="success" sx={{ mb: 2 }}>
+            {success}
+          </Alert>
+        )}
 
         {/* Search */}
-        <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'md', mb: 3, borderColor: 'var(--mn-border-vis)' }}>
-          <Typography level="title-sm" sx={{ mb: 1.5, fontWeight: 700 }}>Find a friend</Typography>
+        <Sheet
+          variant="outlined"
+          sx={{ p: 2, borderRadius: 'md', mb: 3, borderColor: 'var(--mn-border-vis)' }}
+        >
+          <Typography level="title-sm" sx={{ mb: 1.5, fontWeight: 700 }}>
+            Find a friend
+          </Typography>
           <Box sx={{ display: 'flex', gap: 1 }}>
             <Input
               placeholder="Search by username..."
@@ -121,14 +137,22 @@ const CombinedList: React.FC = () => {
                 <Box
                   key={u.id}
                   sx={{
-                    display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-                    p: 1, borderRadius: 'sm', bgcolor: 'background.level1',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    p: 1,
+                    borderRadius: 'sm',
+                    bgcolor: 'background.level1',
                   }}
                 >
                   <Typography level="body-sm" sx={{ fontWeight: 600 }}>
                     {u.display_name || u.username}
                     {u.display_name && (
-                      <Typography component="span" level="body-xs" sx={{ color: 'text.tertiary', ml: 0.5 }}>
+                      <Typography
+                        component="span"
+                        level="body-xs"
+                        sx={{ color: 'text.tertiary', ml: 0.5 }}
+                      >
                         @{u.username}
                       </Typography>
                     )}
@@ -150,7 +174,10 @@ const CombinedList: React.FC = () => {
 
         {/* Pending incoming */}
         {incomingPending.length > 0 && (
-          <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'md', mb: 3, borderColor: 'warning.outlinedBorder' }}>
+          <Sheet
+            variant="outlined"
+            sx={{ p: 2, borderRadius: 'md', mb: 3, borderColor: 'warning.outlinedBorder' }}
+          >
             <Typography level="title-sm" sx={{ mb: 1.5, fontWeight: 700 }}>
               Pending requests ({incomingPending.length})
             </Typography>
@@ -159,26 +186,40 @@ const CombinedList: React.FC = () => {
                 <Box
                   key={req.id}
                   sx={{
-                    display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-                    p: 1, borderRadius: 'sm', bgcolor: 'background.level1',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    p: 1,
+                    borderRadius: 'sm',
+                    bgcolor: 'background.level1',
                   }}
                 >
                   <Typography level="body-sm" sx={{ fontWeight: 600 }}>
                     {req.user.display_name || req.user.username}
-                    <Typography component="span" level="body-xs" sx={{ color: 'text.tertiary', ml: 0.5 }}>
+                    <Typography
+                      component="span"
+                      level="body-xs"
+                      sx={{ color: 'text.tertiary', ml: 0.5 }}
+                    >
                       wants to connect
                     </Typography>
                   </Typography>
                   <Box sx={{ display: 'flex', gap: 0.5 }}>
                     <Button
-                      size="sm" variant="soft" color="success"
+                      size="sm"
+                      variant="soft"
+                      color="success"
                       onClick={() => respond({ variables: { connectionId: req.id, accept: true } })}
                     >
                       Accept
                     </Button>
                     <Button
-                      size="sm" variant="plain" color="danger"
-                      onClick={() => respond({ variables: { connectionId: req.id, accept: false } })}
+                      size="sm"
+                      variant="plain"
+                      color="danger"
+                      onClick={() =>
+                        respond({ variables: { connectionId: req.id, accept: false } })
+                      }
                     >
                       Decline
                     </Button>
@@ -191,21 +232,32 @@ const CombinedList: React.FC = () => {
 
         {/* Outgoing pending */}
         {outgoingPending.length > 0 && (
-          <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'md', mb: 3, borderColor: 'var(--mn-border-vis)' }}>
-            <Typography level="title-sm" sx={{ mb: 1.5, fontWeight: 700 }}>Sent requests</Typography>
+          <Sheet
+            variant="outlined"
+            sx={{ p: 2, borderRadius: 'md', mb: 3, borderColor: 'var(--mn-border-vis)' }}
+          >
+            <Typography level="title-sm" sx={{ mb: 1.5, fontWeight: 700 }}>
+              Sent requests
+            </Typography>
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
               {outgoingPending.map((req: any) => (
                 <Box
                   key={req.id}
                   sx={{
-                    display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-                    p: 1, borderRadius: 'sm', bgcolor: 'background.level1',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    p: 1,
+                    borderRadius: 'sm',
+                    bgcolor: 'background.level1',
                   }}
                 >
                   <Typography level="body-sm" sx={{ fontWeight: 600 }}>
                     {req.user.display_name || req.user.username}
                   </Typography>
-                  <Chip size="sm" variant="soft" color="neutral">Pending</Chip>
+                  <Chip size="sm" variant="soft" color="neutral">
+                    Pending
+                  </Chip>
                 </Box>
               ))}
             </Box>
@@ -213,8 +265,13 @@ const CombinedList: React.FC = () => {
         )}
 
         {/* Active connections */}
-        <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'md', borderColor: 'var(--mn-border-vis)' }}>
-          <Typography level="title-sm" sx={{ mb: 1.5, fontWeight: 700 }}>Your connections</Typography>
+        <Sheet
+          variant="outlined"
+          sx={{ p: 2, borderRadius: 'md', borderColor: 'var(--mn-border-vis)' }}
+        >
+          <Typography level="title-sm" sx={{ mb: 1.5, fontWeight: 700 }}>
+            Your connections
+          </Typography>
           {connections.length === 0 && (
             <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
               No connections yet. Search for a friend above!
@@ -225,17 +282,27 @@ const CombinedList: React.FC = () => {
               <Box
                 key={conn.id}
                 sx={{
-                  display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-                  p: 1, borderRadius: 'sm', bgcolor: 'background.level1',
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  p: 1,
+                  borderRadius: 'sm',
+                  bgcolor: 'background.level1',
                 }}
               >
                 <Typography level="body-sm" sx={{ fontWeight: 600 }}>
                   {conn.user.display_name || conn.user.username}
                 </Typography>
                 <Button
-                  size="sm" variant="plain" color="danger"
+                  size="sm"
+                  variant="plain"
+                  color="danger"
                   onClick={() => {
-                    if (window.confirm(`Remove connection with ${conn.user.display_name || conn.user.username}?`)) {
+                    if (
+                      window.confirm(
+                        `Remove connection with ${conn.user.display_name || conn.user.username}?`,
+                      )
+                    ) {
                       removeConnection({ variables: { connectionId: conn.id } });
                     }
                   }}

--- a/src/components/home/Homepage.tsx
+++ b/src/components/home/Homepage.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from "react";
-import { useQuery, useMutation, useLazyQuery } from "@apollo/client";
+import React, { useState, useEffect } from 'react';
+import { useQuery, useMutation, useLazyQuery } from '@apollo/client';
 import {
   GET_MOVIES,
   ADD_MOVIE,
@@ -11,7 +11,7 @@ import {
   MY_CONNECTIONS,
   PENDING_CONNECTION_REQUESTS,
   COMBINED_LIST,
-} from "../../graphql/queries";
+} from '../../graphql/queries';
 import {
   Autocomplete,
   AutocompleteOption,
@@ -23,10 +23,10 @@ import {
   IconButton,
   ListItemContent,
   CircularProgress,
-} from "@mui/joy";
-import TmdbMatchFlow from "./TmdbMatchFlow";
-import { Movie } from "../../models/Movies";
-import { useAuth } from "../../contexts/AuthContext";
+} from '@mui/joy';
+import TmdbMatchFlow from './TmdbMatchFlow';
+import { Movie } from '../../models/Movies';
+import { useAuth } from '../../contexts/AuthContext';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -67,38 +67,38 @@ const MovieRow: React.FC<MovieRowProps> = ({
 }) => (
   <tr>
     {/* Title */}
-    <td style={{ verticalAlign: "middle", padding: "12px 16px" }}>
-      <Typography level="body-sm" sx={{ fontWeight: 600, color: "text.primary" }}>
+    <td style={{ verticalAlign: 'middle', padding: '12px 16px' }}>
+      <Typography level="body-sm" sx={{ fontWeight: 600, color: 'text.primary' }}>
         {movie.title}
       </Typography>
     </td>
 
     {/* Suggested by */}
-    <td style={{ verticalAlign: "middle", padding: "12px 16px" }}>
+    <td style={{ verticalAlign: 'middle', padding: '12px 16px' }}>
       <Chip size="sm" variant="soft" color="neutral" sx={{ fontWeight: 500 }}>
         {movie.requester}
       </Chip>
     </td>
 
     {/* Date */}
-    <td style={{ verticalAlign: "middle", padding: "12px 16px", whiteSpace: "nowrap" }}>
-      <Typography level="body-xs" sx={{ color: "text.secondary" }}>
+    <td style={{ verticalAlign: 'middle', padding: '12px 16px', whiteSpace: 'nowrap' }}>
+      <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
         {new Date(movie.date_submitted).toLocaleDateString(undefined, {
-          year: "numeric",
-          month: "short",
-          day: "numeric",
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
         })}
       </Typography>
     </td>
 
     {/* TMDB */}
-    <td style={{ verticalAlign: "middle", padding: "12px 8px", textAlign: "center" }}>
+    <td style={{ verticalAlign: 'middle', padding: '12px 8px', textAlign: 'center' }}>
       {movie.tmdb_id ? (
         <a
           href={`https://www.themoviedb.org/movie/${movie.tmdb_id}`}
           target="_blank"
           rel="noopener noreferrer"
-          style={{ color: "var(--joy-palette-primary-500)", fontSize: "0.75rem" }}
+          style={{ color: 'var(--joy-palette-primary-500)', fontSize: '0.75rem' }}
         >
           ↗
         </a>
@@ -109,10 +109,10 @@ const MovieRow: React.FC<MovieRowProps> = ({
     {(canMarkWatched || isAdmin) && (
       <td
         style={{
-          verticalAlign: "middle",
-          padding: "0 12px",
-          textAlign: "right",
-          whiteSpace: "nowrap",
+          verticalAlign: 'middle',
+          padding: '0 12px',
+          textAlign: 'right',
+          whiteSpace: 'nowrap',
         }}
       >
         {canMarkWatched && (
@@ -124,8 +124,8 @@ const MovieRow: React.FC<MovieRowProps> = ({
             title={`Mark "${movie.title}" as watched`}
             sx={{
               opacity: 0.5,
-              transition: "opacity 0.15s",
-              "&:hover": { opacity: 1 },
+              transition: 'opacity 0.15s',
+              '&:hover': { opacity: 1 },
               mr: isAdmin ? 0.5 : 0,
             }}
           >
@@ -141,8 +141,8 @@ const MovieRow: React.FC<MovieRowProps> = ({
             title={`Remove "${movie.title}"`}
             sx={{
               opacity: 0.5,
-              transition: "opacity 0.15s",
-              "&:hover": { opacity: 1 },
+              transition: 'opacity 0.15s',
+              '&:hover': { opacity: 1 },
             }}
           >
             ✕
@@ -152,7 +152,6 @@ const MovieRow: React.FC<MovieRowProps> = ({
     )}
   </tr>
 );
-
 
 // ── Page ──────────────────────────────────────────────────────────────────────
 
@@ -165,11 +164,11 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
   const { isAuthenticated, user } = useAuth();
   const isAdmin = user?.is_admin ?? false;
 
-  const [title, setTitle] = useState("");
+  const [title, setTitle] = useState('');
   const [tmdbId, setTmdbId] = useState<number | null>(null);
   const [tmdbOptions, setTmdbOptions] = useState<TmdbOption[]>([]);
-  const [successMessage, setSuccessMessage] = useState("");
-  const [errorMessage, setErrorMessage] = useState("");
+  const [successMessage, setSuccessMessage] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
   const [matchFlowOpen, setMatchFlowOpen] = useState(false);
   const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
 
@@ -186,9 +185,8 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
   });
 
   const connections = connectionsData?.myConnections || [];
-  const incomingPending = pendingData?.pendingConnectionRequests?.filter(
-    (r: any) => r.direction === 'received'
-  ) || [];
+  const incomingPending =
+    pendingData?.pendingConnectionRequests?.filter((r: any) => r.direction === 'received') || [];
   const isCombinedView = selectedConnectionId !== null;
 
   const debouncedTitle = useDebounce(title, 400);
@@ -228,20 +226,14 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
   const movies: Movie[] = data?.movies ?? [];
 
   // Check if the current user has any personal Elo data
-  const hasEloData = isAuthenticated && movies.some(m => m.elo_rank != null);
+  const hasEloData = isAuthenticated && movies.some((m) => m.elo_rank != null);
 
   const unmatchedMovies = movies.filter(
-    (m) =>
-      !m.tmdb_id &&
-      (isAdmin || (user && String(m.requested_by) === String(user.id)))
+    (m) => !m.tmdb_id && (isAdmin || (user && String(m.requested_by) === String(user.id))),
   );
 
   const handleMarkWatched = async (id: string, movieTitle: string) => {
-    if (
-      !window.confirm(
-        `Mark "${movieTitle}" as watched? It will be removed from the watchlist.`
-      )
-    )
+    if (!window.confirm(`Mark "${movieTitle}" as watched? It will be removed from the watchlist.`))
       return;
     try {
       await markWatched({ variables: { id } });
@@ -260,7 +252,8 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
   };
 
   const handleSeed = async () => {
-    if (!window.confirm('This will DELETE all existing movies and seed 30 new ones. Continue?')) return;
+    if (!window.confirm('This will DELETE all existing movies and seed 30 new ones. Continue?'))
+      return;
     try {
       await seedMovies();
       setSuccessMessage('Seeded 30 movies!');
@@ -273,16 +266,16 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!title.trim()) {
-      setErrorMessage("Please enter a movie title.");
+      setErrorMessage('Please enter a movie title.');
       return;
     }
     try {
       await addMovie({ variables: { title: title.trim(), tmdb_id: tmdbId } });
-      setSuccessMessage("Added to the list!");
-      setTitle("");
+      setSuccessMessage('Added to the list!');
+      setTitle('');
       setTmdbId(null);
       setTmdbOptions([]);
-      setTimeout(() => setSuccessMessage(""), 3000);
+      setTimeout(() => setSuccessMessage(''), 3000);
     } catch (error: any) {
       setErrorMessage(`Error: ${error.message}`);
     }
@@ -301,33 +294,35 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
       component="main"
       sx={{
         flex: 1,
-        bgcolor: "background.body",
+        bgcolor: 'background.body',
         px: { xs: 2, sm: 3, md: 4 },
         py: { xs: 3, sm: 5 },
       }}
     >
-      <Box sx={{ maxWidth: 900, mx: "auto" }}>
+      <Box sx={{ maxWidth: 900, mx: 'auto' }}>
         {/* Page header */}
-        <Box sx={{ textAlign: "center", mb: { xs: 3, sm: 4 } }}>
-          <Typography
-            level="h2"
-            sx={{ fontWeight: 800, letterSpacing: "-0.02em", mb: 0.5 }}
-          >
+        <Box sx={{ textAlign: 'center', mb: { xs: 3, sm: 4 } }}>
+          <Typography level="h2" sx={{ fontWeight: 800, letterSpacing: '-0.02em', mb: 0.5 }}>
             Movie List
           </Typography>
-          <Typography level="body-sm" sx={{ color: "text.secondary" }}>
+          <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
             {movies.length === 0
-              ? "No movies yet — suggest one!"
-              : `${movies.length} movie${movies.length !== 1 ? "s" : ""} in the queue`}
+              ? 'No movies yet — suggest one!'
+              : `${movies.length} movie${movies.length !== 1 ? 's' : ''} in the queue`}
           </Typography>
         </Box>
 
         {/* View selector — segmented control */}
         {isAuthenticated && connections.length > 0 && (
-          <Box sx={{
-            display: 'flex', justifyContent: 'center', flexWrap: 'wrap',
-            gap: 0.5, mb: 3,
-          }}>
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'center',
+              flexWrap: 'wrap',
+              gap: 0.5,
+              mb: 3,
+            }}
+          >
             <Button
               variant={!isCombinedView ? 'soft' : 'plain'}
               color="neutral"
@@ -364,10 +359,17 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
         {isAuthenticated && incomingPending.length > 0 && (
           <Box
             sx={{
-              mb: 3, p: 1.5, borderRadius: 'md',
-              bgcolor: 'warning.softBg', border: '1px solid', borderColor: 'warning.outlinedBorder',
-              textAlign: 'center', display: 'flex', alignItems: 'center',
-              justifyContent: 'center', gap: 1,
+              mb: 3,
+              p: 1.5,
+              borderRadius: 'md',
+              bgcolor: 'warning.softBg',
+              border: '1px solid',
+              borderColor: 'warning.outlinedBorder',
+              textAlign: 'center',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 1,
             }}
           >
             <Typography level="body-sm" sx={{ color: 'warning.softColor' }}>
@@ -376,7 +378,13 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
                 : `${incomingPending.length} pending connection requests`}
             </Typography>
             {onShowConnections && (
-              <Button variant="soft" color="warning" size="sm" onClick={onShowConnections} sx={{ fontWeight: 700 }}>
+              <Button
+                variant="soft"
+                color="warning"
+                size="sm"
+                onClick={onShowConnections}
+                sx={{ fontWeight: 700 }}
+              >
                 View
               </Button>
             )}
@@ -403,7 +411,9 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
             {isAuthenticated ? (
               <>
                 <Typography level="body-sm" sx={{ color: 'primary.softColor' }}>
-                  {hasEloData ? 'Keep ranking movies!' : 'Rate movies to get your personal ranking.'}
+                  {hasEloData
+                    ? 'Keep ranking movies!'
+                    : 'Rate movies to get your personal ranking.'}
                 </Typography>
                 {onShowThisOrThat && (
                   <Button
@@ -429,16 +439,16 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
         {isAuthenticated && (
           <Box sx={{ mb: 4 }}>
             <form onSubmit={handleSubmit}>
-              <Box sx={{ display: "flex", gap: 1, maxWidth: 520, mx: "auto" }}>
+              <Box sx={{ display: 'flex', gap: 1, maxWidth: 520, mx: 'auto' }}>
                 <Autocomplete
                   freeSolo
                   options={tmdbOptions}
                   getOptionLabel={(option) =>
-                    typeof option === "string"
+                    typeof option === 'string'
                       ? option
                       : option.release_year
-                      ? `${option.title} (${option.release_year})`
-                      : option.title
+                        ? `${option.title} (${option.release_year})`
+                        : option.title
                   }
                   inputValue={title}
                   onInputChange={(_, value) => {
@@ -446,7 +456,7 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
                     if (!value) setTmdbId(null);
                   }}
                   onChange={(_, value) => {
-                    if (value && typeof value !== "string") {
+                    if (value && typeof value !== 'string') {
                       setTitle(value.title);
                       setTmdbId(value.tmdb_id);
                     }
@@ -462,15 +472,15 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
                   placeholder="Suggest a movie title..."
                   sx={{
                     flex: 1,
-                    bgcolor: "background.surface",
-                    "--Input-focusedHighlight": "var(--joy-palette-primary-500)",
+                    bgcolor: 'background.surface',
+                    '--Input-focusedHighlight': 'var(--joy-palette-primary-500)',
                   }}
                 />
                 <Button
                   type="submit"
                   color="primary"
                   variant="solid"
-                  sx={{ fontWeight: 700, color: "#0d0f1a", px: 3 }}
+                  sx={{ fontWeight: 700, color: '#0d0f1a', px: 3 }}
                 >
                   Add
                 </Button>
@@ -480,7 +490,7 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
             {successMessage && (
               <Typography
                 level="body-sm"
-                sx={{ textAlign: "center", mt: 1.5, color: "success.400", fontWeight: 600 }}
+                sx={{ textAlign: 'center', mt: 1.5, color: 'success.400', fontWeight: 600 }}
               >
                 {successMessage}
               </Typography>
@@ -488,7 +498,7 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
             {errorMessage && (
               <Typography
                 level="body-sm"
-                sx={{ textAlign: "center", mt: 1.5, color: "danger.400", fontWeight: 600 }}
+                sx={{ textAlign: 'center', mt: 1.5, color: 'danger.400', fontWeight: 600 }}
               >
                 {errorMessage}
               </Typography>
@@ -498,7 +508,7 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
 
         {/* TMDB match flow */}
         {isAuthenticated && unmatchedMovies.length > 0 && (
-          <Box sx={{ textAlign: "center", mb: 3 }}>
+          <Box sx={{ textAlign: 'center', mb: 3 }}>
             <Button
               variant="outlined"
               color="neutral"
@@ -506,23 +516,17 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
               onClick={() => setMatchFlowOpen(true)}
             >
               Match {unmatchedMovies.length} unmatched movie
-              {unmatchedMovies.length !== 1 ? "s" : ""} with TMDB
+              {unmatchedMovies.length !== 1 ? 's' : ''} with TMDB
             </Button>
           </Box>
         )}
         {matchFlowOpen && (
-          <TmdbMatchFlow
-            movies={unmatchedMovies}
-            onClose={() => setMatchFlowOpen(false)}
-          />
+          <TmdbMatchFlow movies={unmatchedMovies} onClose={() => setMatchFlowOpen(false)} />
         )}
 
         {/* Unauthenticated prompt */}
         {!isAuthenticated && movies.length === 0 && (
-          <Typography
-            level="body-sm"
-            sx={{ textAlign: "center", color: "text.tertiary", mb: 4 }}
-          >
+          <Typography level="body-sm" sx={{ textAlign: 'center', color: 'text.tertiary', mb: 4 }}>
             Sign in to suggest movies.
           </Typography>
         )}
@@ -540,24 +544,41 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
                 {combinedData.combinedList.rankings.length === 0 ? (
                   <Box sx={{ textAlign: 'center', py: 6 }}>
                     <Typography level="body-md" sx={{ color: 'text.secondary' }}>
-                      No rankings to combine yet. Both users need to do some "This or That" comparisons first!
+                      No rankings to combine yet. Both users need to do some "This or That"
+                      comparisons first!
                     </Typography>
                   </Box>
                 ) : (
                   <Sheet
                     variant="outlined"
-                    sx={{ borderRadius: 'md', overflow: 'clip', borderColor: 'var(--mn-border-vis)' }}
+                    sx={{
+                      borderRadius: 'md',
+                      overflow: 'clip',
+                      borderColor: 'var(--mn-border-vis)',
+                    }}
                   >
                     <Box sx={{ overflowX: 'auto' }}>
-                      <table style={{ width: '100%', minWidth: 480, borderCollapse: 'collapse', tableLayout: 'auto' }}>
+                      <table
+                        style={{
+                          width: '100%',
+                          minWidth: 480,
+                          borderCollapse: 'collapse',
+                          tableLayout: 'auto',
+                        }}
+                      >
                         <thead>
-                          <tr style={{ background: 'var(--mn-bg-elevated)', borderBottom: '1px solid var(--mn-border-vis)' }}>
+                          <tr
+                            style={{
+                              background: 'var(--mn-bg-elevated)',
+                              borderBottom: '1px solid var(--mn-border-vis)',
+                            }}
+                          >
                             <th style={combinedThStyle}>#</th>
                             <th style={{ ...combinedThStyle, textAlign: 'left' }}>Title</th>
                             <th style={combinedThStyle}>You</th>
                             <th style={combinedThStyle}>
                               {combinedData.combinedList.connection.user.display_name ||
-                               combinedData.combinedList.connection.user.username}
+                                combinedData.combinedList.connection.user.username}
                             </th>
                             <th style={combinedThStyle}>Combined</th>
                           </tr>
@@ -566,7 +587,13 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
                           {combinedData.combinedList.rankings.map((r: any, idx: number) => (
                             <tr key={r.movie.id}>
                               <td style={{ ...combinedTdStyle, textAlign: 'center', width: 48 }}>
-                                <Typography level="body-xs" sx={{ fontWeight: 700, color: idx < 3 ? 'primary.400' : 'text.tertiary' }}>
+                                <Typography
+                                  level="body-xs"
+                                  sx={{
+                                    fontWeight: 700,
+                                    color: idx < 3 ? 'primary.400' : 'text.tertiary',
+                                  }}
+                                >
                                   {idx + 1}
                                 </Typography>
                               </td>
@@ -576,26 +603,40 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
                                     {r.movie.title}
                                   </Typography>
                                   {!r.bothRated && (
-                                    <Chip size="sm" variant="soft" color="neutral">partial</Chip>
+                                    <Chip size="sm" variant="soft" color="neutral">
+                                      partial
+                                    </Chip>
                                   )}
                                 </Box>
                               </td>
                               <td style={{ ...combinedTdStyle, textAlign: 'center' }}>
                                 {r.userAElo != null ? (
-                                  <Chip size="sm" variant="soft" color={r.userAElo >= 1000 ? 'success' : 'warning'}>
+                                  <Chip
+                                    size="sm"
+                                    variant="soft"
+                                    color={r.userAElo >= 1000 ? 'success' : 'warning'}
+                                  >
                                     {Math.round(r.userAElo)}
                                   </Chip>
                                 ) : (
-                                  <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>--</Typography>
+                                  <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+                                    --
+                                  </Typography>
                                 )}
                               </td>
                               <td style={{ ...combinedTdStyle, textAlign: 'center' }}>
                                 {r.userBElo != null ? (
-                                  <Chip size="sm" variant="soft" color={r.userBElo >= 1000 ? 'success' : 'warning'}>
+                                  <Chip
+                                    size="sm"
+                                    variant="soft"
+                                    color={r.userBElo >= 1000 ? 'success' : 'warning'}
+                                  >
                                     {Math.round(r.userBElo)}
                                   </Chip>
                                 ) : (
-                                  <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>--</Typography>
+                                  <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+                                    --
+                                  </Typography>
                                 )}
                               </td>
                               <td style={{ ...combinedTdStyle, textAlign: 'center' }}>
@@ -617,132 +658,132 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
 
         {/* Movie table (personal view) */}
         {!isCombinedView && (
-        <Sheet
-          variant="outlined"
-          sx={{
-            borderRadius: "md",
-            overflow: "clip",
-            borderColor: "var(--mn-border-vis)",
-          }}
-        >
-          <Box sx={{ overflowX: "auto" }}>
-            <table
-              style={{
-                width: "100%",
-                minWidth: 540,
-                borderCollapse: "collapse",
-                tableLayout: "auto",
-              }}
-            >
-              <thead>
-                <tr
-                  style={{
-                    background: "var(--mn-bg-elevated)",
-                    borderBottom: "1px solid var(--mn-border-vis)",
-                  }}
-                >
-                  <th
+          <Sheet
+            variant="outlined"
+            sx={{
+              borderRadius: 'md',
+              overflow: 'clip',
+              borderColor: 'var(--mn-border-vis)',
+            }}
+          >
+            <Box sx={{ overflowX: 'auto' }}>
+              <table
+                style={{
+                  width: '100%',
+                  minWidth: 540,
+                  borderCollapse: 'collapse',
+                  tableLayout: 'auto',
+                }}
+              >
+                <thead>
+                  <tr
                     style={{
-                      padding: "10px 16px",
-                      textAlign: "left",
-                      fontSize: "0.7rem",
-                      fontWeight: 700,
-                      textTransform: "uppercase",
-                      letterSpacing: "0.08em",
-                      color: "var(--mn-text-muted)",
+                      background: 'var(--mn-bg-elevated)',
+                      borderBottom: '1px solid var(--mn-border-vis)',
                     }}
                   >
-                    Title
-                  </th>
-                  <th
-                    style={{
-                      padding: "10px 16px",
-                      textAlign: "left",
-                      fontSize: "0.7rem",
-                      fontWeight: 700,
-                      textTransform: "uppercase",
-                      letterSpacing: "0.08em",
-                      color: "var(--mn-text-muted)",
-                    }}
-                  >
-                    Suggested by
-                  </th>
-                  <th
-                    style={{
-                      padding: "10px 16px",
-                      textAlign: "left",
-                      fontSize: "0.7rem",
-                      fontWeight: 700,
-                      textTransform: "uppercase",
-                      letterSpacing: "0.08em",
-                      color: "var(--mn-text-muted)",
-                    }}
-                  >
-                    Added
-                  </th>
-                  <th
-                    style={{
-                      padding: "10px 8px",
-                      textAlign: "center",
-                      fontSize: "0.7rem",
-                      fontWeight: 700,
-                      textTransform: "uppercase",
-                      letterSpacing: "0.08em",
-                      color: "var(--mn-text-muted)",
-                    }}
-                  >
-                    TMDB
-                  </th>
-                  {isAuthenticated && (
                     <th
                       style={{
-                        padding: "10px 12px",
-                        textAlign: "right",
-                        fontSize: "0.7rem",
+                        padding: '10px 16px',
+                        textAlign: 'left',
+                        fontSize: '0.7rem',
                         fontWeight: 700,
-                        textTransform: "uppercase",
-                        letterSpacing: "0.08em",
-                        color: "var(--mn-text-muted)",
-                      }}
-                    />
-                  )}
-                </tr>
-              </thead>
-              <tbody>
-                {movies.length === 0 ? (
-                  <tr>
-                    <td
-                      colSpan={colCount}
-                      style={{
-                        padding: "48px 16px",
-                        textAlign: "center",
-                        color: "var(--mn-text-muted)",
-                        fontSize: "0.875rem",
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.08em',
+                        color: 'var(--mn-text-muted)',
                       }}
                     >
-                      No movies yet. Be the first to suggest one!
-                    </td>
+                      Title
+                    </th>
+                    <th
+                      style={{
+                        padding: '10px 16px',
+                        textAlign: 'left',
+                        fontSize: '0.7rem',
+                        fontWeight: 700,
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.08em',
+                        color: 'var(--mn-text-muted)',
+                      }}
+                    >
+                      Suggested by
+                    </th>
+                    <th
+                      style={{
+                        padding: '10px 16px',
+                        textAlign: 'left',
+                        fontSize: '0.7rem',
+                        fontWeight: 700,
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.08em',
+                        color: 'var(--mn-text-muted)',
+                      }}
+                    >
+                      Added
+                    </th>
+                    <th
+                      style={{
+                        padding: '10px 8px',
+                        textAlign: 'center',
+                        fontSize: '0.7rem',
+                        fontWeight: 700,
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.08em',
+                        color: 'var(--mn-text-muted)',
+                      }}
+                    >
+                      TMDB
+                    </th>
+                    {isAuthenticated && (
+                      <th
+                        style={{
+                          padding: '10px 12px',
+                          textAlign: 'right',
+                          fontSize: '0.7rem',
+                          fontWeight: 700,
+                          textTransform: 'uppercase',
+                          letterSpacing: '0.08em',
+                          color: 'var(--mn-text-muted)',
+                        }}
+                      />
+                    )}
                   </tr>
-                ) : (
-                  movies.map((movie) => (
-                    <MovieRow
-                      key={movie.id}
-                      movie={movie}
-                      isAdmin={isAdmin}
-                      canMarkWatched={
-                        isAdmin ||
-                        (isAuthenticated && String(movie.requested_by) === String(user?.id))
-                      }
-                      onMarkWatched={handleMarkWatched}
-                      onDelete={handleDelete}
-                      isAuthenticated={isAuthenticated}
-                    />
-                  ))
-                )}
-              </tbody>
-            </table>
-          </Box>
-        </Sheet>
+                </thead>
+                <tbody>
+                  {movies.length === 0 ? (
+                    <tr>
+                      <td
+                        colSpan={colCount}
+                        style={{
+                          padding: '48px 16px',
+                          textAlign: 'center',
+                          color: 'var(--mn-text-muted)',
+                          fontSize: '0.875rem',
+                        }}
+                      >
+                        No movies yet. Be the first to suggest one!
+                      </td>
+                    </tr>
+                  ) : (
+                    movies.map((movie) => (
+                      <MovieRow
+                        key={movie.id}
+                        movie={movie}
+                        isAdmin={isAdmin}
+                        canMarkWatched={
+                          isAdmin ||
+                          (isAuthenticated && String(movie.requested_by) === String(user?.id))
+                        }
+                        onMarkWatched={handleMarkWatched}
+                        onDelete={handleDelete}
+                        isAuthenticated={isAuthenticated}
+                      />
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </Box>
+          </Sheet>
         )}
 
         {/* Seed button — admin only, test env only */}

--- a/src/components/home/MovieCompareCard.tsx
+++ b/src/components/home/MovieCompareCard.tsx
@@ -31,11 +31,13 @@ const MovieCompareCard: React.FC<MovieCompareCardProps> = ({ movie, onPick, disa
       borderColor: 'divider',
       transition: 'border-color 0.2s, transform 0.15s, box-shadow 0.2s',
       opacity: disabled ? 0.5 : 1,
-      '&:hover': disabled ? {} : {
-        borderColor: 'primary.400',
-        transform: 'translateY(-2px)',
-        boxShadow: '0 8px 24px rgba(0,0,0,0.3)',
-      },
+      '&:hover': disabled
+        ? {}
+        : {
+            borderColor: 'primary.400',
+            transform: 'translateY(-2px)',
+            boxShadow: '0 8px 24px rgba(0,0,0,0.3)',
+          },
       display: 'flex',
       flexDirection: 'column',
     }}
@@ -114,7 +116,10 @@ const MovieCompareCard: React.FC<MovieCompareCardProps> = ({ movie, onPick, disa
           color="primary"
           fullWidth
           disabled={disabled}
-          onClick={(e) => { e.stopPropagation(); onPick(movie.id); }}
+          onClick={(e) => {
+            e.stopPropagation();
+            onPick(movie.id);
+          }}
           sx={{ fontWeight: 700, color: '#0d0f1a' }}
         >
           Pick This One

--- a/src/components/home/ThisOrThat.tsx
+++ b/src/components/home/ThisOrThat.tsx
@@ -20,17 +20,18 @@ const ThisOrThat: React.FC = () => {
 
   const [fetchPair, { data: pairData, loading: pairLoading, error: pairError }] = useLazyQuery(
     THIS_OR_THAT,
-    { fetchPolicy: 'network-only' }
+    { fetchPolicy: 'network-only' },
   );
 
   const [recordComparison, { loading: recording }] = useMutation(RECORD_COMPARISON, {
     refetchQueries: [{ query: GET_MOVIES }],
   });
 
-  const { data: rankingsData, loading: rankingsLoading, refetch: refetchRankings } = useQuery(
-    MY_RANKINGS,
-    { skip: tab !== 'rankings' }
-  );
+  const {
+    data: rankingsData,
+    loading: rankingsLoading,
+    refetch: refetchRankings,
+  } = useQuery(MY_RANKINGS, { skip: tab !== 'rankings' });
 
   const [resetComparisons] = useMutation(RESET_MOVIE_COMPARISONS, {
     refetchQueries: [{ query: MY_RANKINGS }, { query: GET_MOVIES }],
@@ -40,7 +41,7 @@ const ThisOrThat: React.FC = () => {
     (excludeIds: string[] = []) => {
       fetchPair({ variables: { excludeIds } });
     },
-    [fetchPair]
+    [fetchPair],
   );
 
   // Load first pair on mount
@@ -90,7 +91,7 @@ const ThisOrThat: React.FC = () => {
   };
 
   const isNotEnoughMovies = pairError?.graphQLErrors?.some(
-    (e) => e.extensions?.code === 'BAD_USER_INPUT'
+    (e) => e.extensions?.code === 'BAD_USER_INPUT',
   );
 
   const pair = pairData?.thisOrThat;
@@ -146,7 +147,10 @@ const ThisOrThat: React.FC = () => {
           <>
             {/* Session counter */}
             {sessionCount > 0 && (
-              <Typography level="body-xs" sx={{ textAlign: 'center', mb: 2, color: 'text.tertiary' }}>
+              <Typography
+                level="body-xs"
+                sx={{ textAlign: 'center', mb: 2, color: 'text.tertiary' }}
+              >
                 {sessionCount} comparison{sessionCount !== 1 ? 's' : ''} this session
               </Typography>
             )}
@@ -183,11 +187,17 @@ const ThisOrThat: React.FC = () => {
                       borderColor: 'divider',
                     }}
                   >
-                    <Skeleton variant="rectangular" sx={{ width: '100%', aspectRatio: { xs: '3/4', sm: '2/3' } }} />
+                    <Skeleton
+                      variant="rectangular"
+                      sx={{ width: '100%', aspectRatio: { xs: '3/4', sm: '2/3' } }}
+                    />
                     <Box sx={{ p: { xs: 1, sm: 2 } }}>
                       <Skeleton variant="text" sx={{ width: '70%', mb: 1 }} />
                       <Skeleton variant="text" sx={{ width: '50%', mb: 1 }} />
-                      <Skeleton variant="rectangular" sx={{ width: '100%', height: 36, borderRadius: 'sm' }} />
+                      <Skeleton
+                        variant="rectangular"
+                        sx={{ width: '100%', height: 36, borderRadius: 'sm' }}
+                      />
                     </Box>
                   </Box>
                 ))}
@@ -215,7 +225,13 @@ const ThisOrThat: React.FC = () => {
                   />
                 </Box>
 
-                <Box sx={{ display: { xs: 'none', sm: 'flex' }, alignItems: 'center', justifyContent: 'center' }}>
+                <Box
+                  sx={{
+                    display: { xs: 'none', sm: 'flex' },
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
                   <Typography
                     level="h4"
                     sx={{ fontWeight: 800, color: 'text.tertiary', userSelect: 'none' }}
@@ -240,17 +256,20 @@ const ThisOrThat: React.FC = () => {
           <>
             {rankingsLoading && (
               <Box sx={{ textAlign: 'center', py: 4 }}>
-                <Typography level="body-sm" sx={{ color: 'text.secondary' }}>Loading rankings...</Typography>
-              </Box>
-            )}
-
-            {!rankingsLoading && (!rankingsData?.myRankings || rankingsData.myRankings.length === 0) && (
-              <Box sx={{ textAlign: 'center', py: 6 }}>
-                <Typography level="body-md" sx={{ color: 'text.secondary' }}>
-                  No rankings yet. Compare some movies to see your preferences!
+                <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
+                  Loading rankings...
                 </Typography>
               </Box>
             )}
+
+            {!rankingsLoading &&
+              (!rankingsData?.myRankings || rankingsData.myRankings.length === 0) && (
+                <Box sx={{ textAlign: 'center', py: 6 }}>
+                  <Typography level="body-md" sx={{ color: 'text.secondary' }}>
+                    No rankings yet. Compare some movies to see your preferences!
+                  </Typography>
+                </Box>
+              )}
 
             {!rankingsLoading && rankingsData?.myRankings?.length > 0 && (
               <Sheet
@@ -260,7 +279,12 @@ const ThisOrThat: React.FC = () => {
                 <Box sx={{ overflowX: 'auto' }}>
                   <table style={{ width: '100%', borderCollapse: 'collapse', tableLayout: 'auto' }}>
                     <thead>
-                      <tr style={{ background: 'var(--mn-bg-elevated)', borderBottom: '1px solid var(--mn-border-vis)' }}>
+                      <tr
+                        style={{
+                          background: 'var(--mn-bg-elevated)',
+                          borderBottom: '1px solid var(--mn-border-vis)',
+                        }}
+                      >
                         <th style={thStyle}>#</th>
                         <th style={{ ...thStyle, textAlign: 'left' }}>Title</th>
                         <th style={thStyle}>Elo</th>
@@ -272,7 +296,13 @@ const ThisOrThat: React.FC = () => {
                       {rankingsData.myRankings.map((r: any, idx: number) => (
                         <tr key={r.movie.id}>
                           <td style={{ ...tdStyle, textAlign: 'center', width: 48 }}>
-                            <Typography level="body-xs" sx={{ fontWeight: 700, color: idx < 3 ? 'primary.400' : 'text.tertiary' }}>
+                            <Typography
+                              level="body-xs"
+                              sx={{
+                                fontWeight: 700,
+                                color: idx < 3 ? 'primary.400' : 'text.tertiary',
+                              }}
+                            >
                               {idx + 1}
                             </Typography>
                           </td>
@@ -282,7 +312,11 @@ const ThisOrThat: React.FC = () => {
                             </Typography>
                           </td>
                           <td style={{ ...tdStyle, textAlign: 'center' }}>
-                            <Chip size="sm" variant="soft" color={r.eloRating >= 1000 ? 'success' : 'warning'}>
+                            <Chip
+                              size="sm"
+                              variant="soft"
+                              color={r.eloRating >= 1000 ? 'success' : 'warning'}
+                            >
                               {Math.round(r.eloRating)}
                             </Chip>
                           </td>

--- a/src/components/home/TmdbMatchFlow.tsx
+++ b/src/components/home/TmdbMatchFlow.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect } from "react";
-import { useLazyQuery, useMutation } from "@apollo/client";
-import { SEARCH_TMDB, MATCH_MOVIE, GET_MOVIES } from "../../graphql/queries";
+import React, { useState, useEffect } from 'react';
+import { useLazyQuery, useMutation } from '@apollo/client';
+import { SEARCH_TMDB, MATCH_MOVIE, GET_MOVIES } from '../../graphql/queries';
 import {
   Modal,
   ModalDialog,
@@ -10,8 +10,8 @@ import {
   Box,
   CircularProgress,
   Divider,
-} from "@mui/joy";
-import { Movie } from "../../models/Movies";
+} from '@mui/joy';
+import { Movie } from '../../models/Movies';
 
 type TmdbResult = {
   tmdb_id: number;
@@ -34,9 +34,12 @@ const TmdbMatchFlow: React.FC<Props> = ({ movies, onClose }) => {
   const [searchError, setSearchError] = useState<string | null>(null);
 
   const [searchTmdb, { loading: searching }] = useLazyQuery(SEARCH_TMDB, {
-    onCompleted: (d) => { setResults(d.searchTmdb || []); setSearchError(null); },
+    onCompleted: (d) => {
+      setResults(d.searchTmdb || []);
+      setSearchError(null);
+    },
     onError: (e) => setSearchError(e.message),
-    fetchPolicy: "network-only",
+    fetchPolicy: 'network-only',
   });
 
   const [matchMovie, { loading: matching }] = useMutation(MATCH_MOVIE, {
@@ -66,13 +69,13 @@ const TmdbMatchFlow: React.FC<Props> = ({ movies, onClose }) => {
 
   return (
     <Modal open onClose={onClose}>
-      <ModalDialog sx={{ maxWidth: 460, width: "100%", p: 3 }}>
+      <ModalDialog sx={{ maxWidth: 460, width: '100%', p: 3 }}>
         <ModalClose />
 
         {!current ? (
           <>
             <Typography level="title-md">All done!</Typography>
-            <Typography level="body-sm" sx={{ color: "text.secondary", mt: 0.5 }}>
+            <Typography level="body-sm" sx={{ color: 'text.secondary', mt: 0.5 }}>
               No more unmatched movies.
             </Typography>
             <Button onClick={onClose} sx={{ mt: 2 }}>
@@ -83,34 +86,42 @@ const TmdbMatchFlow: React.FC<Props> = ({ movies, onClose }) => {
           <>
             <Box sx={{ mb: 2 }}>
               <Typography level="title-md">Match with TMDB</Typography>
-              <Typography level="body-xs" sx={{ color: "text.tertiary", mt: 0.25 }}>
+              <Typography level="body-xs" sx={{ color: 'text.tertiary', mt: 0.25 }}>
                 {index + 1} of {movies.length}
               </Typography>
             </Box>
 
-            <Typography
-              level="body-sm"
-              sx={{ fontWeight: 600, mb: 1.5 }}
-            >
+            <Typography level="body-sm" sx={{ fontWeight: 600, mb: 1.5 }}>
               "{current.title}"
             </Typography>
 
             <Divider sx={{ mb: 1.5 }} />
 
             {searching ? (
-              <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
+              <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
                 <CircularProgress size="sm" />
               </Box>
             ) : searchError ? (
-              <Typography level="body-sm" sx={{ color: "danger.400", py: 2, textAlign: "center" }}>
+              <Typography level="body-sm" sx={{ color: 'danger.400', py: 2, textAlign: 'center' }}>
                 Search failed: {searchError}
               </Typography>
             ) : results.length === 0 ? (
-              <Typography level="body-sm" sx={{ color: "text.tertiary", py: 2, textAlign: "center" }}>
+              <Typography
+                level="body-sm"
+                sx={{ color: 'text.tertiary', py: 2, textAlign: 'center' }}
+              >
                 No results found.
               </Typography>
             ) : (
-              <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75, maxHeight: 320, overflowY: "auto" }}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 0.75,
+                  maxHeight: 320,
+                  overflowY: 'auto',
+                }}
+              >
                 {results.map((r) => (
                   <Button
                     key={r.tmdb_id}
@@ -119,8 +130,8 @@ const TmdbMatchFlow: React.FC<Props> = ({ movies, onClose }) => {
                     disabled={matching}
                     onClick={() => handlePick(r.tmdb_id, r.title)}
                     sx={{
-                      justifyContent: "flex-start",
-                      textAlign: "left",
+                      justifyContent: 'flex-start',
+                      textAlign: 'left',
                       fontWeight: 500,
                       px: 1.5,
                     }}
@@ -130,7 +141,7 @@ const TmdbMatchFlow: React.FC<Props> = ({ movies, onClose }) => {
                       <Typography
                         component="span"
                         level="body-xs"
-                        sx={{ ml: 1, color: "text.tertiary" }}
+                        sx={{ ml: 1, color: 'text.tertiary' }}
                       >
                         {r.release_year}
                       </Typography>
@@ -145,7 +156,7 @@ const TmdbMatchFlow: React.FC<Props> = ({ movies, onClose }) => {
               color="neutral"
               onClick={advance}
               disabled={matching}
-              sx={{ mt: 2, alignSelf: "flex-end" }}
+              sx={{ mt: 2, alignSelf: 'flex-end' }}
             >
               Skip
             </Button>

--- a/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/contexts/__tests__/AuthContext.test.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { render, act, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// Mock Apollo Client
+const mockGetMe = jest.fn();
+const mockClearStore = jest.fn();
+
+jest.mock('@apollo/client', () => ({
+  ...jest.requireActual('@apollo/client'),
+  useLazyQuery: () => [mockGetMe],
+  useApolloClient: () => ({ clearStore: mockClearStore }),
+  gql: (strings: TemplateStringsArray) => strings[0],
+}));
+
+import { AuthProvider, useAuth } from '../AuthContext';
+
+// Test component that exposes auth context
+function TestConsumer() {
+  const { user, isAuthenticated, isLoading, login, logout } = useAuth();
+  return (
+    <div>
+      <span data-testid="loading">{String(isLoading)}</span>
+      <span data-testid="authenticated">{String(isAuthenticated)}</span>
+      <span data-testid="username">{user?.username ?? 'none'}</span>
+      <button
+        data-testid="login-btn"
+        onClick={() =>
+          login('tok', {
+            id: 1,
+            username: 'alice',
+            email: 'a@b.com',
+            display_name: 'Alice',
+            is_admin: false,
+            is_active: true,
+          } as any)
+        }
+      >
+        Login
+      </button>
+      <button data-testid="logout-btn" onClick={() => logout()}>
+        Logout
+      </button>
+    </div>
+  );
+}
+
+describe('AuthProvider', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockGetMe.mockReset();
+    mockClearStore.mockReset();
+  });
+
+  it('on mount with no token: isAuthenticated is false', async () => {
+    mockGetMe.mockResolvedValue({ data: null });
+    await act(async () => {
+      render(
+        <AuthProvider>
+          <TestConsumer />
+        </AuthProvider>,
+      );
+    });
+    expect(screen.getByTestId('authenticated').textContent).toBe('false');
+    expect(screen.getByTestId('username').textContent).toBe('none');
+  });
+
+  it('on mount with valid token: sets user from getMe', async () => {
+    localStorage.setItem('authToken', 'valid-token');
+    mockGetMe.mockResolvedValue({
+      data: { me: { id: 1, username: 'alice', display_name: 'Alice' } },
+    });
+    await act(async () => {
+      render(
+        <AuthProvider>
+          <TestConsumer />
+        </AuthProvider>,
+      );
+    });
+    expect(screen.getByTestId('authenticated').textContent).toBe('true');
+    expect(screen.getByTestId('username').textContent).toBe('alice');
+  });
+
+  it('on mount with token but getMe fails: removes token', async () => {
+    localStorage.setItem('authToken', 'bad-token');
+    mockGetMe.mockRejectedValue(new Error('Unauthorized'));
+    await act(async () => {
+      render(
+        <AuthProvider>
+          <TestConsumer />
+        </AuthProvider>,
+      );
+    });
+    expect(localStorage.getItem('authToken')).toBeNull();
+    expect(screen.getByTestId('authenticated').textContent).toBe('false');
+  });
+});
+
+describe('login', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockGetMe.mockResolvedValue({ data: null });
+    mockClearStore.mockReset();
+  });
+
+  it('stores token in localStorage and sets user', async () => {
+    await act(async () => {
+      render(
+        <AuthProvider>
+          <TestConsumer />
+        </AuthProvider>,
+      );
+    });
+    await act(async () => {
+      screen.getByTestId('login-btn').click();
+    });
+    expect(localStorage.getItem('authToken')).toBe('tok');
+    expect(screen.getByTestId('username').textContent).toBe('alice');
+    expect(mockClearStore).toHaveBeenCalled();
+  });
+});
+
+describe('logout', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockGetMe.mockResolvedValue({ data: null });
+    mockClearStore.mockReset();
+  });
+
+  it('removes token and clears user', async () => {
+    await act(async () => {
+      render(
+        <AuthProvider>
+          <TestConsumer />
+        </AuthProvider>,
+      );
+    });
+    // Login first
+    await act(async () => {
+      screen.getByTestId('login-btn').click();
+    });
+    expect(screen.getByTestId('authenticated').textContent).toBe('true');
+
+    // Now logout
+    await act(async () => {
+      screen.getByTestId('logout-btn').click();
+    });
+    expect(localStorage.getItem('authToken')).toBeNull();
+    expect(screen.getByTestId('authenticated').textContent).toBe('false');
+    expect(mockClearStore).toHaveBeenCalledTimes(2); // login + logout
+  });
+});
+
+describe('useAuth', () => {
+  it('throws when used outside AuthProvider', () => {
+    // Suppress console.error for expected error
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    expect(() => render(<TestConsumer />)).toThrow('useAuth must be used within an AuthProvider');
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -127,8 +127,22 @@ export const GET_USERS = gql`
 `;
 
 export const CREATE_USER = gql`
-  mutation CreateUser($username: String!, $email: String!, $password: String!, $display_name: String, $is_admin: Boolean, $is_active: Boolean) {
-    createUser(username: $username, email: $email, password: $password, display_name: $display_name, is_admin: $is_admin, is_active: $is_active) {
+  mutation CreateUser(
+    $username: String!
+    $email: String!
+    $password: String!
+    $display_name: String
+    $is_admin: Boolean
+    $is_active: Boolean
+  ) {
+    createUser(
+      username: $username
+      email: $email
+      password: $password
+      display_name: $display_name
+      is_admin: $is_admin
+      is_active: $is_active
+    ) {
       id
       username
       email
@@ -143,8 +157,24 @@ export const CREATE_USER = gql`
 `;
 
 export const UPDATE_USER = gql`
-  mutation UpdateUser($id: ID!, $username: String, $email: String, $password: String, $display_name: String, $is_admin: Boolean, $is_active: Boolean) {
-    updateUser(id: $id, username: $username, email: $email, password: $password, display_name: $display_name, is_admin: $is_admin, is_active: $is_active) {
+  mutation UpdateUser(
+    $id: ID!
+    $username: String
+    $email: String
+    $password: String
+    $display_name: String
+    $is_admin: Boolean
+    $is_active: Boolean
+  ) {
+    updateUser(
+      id: $id
+      username: $username
+      email: $email
+      password: $password
+      display_name: $display_name
+      is_admin: $is_admin
+      is_active: $is_active
+    ) {
       id
       username
       email

--- a/src/index.css
+++ b/src/index.css
@@ -1,26 +1,30 @@
 /* ── Design tokens ─────────────────────────────────────────────────────── */
 :root {
-  --mn-bg-base:      #0d0f1a;
-  --mn-bg-surface:   #141624;
-  --mn-bg-elevated:  #1c1f30;
-  --mn-bg-hover:     rgba(255, 255, 255, 0.04);
-  --mn-border:       rgba(255, 255, 255, 0.08);
-  --mn-border-vis:   #2a2e4a;
-  --mn-gold:         #f5c518;
-  --mn-gold-dim:     #c9a000;
+  --mn-bg-base: #0d0f1a;
+  --mn-bg-surface: #141624;
+  --mn-bg-elevated: #1c1f30;
+  --mn-bg-hover: rgba(255, 255, 255, 0.04);
+  --mn-border: rgba(255, 255, 255, 0.08);
+  --mn-border-vis: #2a2e4a;
+  --mn-gold: #f5c518;
+  --mn-gold-dim: #c9a000;
   --mn-text-primary: #f0f2f8;
   --mn-text-secondary: #9097b8;
-  --mn-text-muted:   #565a7a;
-  --mn-danger:       #e04040;
-  --mn-success:      #4caf82;
+  --mn-text-muted: #565a7a;
+  --mn-danger: #e04040;
+  --mn-success: #4caf82;
 }
 
 /* ── Reset & base ──────────────────────────────────────────────────────── */
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
-html, body, #root {
+html,
+body,
+#root {
   height: 100%;
 }
 
@@ -28,8 +32,9 @@ body {
   margin: 0;
   background-color: var(--mn-bg-base);
   color: var(--mn-text-primary);
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell',
+    'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,9 +9,7 @@ import client from './graphql/client';
 import { AuthProvider } from './contexts/AuthContext';
 import theme from './theme';
 
-const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
-);
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <React.StrictMode>
     <CssVarsProvider theme={theme} defaultMode="dark">
@@ -22,5 +20,5 @@ root.render(
         </AuthProvider>
       </ApolloProvider>
     </CssVarsProvider>
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/src/utils/__tests__/gravatar.test.ts
+++ b/src/utils/__tests__/gravatar.test.ts
@@ -1,0 +1,36 @@
+import { getGravatarUrl } from '../gravatar';
+
+describe('getGravatarUrl', () => {
+  it('returns a Gravatar URL with MD5 hash', () => {
+    const url = getGravatarUrl('test@example.com');
+    expect(url).toMatch(/^https:\/\/www\.gravatar\.com\/avatar\/[a-f0-9]{32}/);
+  });
+
+  it('default size is 32', () => {
+    const url = getGravatarUrl('test@example.com');
+    expect(url).toContain('s=32');
+  });
+
+  it('custom size parameter is included', () => {
+    const url = getGravatarUrl('test@example.com', 128);
+    expect(url).toContain('s=128');
+  });
+
+  it('trims whitespace from email', () => {
+    const url1 = getGravatarUrl('  test@example.com  ');
+    const url2 = getGravatarUrl('test@example.com');
+    expect(url1).toBe(url2);
+  });
+
+  it('lowercases email before hashing', () => {
+    const url1 = getGravatarUrl('TEST@Example.COM');
+    const url2 = getGravatarUrl('test@example.com');
+    expect(url1).toBe(url2);
+  });
+
+  it('is deterministic', () => {
+    const url1 = getGravatarUrl('user@test.com');
+    const url2 = getGravatarUrl('user@test.com');
+    expect(url1).toBe(url2);
+  });
+});

--- a/src/utils/__tests__/textUtils.test.ts
+++ b/src/utils/__tests__/textUtils.test.ts
@@ -1,0 +1,23 @@
+import { columnNameToDisplayName } from '../textUtils';
+
+describe('columnNameToDisplayName', () => {
+  it('converts snake_case to Title Case', () => {
+    expect(columnNameToDisplayName('some_column')).toBe('Some Column');
+  });
+
+  it('handles single word', () => {
+    expect(columnNameToDisplayName('name')).toBe('Name');
+  });
+
+  it('handles multiple underscores', () => {
+    expect(columnNameToDisplayName('a_b_c')).toBe('A B C');
+  });
+
+  it('handles empty string', () => {
+    expect(columnNameToDisplayName('')).toBe('');
+  });
+
+  it('handles already capitalized words', () => {
+    expect(columnNameToDisplayName('Display_Name')).toBe('Display Name');
+  });
+});

--- a/src/utils/textUtils.ts
+++ b/src/utils/textUtils.ts
@@ -1,6 +1,6 @@
 export function columnNameToDisplayName(columnName: string) {
   return columnName
-    .split("_")
+    .split('_')
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
+    .join(' ');
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,7 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- **192 backend tests** (Jest + ts-jest) covering auth, elo, pair selection, all resolvers, scheduler, and email
- **21 frontend tests** covering AuthContext, textUtils, gravatar, and App component
- **Prettier** formatting (shared root config) + **ESLint** for backend TypeScript
- **Husky + lint-staged** pre-commit hooks enforce formatting on every commit
- **CI workflow** runs lint + tests on all PRs (including drafts) and all branch pushes
- **Coverage thresholds**: 80% statements/lines/functions, 65% branches (backend)
- Updated `CLAUDE.md` with testing requirements and going-forward coverage policy

## Test plan
- [x] All 192 backend tests pass (`cd backend && npm test`)
- [x] All 21 frontend tests pass (`npm test -- --watchAll=false`)
- [x] Prettier check passes (`npx prettier --check .`)
- [x] ESLint passes (`cd backend && npx eslint src/`)
- [x] Pre-commit hook runs lint-staged successfully
- [ ] CI workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)