### PR TITLE
feat: cache TMDB metadata in DB for instant This or That

### DIFF
--- a/backend/migrations/1745900000000_add-tmdb-metadata-to-movies.js
+++ b/backend/migrations/1745900000000_add-tmdb-metadata-to-movies.js
@@ -1,0 +1,21 @@
+exports.up = (pgm) => {
+  pgm.addColumns('movies', {
+    poster_path: { type: 'text' },
+    release_year: { type: 'text' },
+    director: { type: 'text' },
+    cast_list: { type: 'text[]' },
+    genre_tags: { type: 'text[]' },
+    tmdb_fetched_at: { type: 'timestamptz' },
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropColumns('movies', [
+    'poster_path',
+    'release_year',
+    'director',
+    'cast_list',
+    'genre_tags',
+    'tmdb_fetched_at',
+  ]);
+};

--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -153,10 +153,10 @@ async function fetchAndStoreTmdbData(movieId: number, tmdbId: number): Promise<v
        SET poster_path = $1, release_year = $2, director = $3,
            cast_list = $4, genre_tags = $5, tmdb_fetched_at = NOW()
        WHERE id = $6`,
-      [posterPath, releaseYear, director, castList, tags, movieId]
+      [posterPath, releaseYear, director, castList, tags, movieId],
     );
   } catch (err) {
-    console.error(`TMDB fetch+store failed for movie ${movieId} (tmdb ${tmdbId}):`, err);
+    console.error('TMDB fetch+store failed for movie %d (tmdb %d):', movieId, tmdbId, err);
   }
 }
 
@@ -424,9 +424,7 @@ export const resolvers = {
           id: String(candidate.id),
           title: candidate.title,
           tmdb_id: candidate.tmdb_id,
-          poster_url: row.poster_path
-            ? `https://image.tmdb.org/t/p/w342${row.poster_path}`
-            : null,
+          poster_url: row.poster_path ? `https://image.tmdb.org/t/p/w342${row.poster_path}` : null,
           release_year: row.release_year ?? null,
           director: row.director ?? null,
           cast: row.cast_list ?? [],
@@ -1564,7 +1562,7 @@ export const resolvers = {
       }
       // Find movies with tmdb_id but no cached metadata
       const result = await pool.query(
-        `SELECT id, tmdb_id FROM movies WHERE tmdb_id IS NOT NULL AND tmdb_fetched_at IS NULL`
+        `SELECT id, tmdb_id FROM movies WHERE tmdb_id IS NOT NULL AND tmdb_fetched_at IS NULL`,
       );
       let count = 0;
       for (const row of result.rows) {

--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -120,32 +120,11 @@ setInterval(
   15 * 60 * 1000,
 ).unref();
 
-// ── TMDB enrichment cache ────────────────────────────────────────────────────
+// ── TMDB metadata: fetch from API and persist to DB ──────────────────────────
 
-interface TmdbCacheEntry {
-  data: TmdbEnrichment;
-  expiresAt: number;
-}
-
-interface TmdbEnrichment {
-  poster_url: string | null;
-  release_year: string | null;
-  director: string | null;
-  cast: string[];
-  tags: string[];
-}
-
-const tmdbCache = new Map<number, TmdbCacheEntry>();
-const TMDB_CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
-
-async function enrichWithTmdb(tmdbId: number): Promise<TmdbEnrichment> {
-  const cached = tmdbCache.get(tmdbId);
-  if (cached && cached.expiresAt > Date.now()) return cached.data;
-
+async function fetchAndStoreTmdbData(movieId: number, tmdbId: number): Promise<void> {
   const apiKey = process.env.TMDB_API_KEY;
-  if (!apiKey) {
-    return { poster_url: null, release_year: null, director: null, cast: [], tags: [] };
-  }
+  if (!apiKey) return;
 
   try {
     const [movieRes, creditsRes, keywordsRes] = await Promise.all([
@@ -162,22 +141,22 @@ async function enrichWithTmdb(tmdbId: number): Promise<TmdbEnrichment> {
 
     const genres: string[] = movie?.genres?.map((g: any) => g.name) ?? [];
     const keywordNames: string[] = keywords?.keywords?.map((k: any) => k.name) ?? [];
-    // Fill tags: genres first, then keywords, up to 5
     const tags = [...genres, ...keywordNames.filter((k) => !genres.includes(k))].slice(0, 5);
 
-    const data: TmdbEnrichment = {
-      poster_url: movie?.poster_path ? `https://image.tmdb.org/t/p/w342${movie.poster_path}` : null,
-      release_year: movie?.release_date ? movie.release_date.split('-')[0] : null,
-      director: credits?.crew?.find((c: any) => c.job === 'Director')?.name ?? null,
-      cast: (credits?.cast ?? []).slice(0, 3).map((c: any) => c.name),
-      tags,
-    };
+    const posterPath = movie?.poster_path ?? null;
+    const releaseYear = movie?.release_date ? movie.release_date.split('-')[0] : null;
+    const director = credits?.crew?.find((c: any) => c.job === 'Director')?.name ?? null;
+    const castList = (credits?.cast ?? []).slice(0, 3).map((c: any) => c.name);
 
-    tmdbCache.set(tmdbId, { data, expiresAt: Date.now() + TMDB_CACHE_TTL });
-    return data;
+    await pool.query(
+      `UPDATE movies
+       SET poster_path = $1, release_year = $2, director = $3,
+           cast_list = $4, genre_tags = $5, tmdb_fetched_at = NOW()
+       WHERE id = $6`,
+      [posterPath, releaseYear, director, castList, tags, movieId]
+    );
   } catch (err) {
-    console.error(`TMDB enrichment failed for ${tmdbId}:`, err);
-    return { poster_url: null, release_year: null, director: null, cast: [], tags: [] };
+    console.error(`TMDB fetch+store failed for movie ${movieId} (tmdb ${tmdbId}):`, err);
   }
 }
 
@@ -391,9 +370,10 @@ export const resolvers = {
       const userId = context.user.userId;
       const excludeIntIds = (excludeIds ?? []).map(Number).filter((n) => !isNaN(n));
 
-      // Fetch candidates, excluding recently seen
+      // Fetch candidates with cached TMDB metadata, excluding recently seen
       let candidatesResult = await pool.query(
         `SELECT m.id, m.title, m.tmdb_id,
+                m.poster_path, m.release_year, m.director, m.cast_list, m.genre_tags,
                 COALESCE(ume.comparison_count, 0) AS user_comparison_count,
                 COALESCE(ume.elo_rating, 1000) AS elo_rating
          FROM movies m
@@ -407,6 +387,7 @@ export const resolvers = {
       if (candidatesResult.rows.length < 2) {
         candidatesResult = await pool.query(
           `SELECT m.id, m.title, m.tmdb_id,
+                  m.poster_path, m.release_year, m.director, m.cast_list, m.genre_tags,
                   COALESCE(ume.comparison_count, 0) AS user_comparison_count,
                   COALESCE(ume.elo_rating, 1000) AS elo_rating
            FROM movies m
@@ -422,51 +403,40 @@ export const resolvers = {
         });
       }
 
-      const candidates: MovieCandidate[] = candidatesResult.rows.map((r: any) => ({
-        id: r.id,
-        title: r.title,
-        tmdb_id: r.tmdb_id,
-        userComparisonCount: Number(r.user_comparison_count),
-        elo_rating: Number(r.elo_rating),
-      }));
+      // Build a lookup so we can retrieve DB rows after pair selection
+      const rowMap = new Map<number, any>();
+      const candidates: MovieCandidate[] = candidatesResult.rows.map((r: any) => {
+        rowMap.set(r.id, r);
+        return {
+          id: r.id,
+          title: r.title,
+          tmdb_id: r.tmdb_id,
+          userComparisonCount: Number(r.user_comparison_count),
+          elo_rating: Number(r.elo_rating),
+        };
+      });
 
       const [first, second] = selectPair(candidates);
 
-      // Enrich both movies with TMDB data
-      const [enrichA, enrichB] = await Promise.all([
-        first.tmdb_id
-          ? enrichWithTmdb(first.tmdb_id)
-          : Promise.resolve({
-              poster_url: null,
-              release_year: null,
-              director: null,
-              cast: [],
-              tags: [],
-            }),
-        second.tmdb_id
-          ? enrichWithTmdb(second.tmdb_id)
-          : Promise.resolve({
-              poster_url: null,
-              release_year: null,
-              director: null,
-              cast: [],
-              tags: [],
-            }),
-      ]);
+      const buildMovie = (candidate: MovieCandidate) => {
+        const row = rowMap.get(candidate.id)!;
+        return {
+          id: String(candidate.id),
+          title: candidate.title,
+          tmdb_id: candidate.tmdb_id,
+          poster_url: row.poster_path
+            ? `https://image.tmdb.org/t/p/w342${row.poster_path}`
+            : null,
+          release_year: row.release_year ?? null,
+          director: row.director ?? null,
+          cast: row.cast_list ?? [],
+          tags: row.genre_tags ?? [],
+        };
+      };
 
       return {
-        movieA: {
-          id: String(first.id),
-          title: first.title,
-          tmdb_id: first.tmdb_id,
-          ...enrichA,
-        },
-        movieB: {
-          id: String(second.id),
-          title: second.title,
-          tmdb_id: second.tmdb_id,
-          ...enrichB,
-        },
+        movieA: buildMovie(first),
+        movieB: buildMovie(second),
       };
     },
     myRankings: async (_: any, __: any, context: any) => {
@@ -658,6 +628,11 @@ export const resolvers = {
         { title, requester: requesterName },
         context.ipAddress,
       );
+      // Fetch and store TMDB metadata in the background
+      const newMovieId = insertResult.rows[0].id;
+      if (tmdb_id) {
+        fetchAndStoreTmdbData(newMovieId, tmdb_id).catch(() => {});
+      }
       return {
         ...insertResult.rows[0],
         user_username: userRow.rows[0]?.username,
@@ -705,6 +680,8 @@ export const resolvers = {
         { original_title: movie.title, matched_title: title, tmdb_id },
         context.ipAddress ?? 'unknown',
       );
+      // Fetch and store TMDB metadata in the background
+      fetchAndStoreTmdbData(Number(id), tmdb_id).catch(() => {});
       return {
         ...result.rows[0],
         user_username: movie.user_username,
@@ -1558,12 +1535,14 @@ export const resolvers = {
       await pool.query('DELETE FROM user_movie_elo');
       await pool.query('DELETE FROM movies');
 
-      // Insert seed movies
+      // Insert seed movies and fetch TMDB metadata
       for (const movie of SEED_MOVIES) {
-        await pool.query(
-          'INSERT INTO movies (title, requested_by, rank, tmdb_id) VALUES ($1, $2, 0, $3)',
+        const ins = await pool.query(
+          'INSERT INTO movies (title, requested_by, rank, tmdb_id) VALUES ($1, $2, 0, $3) RETURNING id',
           [movie.title, context.user.userId, movie.tmdb_id],
         );
+        // Fire-and-forget TMDB fetch for each seeded movie
+        fetchAndStoreTmdbData(ins.rows[0].id, movie.tmdb_id).catch(() => {});
       }
 
       await logAudit(
@@ -1576,6 +1555,23 @@ export const resolvers = {
       );
 
       return SEED_MOVIES.length;
+    },
+    backfillTmdbData: async (_: any, __: any, context: any) => {
+      if (!context.user?.isAdmin) {
+        throw new GraphQLError('Not authorized', {
+          extensions: { code: 'FORBIDDEN' },
+        });
+      }
+      // Find movies with tmdb_id but no cached metadata
+      const result = await pool.query(
+        `SELECT id, tmdb_id FROM movies WHERE tmdb_id IS NOT NULL AND tmdb_fetched_at IS NULL`
+      );
+      let count = 0;
+      for (const row of result.rows) {
+        await fetchAndStoreTmdbData(row.id, row.tmdb_id);
+        count++;
+      }
+      return count;
     },
 
     sendConnectionRequest: async (

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -185,6 +185,7 @@ export const typeDefs = `#graphql
     updateUser(id: ID!, username: String, email: String, password: String, display_name: String, is_admin: Boolean, is_active: Boolean): User!
     deleteUser(id: ID!): Boolean!
     seedMovies: Int!
+    backfillTmdbData: Int!
     sendConnectionRequest(addresseeId: ID!): UserConnection!
     respondToConnectionRequest(connectionId: ID!, accept: Boolean!): UserConnection!
     removeConnection(connectionId: ID!): Boolean!

--- a/src/components/admin/LetterboxdImport.tsx
+++ b/src/components/admin/LetterboxdImport.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useMutation } from '@apollo/client';
 import { Box, Button, Input, Typography, Alert, CircularProgress, List, ListItem } from '@mui/joy';
-import { IMPORT_FROM_LETTERBOXD, GET_MOVIES } from '../../graphql/queries';
+import { IMPORT_FROM_LETTERBOXD, BACKFILL_TMDB_DATA, GET_MOVIES } from '../../graphql/queries';
 
 interface ImportResult {
   imported: number;
@@ -13,10 +13,14 @@ interface ImportResult {
 export const LetterboxdImport: React.FC = () => {
   const [url, setUrl] = useState('');
   const [result, setResult] = useState<ImportResult | null>(null);
+  const [backfillResult, setBackfillResult] = useState<number | null>(null);
+  const [backfillError, setBackfillError] = useState<string | null>(null);
 
   const [importMovies, { loading }] = useMutation(IMPORT_FROM_LETTERBOXD, {
     refetchQueries: [{ query: GET_MOVIES }],
   });
+
+  const [backfillTmdb, { loading: backfilling }] = useMutation(BACKFILL_TMDB_DATA);
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setResult(null);
@@ -102,6 +106,45 @@ export const LetterboxdImport: React.FC = () => {
           )}
         </Box>
       )}
+
+      {/* TMDB Backfill */}
+      <Box sx={{ mt: 5, pt: 4, borderTop: '1px solid', borderColor: 'divider' }}>
+        <Typography level="title-md" fontWeight={700} sx={{ color: 'text.secondary', mb: 1 }}>
+          Backfill TMDB Data
+        </Typography>
+        <Typography level="body-sm" sx={{ color: 'text.tertiary', mb: 2 }}>
+          Fetch poster, director, cast, and genre data from TMDB for any movies that are missing it.
+        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Button
+            loading={backfilling}
+            onClick={async () => {
+              setBackfillResult(null);
+              setBackfillError(null);
+              try {
+                const { data } = await backfillTmdb();
+                setBackfillResult(data.backfillTmdbData);
+              } catch (err: any) {
+                setBackfillError(err.message ?? 'Unknown error');
+              }
+            }}
+          >
+            Backfill Now
+          </Button>
+          {backfillResult !== null && (
+            <Alert color={backfillResult > 0 ? 'success' : 'neutral'} variant="soft" size="sm">
+              {backfillResult > 0
+                ? `Fetched TMDB data for ${backfillResult} movie${backfillResult !== 1 ? 's' : ''}`
+                : 'All movies already have TMDB data'}
+            </Alert>
+          )}
+          {backfillError && (
+            <Alert color="danger" variant="soft" size="sm">
+              {backfillError}
+            </Alert>
+          )}
+        </Box>
+      </Box>
     </Box>
   );
 };

--- a/src/components/home/ThisOrThat.tsx
+++ b/src/components/home/ThisOrThat.tsx
@@ -23,10 +23,7 @@ const ThisOrThat: React.FC = () => {
   const [initialLoading, setInitialLoading] = useState(true);
   const [pairError, setPairError] = useState<any>(null);
 
-  const [fetchPair] = useLazyQuery(
-    THIS_OR_THAT,
-    { fetchPolicy: 'network-only' },
-  );
+  const [fetchPair] = useLazyQuery(THIS_OR_THAT, { fetchPolicy: 'network-only' });
 
   // Pre-fetched next pair
   const prefetchedRef = useRef<any>(null);
@@ -52,34 +49,38 @@ const ThisOrThat: React.FC = () => {
       if (prefetchingRef.current) return;
       prefetchingRef.current = true;
       prefetchedRef.current = null;
-      fetchPair({ variables: { excludeIds } }).then((result) => {
-        prefetchedRef.current = result.data?.thisOrThat ?? null;
-        prefetchingRef.current = false;
-      }).catch(() => {
-        prefetchingRef.current = false;
-      });
+      fetchPair({ variables: { excludeIds } })
+        .then((result) => {
+          prefetchedRef.current = result.data?.thisOrThat ?? null;
+          prefetchingRef.current = false;
+        })
+        .catch(() => {
+          prefetchingRef.current = false;
+        });
     },
-    [fetchPair]
+    [fetchPair],
   );
 
   // Load a pair (used for initial load and fallback)
   const loadPair = useCallback(
     (excludeIds: string[] = []) => {
-      fetchPair({ variables: { excludeIds } }).then((result) => {
-        if (result.data?.thisOrThat) {
-          setCurrentPair(result.data.thisOrThat);
-          setPairError(null);
-        }
-        if (result.error) {
-          setPairError(result.error);
-        }
-        setInitialLoading(false);
-        setFading(false);
-      }).catch((err) => {
-        setPairError(err);
-        setInitialLoading(false);
-        setFading(false);
-      });
+      fetchPair({ variables: { excludeIds } })
+        .then((result) => {
+          if (result.data?.thisOrThat) {
+            setCurrentPair(result.data.thisOrThat);
+            setPairError(null);
+          }
+          if (result.error) {
+            setPairError(result.error);
+          }
+          setInitialLoading(false);
+          setFading(false);
+        })
+        .catch((err) => {
+          setPairError(err);
+          setInitialLoading(false);
+          setFading(false);
+        });
     },
     [fetchPair],
   );
@@ -100,7 +101,8 @@ const ThisOrThat: React.FC = () => {
   const handlePick = async (winnerId: string) => {
     if (!currentPair || recording) return;
 
-    const loserId = currentPair.movieA.id === winnerId ? currentPair.movieB.id : currentPair.movieA.id;
+    const loserId =
+      currentPair.movieA.id === winnerId ? currentPair.movieB.id : currentPair.movieA.id;
 
     // Fade out
     setFading(true);

--- a/src/components/home/ThisOrThat.tsx
+++ b/src/components/home/ThisOrThat.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { useLazyQuery, useMutation, useQuery } from '@apollo/client';
 import {
   THIS_OR_THAT,
@@ -18,10 +18,19 @@ const ThisOrThat: React.FC = () => {
   const [seenIds, setSeenIds] = useState<string[]>([]);
   const [fading, setFading] = useState(false);
 
-  const [fetchPair, { data: pairData, loading: pairLoading, error: pairError }] = useLazyQuery(
+  // Current pair state (either from initial fetch or swapped from pre-fetch)
+  const [currentPair, setCurrentPair] = useState<any>(null);
+  const [initialLoading, setInitialLoading] = useState(true);
+  const [pairError, setPairError] = useState<any>(null);
+
+  const [fetchPair] = useLazyQuery(
     THIS_OR_THAT,
     { fetchPolicy: 'network-only' },
   );
+
+  // Pre-fetched next pair
+  const prefetchedRef = useRef<any>(null);
+  const prefetchingRef = useRef(false);
 
   const [recordComparison, { loading: recording }] = useMutation(RECORD_COMPARISON, {
     refetchQueries: [{ query: GET_MOVIES }],
@@ -37,9 +46,40 @@ const ThisOrThat: React.FC = () => {
     refetchQueries: [{ query: MY_RANKINGS }, { query: GET_MOVIES }],
   });
 
+  // Pre-fetch the next pair in the background
+  const prefetchNext = useCallback(
+    (excludeIds: string[] = []) => {
+      if (prefetchingRef.current) return;
+      prefetchingRef.current = true;
+      prefetchedRef.current = null;
+      fetchPair({ variables: { excludeIds } }).then((result) => {
+        prefetchedRef.current = result.data?.thisOrThat ?? null;
+        prefetchingRef.current = false;
+      }).catch(() => {
+        prefetchingRef.current = false;
+      });
+    },
+    [fetchPair]
+  );
+
+  // Load a pair (used for initial load and fallback)
   const loadPair = useCallback(
     (excludeIds: string[] = []) => {
-      fetchPair({ variables: { excludeIds } });
+      fetchPair({ variables: { excludeIds } }).then((result) => {
+        if (result.data?.thisOrThat) {
+          setCurrentPair(result.data.thisOrThat);
+          setPairError(null);
+        }
+        if (result.error) {
+          setPairError(result.error);
+        }
+        setInitialLoading(false);
+        setFading(false);
+      }).catch((err) => {
+        setPairError(err);
+        setInitialLoading(false);
+        setFading(false);
+      });
     },
     [fetchPair],
   );
@@ -49,11 +89,18 @@ const ThisOrThat: React.FC = () => {
     loadPair();
   }, [loadPair]);
 
-  const handlePick = async (winnerId: string) => {
-    const pair = pairData?.thisOrThat;
-    if (!pair || recording) return;
+  // Pre-fetch next pair once current pair is shown
+  useEffect(() => {
+    if (currentPair && !fading) {
+      const excludeIds = [currentPair.movieA.id, currentPair.movieB.id];
+      prefetchNext(excludeIds);
+    }
+  }, [currentPair, fading, prefetchNext]);
 
-    const loserId = pair.movieA.id === winnerId ? pair.movieB.id : pair.movieA.id;
+  const handlePick = async (winnerId: string) => {
+    if (!currentPair || recording) return;
+
+    const loserId = currentPair.movieA.id === winnerId ? currentPair.movieB.id : currentPair.movieA.id;
 
     // Fade out
     setFading(true);
@@ -62,24 +109,23 @@ const ThisOrThat: React.FC = () => {
       await recordComparison({ variables: { winnerId, loserId } });
       setSessionCount((c) => c + 1);
 
-      // Track seen IDs for next pair exclusion
-      const newSeen = [...seenIds, pair.movieA.id, pair.movieB.id];
+      // Track seen IDs
+      const newSeen = [...seenIds, currentPair.movieA.id, currentPair.movieB.id];
       setSeenIds(newSeen);
 
-      // Load next pair
-      loadPair([pair.movieA.id, pair.movieB.id]);
+      // Use pre-fetched pair if available, otherwise fetch fresh
+      if (prefetchedRef.current) {
+        setCurrentPair(prefetchedRef.current);
+        prefetchedRef.current = null;
+        setFading(false);
+      } else {
+        loadPair([currentPair.movieA.id, currentPair.movieB.id]);
+      }
     } catch (err: any) {
       console.error('Failed to record comparison:', err);
       setFading(false);
     }
   };
-
-  // Clear fade when new pair arrives
-  useEffect(() => {
-    if (pairData?.thisOrThat) {
-      setFading(false);
-    }
-  }, [pairData]);
 
   const handleReset = async (movieId: string, title: string) => {
     if (!window.confirm(`Reset all your comparisons for "${title}"?`)) return;
@@ -91,11 +137,11 @@ const ThisOrThat: React.FC = () => {
   };
 
   const isNotEnoughMovies = pairError?.graphQLErrors?.some(
-    (e) => e.extensions?.code === 'BAD_USER_INPUT',
+    (e: any) => e.extensions?.code === 'BAD_USER_INPUT',
   );
 
-  const pair = pairData?.thisOrThat;
-  const showSkeleton = (pairLoading || fading) && !isNotEnoughMovies;
+  const pair = currentPair;
+  const showSkeleton = (initialLoading || (fading && !prefetchedRef.current)) && !isNotEnoughMovies;
 
   return (
     <Box

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -473,3 +473,9 @@ export const REMOVE_CONNECTION = gql`
     removeConnection(connectionId: $connectionId)
   }
 `;
+
+export const BACKFILL_TMDB_DATA = gql`
+  mutation BackfillTmdbData {
+    backfillTmdbData
+  }
+`;


### PR DESCRIPTION
## Summary
- Persist TMDB movie metadata (poster, year, director, cast, tags) in the `movies` table at add/match time, eliminating all TMDB API calls from the `thisOrThat` query path
- Add DB migration with 6 new columns: `poster_path`, `release_year`, `director`, `cast_list`, `genre_tags`, `tmdb_fetched_at`
- Add `backfillTmdbData` admin mutation to populate existing movies
- Frontend pre-fetches the next pair while the user views the current one, enabling instant transitions

## Test plan
- [ ] Run migration on dev database, verify columns added
- [ ] Add a movie with TMDB match — verify metadata columns populated
- [ ] Use `matchMovie` on an unmatched movie — verify metadata backfilled
- [ ] Open This or That — verify posters, director, cast, tags display from DB data
- [ ] Run `backfillTmdbData` mutation as admin — verify existing movies get metadata
- [ ] Verify pair transitions feel instant (pre-fetch working)
- [ ] Restart backend server — verify This or That still shows metadata (no cold cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)