### PR TITLE
Remove redundant PR triggers from CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   push:
     branches: ['*']
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -4,42 +4,13 @@ on:
   push:
     branches:
       - dev
-  pull_request:
-    branches:
-      - dev
 
 permissions:
   contents: read
 
 jobs:
-  test-backend:
-    name: Backend Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: backend/package-lock.json
-      - run: cd backend && npm ci
-      - run: cd backend && npm test -- --coverage --ci
-
-  test-frontend:
-    name: Frontend Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-      - run: npm ci
-      - run: npm test -- --coverage --ci --watchAll=false
-
   changes:
     name: Detect changed paths
-    needs: [test-backend, test-frontend]
     runs-on: ubuntu-latest
     outputs:
       frontend: ${{ steps.filter.outputs.frontend }}


### PR DESCRIPTION
## Summary
- Removed `pull_request` trigger from `ci.yml` — `push: branches: ['*']` already runs lint + tests on every branch push, covering PR code changes
- Removed duplicate `test-backend`/`test-frontend` jobs and `pull_request` trigger from `test-build.yml` — CI workflow already handles testing; kept only the unique Docker build validation on `dev` push
- `deploy-test.yml` and `deploy.yml` left unchanged (serve unique purposes)

## Test plan
- [ ] Push to a non-dev, non-master branch → only `CI` workflow should run
- [ ] Push to `dev` → `CI` + `Test Build` (Docker builds only) should run
- [ ] Open a PR → `Deploy Test Branch` should run, `CI` should NOT run as a separate PR check (branch push check covers it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)