### PR TITLE
feat: per-user tag system, 'Seen it' tag, and rewatch flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,13 +59,18 @@ searchTmdb(query: String!): [TmdbMovie!]!          # TMDB search (needs TMDB_API
 auditLogs(limit: Int, offset: Int): [AuditLog!]!  # admin only, max 500
 loginHistory(userId: ID, limit: Int): [LoginHistory!]!  # admin only, max 500
 kometaSchedule: KometaSchedule                     # admin only
+tags: [Tag!]!                                          # all tag definitions (public)
+watchedMovies(limit: Int, offset: Int): [Movie!]!      # requires auth, watched history
 
 # Mutations
 addMovie(title: String!, tmdb_id: Int): Movie!         # requires auth
 matchMovie(id: ID!, tmdb_id: Int!, title: String!): Movie!  # requires auth, owner or admin
-markWatched(id: ID!): Movie!                            # requires auth, owner or admin
+markWatched(id: ID!): Movie!                            # requires auth, owner or admin ("Done")
 deleteMovie(id: ID!): Boolean!                          # admin only
 reorderMovie(id: ID!, afterId: ID): Movie!             # admin only (afterId=null → move to top)
+setMovieTag(movieId: ID!, tagSlug: String!, value: String): MovieUserTag!  # requires auth
+removeMovieTag(movieId: ID!, tagSlug: String!): Boolean!  # requires auth
+unwatchMovie(id: ID!): Movie!                          # requires auth, owner or admin (requeue)
 exportKometa(collectionName: String): KometaExportResult!  # admin + production only
 updateKometaSchedule(...): KometaSchedule!             # admin + production only
 importFromLetterboxd(url: String!): ImportResult!      # admin only
@@ -89,10 +94,11 @@ src/components/
 ├── auth/
 │   └── Login.tsx            # username/password form
 ├── common/
-│   ├── Navbar.tsx           # Movies/Admin navigation, Logout
+│   ├── Navbar.tsx           # Movies/This or That/Combined/History/Admin navigation, Logout
 │   └── Footer.tsx           # deploy timestamp, git branch/hash
 └── home/
-    ├── Homepage.tsx          # movie list, drag-to-reorder (@dnd-kit), Add Movie, Mark Watched
+    ├── Homepage.tsx          # movie list, Add Movie, "Done" (mark watched), "Seen it" toggle
+    ├── WatchHistory.tsx      # paginated watched history + "Watch again" requeue
     └── TmdbMatchFlow.tsx     # TMDB search + match UI for unmatched movies
 ```
 
@@ -114,16 +120,38 @@ src/components/
 | `audit_logs`      | id, actor_id (FK→users), action, target_type, target_id, metadata (JSONB), ip_address, created_at                                                     |
 | `login_history`   | id, user_id (FK→users), ip_address, user_agent, succeeded, created_at                                                                                 |
 | `kometa_schedule` | id, enabled, frequency, daily_time, collection_name, last_run_at, updated_at                                                                          |
+| `tags`            | id, slug (unique, varchar 50), label (varchar 100), value_type ('boolean'\|'number'\|'text'), created_at                                              |
+| `movie_user_tags` | id, movie_id (FK→movies), user_id (FK→users), tag_id (FK→tags), value (nullable text), created_at, updated_at — UNIQUE(movie_id, user_id, tag_id)     |
 
 ## Audit log actions
 
-`MOVIE_ADD`, `MOVIE_WATCHED`, `MOVIE_DELETE`, `MOVIE_REORDER`, `MOVIE_TMDB_MATCH`, `MOVIE_INTEREST_SET`, `LOGIN_SUCCESS`, `LOGIN_FAILURE`, `USER_CREATE`, `USER_UPDATE`, `USER_DELETE`, `KOMETA_EXPORT`, `KOMETA_SCHEDULE_EXPORT`, `LETTERBOXD_IMPORT`
+`MOVIE_ADD`, `MOVIE_WATCHED`, `MOVIE_DELETE`, `MOVIE_REORDER`, `MOVIE_TMDB_MATCH`, `MOVIE_INTEREST_SET`, `MOVIE_TAG_SET`, `MOVIE_TAG_REMOVE`, `MOVIE_UNWATCH`, `LOGIN_SUCCESS`, `LOGIN_FAILURE`, `USER_CREATE`, `USER_UPDATE`, `USER_DELETE`, `KOMETA_EXPORT`, `KOMETA_SCHEDULE_EXPORT`, `LETTERBOXD_IMPORT`
 
 ## Key features
 
-### Watched tracking
+### Watched tracking ("Done")
 
-`markWatched(id)` sets `watched_at = NOW()`. `movies` query returns only `WHERE watched_at IS NULL`.
+`markWatched(id)` sets `watched_at = NOW()`. `movies` query returns only `WHERE watched_at IS NULL`. UI labels this action "Done" and confirms with "It'll move to your watch history."
+
+`unwatchMovie(id)` clears `watched_at` and sets `rank = MAX(rank)+1`, putting the movie back at the end of the queue ("Watch again" in the History view).
+
+`watchedMovies(limit, offset)` returns movies with `watched_at IS NOT NULL` for the History view.
+
+### Per-user tag system
+
+Generic, extensible tagging framework for movies. Tags are per-user (Alice can tag Inception as "seen" independently of Bob).
+
+**Tables**: `tags` (definitions) + `movie_user_tags` (per-user, per-movie instances). See migration `1746200000000_create-tags-system.js`.
+
+**Tag types**: `boolean` (tag exists = true), `number`, `text` (value stored in `movie_user_tags.value`).
+
+**Seeded tags**: `seen` ("Seen it") — indicates a user has personally watched the movie before.
+
+**Adding new tags**: `INSERT INTO tags (slug, label, value_type) VALUES ('podcast-ep', 'Podcast Episode', 'number');`
+
+**GraphQL**: `setMovieTag(movieId, tagSlug, value?)` upserts, `removeMovieTag(movieId, tagSlug)` deletes. `Movie.myTags` returns current user's tags; `Movie.userTags` returns all users' tags.
+
+**Frontend**: Eye icon toggle on movie rows for "Seen it". Shows count of users who've seen the movie + tooltip with names. "I've seen this" button appears after adding a movie.
 
 ### Drag-and-drop reordering
 
@@ -207,6 +235,7 @@ backend/src/__tests__/
     connection-resolvers.test.ts
     letterboxd-resolvers.test.ts
     kometa-resolvers.test.ts
+    tag-resolvers.test.ts
 
 src/utils/__tests__/
   textUtils.test.ts

--- a/PLAN.md
+++ b/PLAN.md
@@ -10,14 +10,14 @@ Two independent systems working together:
 
 ## UX Terminology Changes
 
-| Current | New | Where |
-|---------|-----|-------|
-| `✓` icon + "Mark as watched" title | `✓` icon + "Done" title | Movie row action button |
-| `"Mark [title] as watched? It will be removed from the watchlist."` | `"Mark [title] as done? It'll move to your watch history."` | Confirmation dialog |
-| (n/a) | "Seen it" toggle (eye icon) | Movie row — per-user, toggleable |
-| (n/a) | "History" link | Navbar (subtle, not prominent) |
-| (n/a) | "Watch again" button | History view — brings movie back to queue |
-| "I'm in" / "Pass" | No change | Keep as-is |
+| Current                                                             | New                                                         | Where                                     |
+| ------------------------------------------------------------------- | ----------------------------------------------------------- | ----------------------------------------- |
+| `✓` icon + "Mark as watched" title                                  | `✓` icon + "Done" title                                     | Movie row action button                   |
+| `"Mark [title] as watched? It will be removed from the watchlist."` | `"Mark [title] as done? It'll move to your watch history."` | Confirmation dialog                       |
+| (n/a)                                                               | "Seen it" toggle (eye icon)                                 | Movie row — per-user, toggleable          |
+| (n/a)                                                               | "History" link                                              | Navbar (subtle, not prominent)            |
+| (n/a)                                                               | "Watch again" button                                        | History view — brings movie back to queue |
+| "I'm in" / "Pass"                                                   | No change                                                   | Keep as-is                                |
 
 ## Phase 1: Database Migration
 
@@ -66,28 +66,31 @@ type Tag {
 
 type MovieUserTag {
   tag: Tag!
-  user: ConnectionUser!   # reuse existing type (id, username, display_name)
+  user: ConnectionUser! # reuse existing type (id, username, display_name)
   value: String
   createdAt: String!
 }
 ```
 
 Add fields to `Movie` type:
+
 ```graphql
 type Movie {
   # ...existing fields...
-  myTags: [MovieUserTag!]!      # tags set by the current user on this movie
-  userTags: [MovieUserTag!]!    # all users' tags on this movie (visible to everyone)
+  myTags: [MovieUserTag!]! # tags set by the current user on this movie
+  userTags: [MovieUserTag!]! # all users' tags on this movie (visible to everyone)
 }
 ```
 
 Add queries:
+
 ```graphql
 tags: [Tag!]!                                        # list all tag definitions
 watchedMovies(limit: Int, offset: Int): [Movie!]!    # movies with watched_at IS NOT NULL
 ```
 
 Add mutations:
+
 ```graphql
 setMovieTag(movieId: ID!, tagSlug: String!, value: String): MovieUserTag!
 removeMovieTag(movieId: ID!, tagSlug: String!): Boolean!
@@ -134,6 +137,7 @@ export const UNWATCH_MOVIE = gql`...`;
 ```
 
 **Update existing queries** to include `myTags` and `userTags` on Movie:
+
 - `GET_MOVIES` — add `myTags { tag { slug label } } userTags { tag { slug label } user { id display_name username } }`
 
 ## Phase 5: Frontend — "Seen It" Toggle on Movie Rows
@@ -174,9 +178,11 @@ export const UNWATCH_MOVIE = gql`...`;
 - Minimal, not prominent — accessed via a subtle "History" link in the navbar
 
 **Navbar change** (`Navbar.tsx`):
+
 - Add "History" nav button (authenticated only), styled more subtle than other nav items (maybe `variant="plain"` with muted color)
 
 **App.tsx change**:
+
 - Add `'history'` to `ViewName` union
 - Add routing for history view
 - Pass `onShowHistory` callback to Navbar
@@ -192,6 +198,7 @@ Implementation: In the success message area, add a small button "I've seen it" t
 **New file**: `backend/src/__tests__/resolvers/tag-resolvers.test.ts`
 
 Test cases:
+
 - `setMovieTag`: happy path (boolean tag), tag with value, movie not found, tag not found, unauthenticated, upsert behavior, audit logging
 - `removeMovieTag`: happy path, not found (no-op returns false), unauthenticated
 - `unwatchMovie`: happy path (clears watched_at, re-ranks), movie not found, not authorized (not owner/admin), movie not watched (already active), unauthenticated, audit logging
@@ -206,19 +213,19 @@ Test cases:
 
 ## Files Modified (summary)
 
-| File | Change |
-|------|--------|
-| `backend/migrations/1746200000000_create-tags-system.js` | **NEW** — tags + movie_user_tags tables |
-| `backend/src/schema.ts` | Add Tag, MovieUserTag types; add fields, queries, mutations |
-| `backend/src/resolvers.ts` | Add tag/unwatch resolvers, Movie field resolvers |
-| `src/graphql/queries.ts` | Add tag/history queries+mutations, update GET_MOVIES |
-| `src/models/Movies.ts` | Add myTags/userTags to Movie type |
-| `src/components/home/Homepage.tsx` | "Seen it" toggle, "Done" wording, post-add "Seen it" option |
-| `src/components/home/WatchHistory.tsx` | **NEW** — watched history view |
-| `src/components/common/Navbar.tsx` | Add "History" link |
-| `src/App.tsx` | Add history view routing |
-| `backend/src/__tests__/resolvers/tag-resolvers.test.ts` | **NEW** — tag system tests |
-| `CLAUDE.md` | Update with new tables, actions, queries |
+| File                                                     | Change                                                      |
+| -------------------------------------------------------- | ----------------------------------------------------------- |
+| `backend/migrations/1746200000000_create-tags-system.js` | **NEW** — tags + movie_user_tags tables                     |
+| `backend/src/schema.ts`                                  | Add Tag, MovieUserTag types; add fields, queries, mutations |
+| `backend/src/resolvers.ts`                               | Add tag/unwatch resolvers, Movie field resolvers            |
+| `src/graphql/queries.ts`                                 | Add tag/history queries+mutations, update GET_MOVIES        |
+| `src/models/Movies.ts`                                   | Add myTags/userTags to Movie type                           |
+| `src/components/home/Homepage.tsx`                       | "Seen it" toggle, "Done" wording, post-add "Seen it" option |
+| `src/components/home/WatchHistory.tsx`                   | **NEW** — watched history view                              |
+| `src/components/common/Navbar.tsx`                       | Add "History" link                                          |
+| `src/App.tsx`                                            | Add history view routing                                    |
+| `backend/src/__tests__/resolvers/tag-resolvers.test.ts`  | **NEW** — tag system tests                                  |
+| `CLAUDE.md`                                              | Update with new tables, actions, queries                    |
 
 ## Order of implementation
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,233 @@
+# Plan: Per-User Tag System + "Seen It" Tag + Rewatch Flow
+
+## Summary
+
+Two independent systems working together:
+
+1. **Movie lifecycle (unchanged)**: `watched_at` column stays — "Done" removes from queue with a date
+2. **Per-user tag system (new)**: Generic tagging — each user can tag any movie. First tag: "Seen it" (I've personally watched this before). Extensible for future tags (e.g. podcast episode order)
+3. **Rewatch flow (new)**: Watched movies can be put back in the queue via "Watch again"
+
+## UX Terminology Changes
+
+| Current | New | Where |
+|---------|-----|-------|
+| `✓` icon + "Mark as watched" title | `✓` icon + "Done" title | Movie row action button |
+| `"Mark [title] as watched? It will be removed from the watchlist."` | `"Mark [title] as done? It'll move to your watch history."` | Confirmation dialog |
+| (n/a) | "Seen it" toggle (eye icon) | Movie row — per-user, toggleable |
+| (n/a) | "History" link | Navbar (subtle, not prominent) |
+| (n/a) | "Watch again" button | History view — brings movie back to queue |
+| "I'm in" / "Pass" | No change | Keep as-is |
+
+## Phase 1: Database Migration
+
+**New file**: `backend/migrations/1746200000000_create-tags-system.js`
+
+```sql
+-- Tag definitions
+CREATE TABLE tags (
+  id SERIAL PRIMARY KEY,
+  slug VARCHAR(50) NOT NULL UNIQUE,
+  label VARCHAR(100) NOT NULL,
+  value_type VARCHAR(20) NOT NULL DEFAULT 'boolean',  -- 'boolean', 'number', 'text'
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Per-user, per-movie tag instances
+CREATE TABLE movie_user_tags (
+  id SERIAL PRIMARY KEY,
+  movie_id INTEGER NOT NULL REFERENCES movies(id) ON DELETE CASCADE,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  tag_id INTEGER NOT NULL REFERENCES tags(id) ON DELETE CASCADE,
+  value TEXT,  -- null for boolean tags; stores number/text for others
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(movie_id, user_id, tag_id)
+);
+
+CREATE INDEX idx_movie_user_tags_movie ON movie_user_tags(movie_id);
+CREATE INDEX idx_movie_user_tags_user ON movie_user_tags(user_id);
+
+-- Seed the first tag
+INSERT INTO tags (slug, label, value_type) VALUES ('seen', 'Seen it', 'boolean');
+```
+
+## Phase 2: Backend — GraphQL Schema
+
+Add to `backend/src/schema.ts`:
+
+```graphql
+type Tag {
+  id: ID!
+  slug: String!
+  label: String!
+  valueType: String!
+}
+
+type MovieUserTag {
+  tag: Tag!
+  user: ConnectionUser!   # reuse existing type (id, username, display_name)
+  value: String
+  createdAt: String!
+}
+```
+
+Add fields to `Movie` type:
+```graphql
+type Movie {
+  # ...existing fields...
+  myTags: [MovieUserTag!]!      # tags set by the current user on this movie
+  userTags: [MovieUserTag!]!    # all users' tags on this movie (visible to everyone)
+}
+```
+
+Add queries:
+```graphql
+tags: [Tag!]!                                        # list all tag definitions
+watchedMovies(limit: Int, offset: Int): [Movie!]!    # movies with watched_at IS NOT NULL
+```
+
+Add mutations:
+```graphql
+setMovieTag(movieId: ID!, tagSlug: String!, value: String): MovieUserTag!
+removeMovieTag(movieId: ID!, tagSlug: String!): Boolean!
+unwatchMovie(id: ID!): Movie!    # clears watched_at, sets rank = MAX(rank)+1
+```
+
+## Phase 3: Backend — Resolvers
+
+### Field resolvers on Movie
+
+- `Movie.myTags`: If `context.user` exists, query `movie_user_tags` for that user+movie, JOIN `tags` and `users`
+- `Movie.userTags`: Query all `movie_user_tags` for that movie, JOIN `tags` and `users`
+
+These only fire when the fields are actually requested in the query (GraphQL lazy resolution).
+
+### Query resolvers
+
+- `tags`: `SELECT * FROM tags ORDER BY slug`
+- `watchedMovies(limit, offset)`: `SELECT * FROM movies WHERE watched_at IS NOT NULL ORDER BY watched_at DESC LIMIT $1 OFFSET $2` — requires auth. Includes same requester resolution as existing movie queries.
+
+### Mutation resolvers
+
+- **`setMovieTag(movieId, tagSlug, value)`**: Requires auth. Looks up tag by slug, validates movie exists. UPSERT into `movie_user_tags`. Audit log: `MOVIE_TAG_SET`.
+- **`removeMovieTag(movieId, tagSlug)`**: Requires auth. DELETE from `movie_user_tags` WHERE user+movie+tag. Audit log: `MOVIE_TAG_REMOVE`.
+- **`unwatchMovie(id)`**: Requires auth. Owner or admin. Sets `watched_at = NULL`, sets `rank = (SELECT COALESCE(MAX(rank), 0) + 1 FROM movies WHERE watched_at IS NULL)`. Audit log: `MOVIE_UNWATCH`.
+
+### Audit log actions (add)
+
+`MOVIE_TAG_SET`, `MOVIE_TAG_REMOVE`, `MOVIE_UNWATCH`
+
+## Phase 4: Frontend — GraphQL Operations
+
+**New queries/mutations in `src/graphql/queries.ts`**:
+
+```typescript
+// Tags
+export const GET_TAGS = gql`...`;
+export const SET_MOVIE_TAG = gql`...`;
+export const REMOVE_MOVIE_TAG = gql`...`;
+
+// History
+export const WATCHED_MOVIES = gql`...`;
+export const UNWATCH_MOVIE = gql`...`;
+```
+
+**Update existing queries** to include `myTags` and `userTags` on Movie:
+- `GET_MOVIES` — add `myTags { tag { slug label } } userTags { tag { slug label } user { id display_name username } }`
+
+## Phase 5: Frontend — "Seen It" Toggle on Movie Rows
+
+**Modify `MovieRow` component** in `Homepage.tsx`:
+
+- Add an eye icon button (or "Seen" chip) between the TMDB link and the action buttons
+- When current user has the "seen" tag → show filled/highlighted eye
+- When not → show outlined/dim eye
+- Click toggles: calls `setMovieTag` or `removeMovieTag`
+- On hover/title: "I've seen this before" / "Mark as seen"
+- Below the title or as a small tooltip: show "Seen by: Alice, Bob" if other users have the tag
+
+**Only visible when authenticated.**
+
+### Visual design
+
+```
+| Title          | Suggested by | Added       | TMDB | Seen     | Actions |
+| Inception      | alice        | Jan 3, 2026 |  ↗   | 👁 (2)  |  ✓  ✕  |
+```
+
+- The eye icon is subtle/dim by default, highlighted when the current user has tagged it
+- "(2)" shows how many users have seen it — clickable/hoverable to show names
+
+## Phase 6: Frontend — "Done" Terminology Update
+
+- `Homepage.tsx` line 128: Change `title` from `Mark "${movie.title}" as watched` → `Mark "${movie.title}" as done`
+- `Homepage.tsx` line 269: Change confirm dialog from `Mark "${movieTitle}" as watched? It will be removed from the watchlist.` → `Mark "${movieTitle}" as done? It'll move to your watch history.`
+
+## Phase 7: Frontend — Watch History View
+
+**New component**: `src/components/home/WatchHistory.tsx`
+
+- Simple paginated list of movies where `watched_at IS NOT NULL`
+- Each row shows: title, who suggested it, watched date
+- "Watch again" button per movie → calls `unwatchMovie`, confirms first
+- Minimal, not prominent — accessed via a subtle "History" link in the navbar
+
+**Navbar change** (`Navbar.tsx`):
+- Add "History" nav button (authenticated only), styled more subtle than other nav items (maybe `variant="plain"` with muted color)
+
+**App.tsx change**:
+- Add `'history'` to `ViewName` union
+- Add routing for history view
+- Pass `onShowHistory` callback to Navbar
+
+## Phase 8: Frontend — "Seen It" on Add Movie Flow
+
+After successfully adding a movie (the "Added to the list!" success state), briefly show a "I've seen this" chip/button so the user can immediately tag it. This is optional UX sugar — the user can always toggle it in the row after.
+
+Implementation: In the success message area, add a small button "I've seen it" that calls `setMovieTag` with the newly added movie's ID. Disappears after 3s (same as the success message).
+
+## Phase 9: Backend Tests
+
+**New file**: `backend/src/__tests__/resolvers/tag-resolvers.test.ts`
+
+Test cases:
+- `setMovieTag`: happy path (boolean tag), tag with value, movie not found, tag not found, unauthenticated, upsert behavior, audit logging
+- `removeMovieTag`: happy path, not found (no-op returns false), unauthenticated
+- `unwatchMovie`: happy path (clears watched_at, re-ranks), movie not found, not authorized (not owner/admin), movie not watched (already active), unauthenticated, audit logging
+- `watchedMovies`: returns watched movies ordered by watched_at DESC, pagination, unauthenticated
+- `tags`: returns all tags
+- `Movie.myTags` / `Movie.userTags` field resolvers
+
+## Phase 10: Frontend Tests
+
+- Update existing `Homepage` tests if any exist for the new "Done" wording
+- Basic test for `WatchHistory` component
+
+## Files Modified (summary)
+
+| File | Change |
+|------|--------|
+| `backend/migrations/1746200000000_create-tags-system.js` | **NEW** — tags + movie_user_tags tables |
+| `backend/src/schema.ts` | Add Tag, MovieUserTag types; add fields, queries, mutations |
+| `backend/src/resolvers.ts` | Add tag/unwatch resolvers, Movie field resolvers |
+| `src/graphql/queries.ts` | Add tag/history queries+mutations, update GET_MOVIES |
+| `src/models/Movies.ts` | Add myTags/userTags to Movie type |
+| `src/components/home/Homepage.tsx` | "Seen it" toggle, "Done" wording, post-add "Seen it" option |
+| `src/components/home/WatchHistory.tsx` | **NEW** — watched history view |
+| `src/components/common/Navbar.tsx` | Add "History" link |
+| `src/App.tsx` | Add history view routing |
+| `backend/src/__tests__/resolvers/tag-resolvers.test.ts` | **NEW** — tag system tests |
+| `CLAUDE.md` | Update with new tables, actions, queries |
+
+## Order of implementation
+
+1. Migration (Phase 1)
+2. Backend schema + resolvers + tests (Phases 2, 3, 9)
+3. Frontend GraphQL operations (Phase 4)
+4. Frontend "Done" wording (Phase 6) — smallest change, do early
+5. Frontend "Seen it" toggle (Phase 5)
+6. Frontend history view (Phase 7)
+7. Post-add "Seen it" option (Phase 8)
+8. Frontend tests (Phase 10)
+9. Update CLAUDE.md

--- a/backend/migrations/1746200000000_create-tags-system.js
+++ b/backend/migrations/1746200000000_create-tags-system.js
@@ -1,0 +1,108 @@
+/**
+ * Per-User Movie Tag System
+ *
+ * Creates a generic, extensible tagging framework for movies:
+ *
+ *   tags             – Tag definitions (slug, label, value type)
+ *   movie_user_tags  – Per-user, per-movie tag instances with optional value
+ *
+ * ## How it works
+ *
+ *   - Each tag has a `slug` (unique key), `label` (display name), and
+ *     `value_type` ('boolean' | 'number' | 'text').
+ *   - Boolean tags (like "seen") only need a row to exist — no value column needed.
+ *   - Number/text tags store their payload in the `value` column.
+ *   - Tags are per-user: Alice can tag Inception as "seen" independently of Bob.
+ *
+ * ## Seeded tags
+ *
+ *   slug: 'seen', label: 'Seen it', type: 'boolean'
+ *     → "I've personally watched this movie before"
+ *
+ * ## Adding new tags later
+ *
+ *   INSERT INTO tags (slug, label, value_type) VALUES ('podcast-ep', 'Podcast Episode', 'number');
+ *
+ *   Then users can tag movies:
+ *   INSERT INTO movie_user_tags (movie_id, user_id, tag_id, value)
+ *   VALUES (42, 1, (SELECT id FROM tags WHERE slug = 'podcast-ep'), '137');
+ */
+
+exports.up = (pgm) => {
+  // Tag definitions
+  pgm.createTable('tags', {
+    id: 'id',
+    slug: {
+      type: 'varchar(50)',
+      notNull: true,
+      unique: true,
+    },
+    label: {
+      type: 'varchar(100)',
+      notNull: true,
+    },
+    value_type: {
+      type: 'varchar(20)',
+      notNull: true,
+      default: "'boolean'",
+    },
+    created_at: {
+      type: 'timestamptz',
+      notNull: true,
+      default: pgm.func('NOW()'),
+    },
+  });
+
+  // Per-user, per-movie tag instances
+  pgm.createTable('movie_user_tags', {
+    id: 'id',
+    movie_id: {
+      type: 'integer',
+      notNull: true,
+      references: '"movies"',
+      onDelete: 'CASCADE',
+    },
+    user_id: {
+      type: 'integer',
+      notNull: true,
+      references: '"users"',
+      onDelete: 'CASCADE',
+    },
+    tag_id: {
+      type: 'integer',
+      notNull: true,
+      references: '"tags"',
+      onDelete: 'CASCADE',
+    },
+    value: {
+      type: 'text',
+      notNull: false,
+    },
+    created_at: {
+      type: 'timestamptz',
+      notNull: true,
+      default: pgm.func('NOW()'),
+    },
+    updated_at: {
+      type: 'timestamptz',
+      notNull: true,
+      default: pgm.func('NOW()'),
+    },
+  });
+
+  pgm.addConstraint('movie_user_tags', 'movie_user_tags_unique', {
+    unique: ['movie_id', 'user_id', 'tag_id'],
+  });
+
+  pgm.createIndex('movie_user_tags', ['movie_id']);
+  pgm.createIndex('movie_user_tags', ['user_id']);
+  pgm.createIndex('movie_user_tags', ['tag_id']);
+
+  // Seed the first tag
+  pgm.sql(`INSERT INTO tags (slug, label, value_type) VALUES ('seen', 'Seen it', 'boolean')`);
+};
+
+exports.down = (pgm) => {
+  pgm.dropTable('movie_user_tags');
+  pgm.dropTable('tags');
+};

--- a/backend/src/__tests__/resolvers/tag-resolvers.test.ts
+++ b/backend/src/__tests__/resolvers/tag-resolvers.test.ts
@@ -1,0 +1,337 @@
+import { mockQuery, authContext, adminContext, anonContext } from './__helpers';
+import { resolvers } from '../../resolvers';
+
+const { setMovieTag, removeMovieTag, unwatchMovie } = resolvers.Mutation;
+const { tags, watchedMovies } = resolvers.Query;
+const { myTags, userTags } = resolvers.Movie;
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+// ── Query.tags ────────────────────────────────────────────────────────────────
+
+describe('Query.tags', () => {
+  it('returns all tag definitions', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 1, slug: 'seen', label: 'Seen it', value_type: 'boolean' }],
+    });
+    const result = await (tags as any)(null, {}, authContext());
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: '1',
+      slug: 'seen',
+      label: 'Seen it',
+      valueType: 'boolean',
+    });
+  });
+
+  it('returns empty array when no tags exist', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const result = await (tags as any)(null, {}, authContext());
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ── Query.watchedMovies ───────────────────────────────────────────────────────
+
+describe('Query.watchedMovies', () => {
+  it('returns watched movies ordered by watched_at desc', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 1,
+          title: 'Inception',
+          requested_by: 1,
+          watched_at: new Date('2025-01-01'),
+          user_username: 'alice',
+          user_display_name: 'Alice',
+        },
+      ],
+    });
+    const result = await watchedMovies(null, {}, authContext());
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('Inception');
+  });
+
+  it('respects limit and offset', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await watchedMovies(null, { limit: 10, offset: 5 }, authContext());
+    expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('LIMIT $1 OFFSET $2'), [10, 5]);
+  });
+
+  it('clamps limit to 200 max', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await watchedMovies(null, { limit: 500 }, authContext());
+    expect(mockQuery).toHaveBeenCalledWith(expect.any(String), [200, 0]);
+  });
+
+  it('unauthenticated throws UNAUTHENTICATED', async () => {
+    await expect(watchedMovies(null, {}, anonContext())).rejects.toThrow('Not authenticated');
+  });
+});
+
+// ── Mutation.setMovieTag ──────────────────────────────────────────────────────
+
+describe('Mutation.setMovieTag', () => {
+  it('creates a boolean tag on a movie', async () => {
+    const now = new Date('2025-01-01');
+    // 1: tag lookup
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 1, slug: 'seen', label: 'Seen it', value_type: 'boolean' }],
+    });
+    // 2: movie lookup
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 5, title: 'Inception' }] });
+    // 3: upsert
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 1, movie_id: 5, user_id: 1, tag_id: 1, value: null, created_at: now }],
+    });
+    // 4: user lookup
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 1, username: 'testuser', display_name: 'Test User' }],
+    });
+    // 5: audit log
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await setMovieTag(
+      null,
+      { movieId: '5', tagSlug: 'seen' },
+      authContext({ userId: 1 }),
+    );
+
+    expect(result.tag.slug).toBe('seen');
+    expect(result.user.username).toBe('testuser');
+    expect(result.value).toBeNull();
+  });
+
+  it('creates a tag with a value', async () => {
+    const now = new Date('2025-01-01');
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 2, slug: 'podcast-ep', label: 'Podcast Episode', value_type: 'number' }],
+    });
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 5, title: 'Inception' }] });
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 1, movie_id: 5, user_id: 1, tag_id: 2, value: '42', created_at: now }],
+    });
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 1, username: 'testuser', display_name: 'Test' }],
+    });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await setMovieTag(
+      null,
+      { movieId: '5', tagSlug: 'podcast-ep', value: '42' },
+      authContext(),
+    );
+    expect(result.value).toBe('42');
+  });
+
+  it('throws NOT_FOUND for unknown tag slug', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await expect(
+      setMovieTag(null, { movieId: '5', tagSlug: 'nope' }, authContext()),
+    ).rejects.toThrow('Tag not found');
+  });
+
+  it('throws NOT_FOUND for unknown movie', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 1, slug: 'seen', label: 'Seen it', value_type: 'boolean' }],
+    });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await expect(
+      setMovieTag(null, { movieId: '999', tagSlug: 'seen' }, authContext()),
+    ).rejects.toThrow('Movie not found');
+  });
+
+  it('unauthenticated throws UNAUTHENTICATED', async () => {
+    await expect(
+      setMovieTag(null, { movieId: '5', tagSlug: 'seen' }, anonContext()),
+    ).rejects.toThrow('Not authenticated');
+  });
+});
+
+// ── Mutation.removeMovieTag ───────────────────────────────────────────────────
+
+describe('Mutation.removeMovieTag', () => {
+  it('removes an existing tag and returns true', async () => {
+    // tag lookup
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }] });
+    // movie lookup
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 5, title: 'Inception' }] });
+    // delete
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }] });
+    // audit
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await removeMovieTag(null, { movieId: '5', tagSlug: 'seen' }, authContext());
+    expect(result).toBe(true);
+  });
+
+  it('returns false when tag slug does not exist', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const result = await removeMovieTag(null, { movieId: '5', tagSlug: 'nope' }, authContext());
+    expect(result).toBe(false);
+  });
+
+  it('returns false when tag was not applied', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }] });
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 5, title: 'Inception' }] });
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // delete found nothing
+    const result = await removeMovieTag(null, { movieId: '5', tagSlug: 'seen' }, authContext());
+    expect(result).toBe(false);
+  });
+
+  it('unauthenticated throws UNAUTHENTICATED', async () => {
+    await expect(
+      removeMovieTag(null, { movieId: '5', tagSlug: 'seen' }, anonContext()),
+    ).rejects.toThrow('Not authenticated');
+  });
+});
+
+// ── Mutation.unwatchMovie ─────────────────────────────────────────────────────
+
+describe('Mutation.unwatchMovie', () => {
+  it('clears watched_at and re-ranks the movie (owner)', async () => {
+    // movie check
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 5, title: 'Inception', requested_by: 1, watched_at: new Date() }],
+    });
+    // update
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 5,
+          title: 'Inception',
+          requested_by: 1,
+          watched_at: null,
+          rank: 10,
+          date_submitted: new Date(),
+        },
+      ],
+    });
+    // user lookup
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ username: 'testuser', display_name: 'Test User' }],
+    });
+    // audit
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await unwatchMovie(null, { id: '5' }, authContext({ userId: 1 }));
+    expect(result.watched_at).toBeNull();
+    expect(result.id).toBe(5);
+  });
+
+  it('allows admin to unwatch any movie', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 5, title: 'Inception', requested_by: 2, watched_at: new Date() }],
+    });
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 5, title: 'Inception', requested_by: 2, watched_at: null, rank: 10 }],
+    });
+    mockQuery.mockResolvedValueOnce({ rows: [{ username: 'bob', display_name: 'Bob' }] });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await unwatchMovie(null, { id: '5' }, adminContext());
+    expect(result.id).toBe(5);
+  });
+
+  it('throws NOT_FOUND for unknown movie', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await expect(unwatchMovie(null, { id: '999' }, authContext())).rejects.toThrow(
+      'Movie not found',
+    );
+  });
+
+  it('throws BAD_USER_INPUT if movie is not watched', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 5, title: 'Inception', requested_by: 1, watched_at: null }],
+    });
+    await expect(unwatchMovie(null, { id: '5' }, authContext({ userId: 1 }))).rejects.toThrow(
+      'Movie is not marked as watched',
+    );
+  });
+
+  it('throws FORBIDDEN if not owner and not admin', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 5, title: 'Inception', requested_by: 2, watched_at: new Date() }],
+    });
+    await expect(unwatchMovie(null, { id: '5' }, authContext({ userId: 1 }))).rejects.toThrow(
+      'Not authorized',
+    );
+  });
+
+  it('unauthenticated throws UNAUTHENTICATED', async () => {
+    await expect(unwatchMovie(null, { id: '5' }, anonContext())).rejects.toThrow(
+      'Not authenticated',
+    );
+  });
+});
+
+// ── Movie.myTags field resolver ───────────────────────────────────────────────
+
+describe('Movie.myTags', () => {
+  it('returns tags for the current user on a movie', async () => {
+    const now = new Date('2025-01-01');
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          tag_id: 1,
+          slug: 'seen',
+          label: 'Seen it',
+          value_type: 'boolean',
+          uid: 1,
+          username: 'testuser',
+          display_name: 'Test',
+          value: null,
+          created_at: now,
+        },
+      ],
+    });
+    const result = await myTags({ id: 5 }, {}, authContext());
+    expect(result).toHaveLength(1);
+    expect(result[0].tag.slug).toBe('seen');
+  });
+
+  it('returns empty array for unauthenticated user', async () => {
+    const result = await myTags({ id: 5 }, {}, anonContext());
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ── Movie.userTags field resolver ─────────────────────────────────────────────
+
+describe('Movie.userTags', () => {
+  it('returns all user tags for a movie', async () => {
+    const now = new Date('2025-01-01');
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          tag_id: 1,
+          slug: 'seen',
+          label: 'Seen it',
+          value_type: 'boolean',
+          uid: 1,
+          username: 'alice',
+          display_name: 'Alice',
+          value: null,
+          created_at: now,
+        },
+        {
+          tag_id: 1,
+          slug: 'seen',
+          label: 'Seen it',
+          value_type: 'boolean',
+          uid: 2,
+          username: 'bob',
+          display_name: 'Bob',
+          value: null,
+          created_at: now,
+        },
+      ],
+    });
+    const result = await (userTags as any)({ id: 5 }, {}, authContext());
+    expect(result).toHaveLength(2);
+    expect(result[0].user.username).toBe('alice');
+    expect(result[1].user.username).toBe('bob');
+  });
+});

--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -670,6 +670,38 @@ export const resolvers = {
       );
       return result.rows.map((r: any) => String(r.movie_id));
     },
+
+    tags: async () => {
+      const result = await pool.query('SELECT * FROM tags ORDER BY slug');
+      return result.rows.map((r: any) => ({
+        id: String(r.id),
+        slug: r.slug,
+        label: r.label,
+        valueType: r.value_type,
+      }));
+    },
+
+    watchedMovies: async (
+      _: any,
+      { limit, offset }: { limit?: number; offset?: number },
+      context: any,
+    ) => {
+      if (!context.user) {
+        throw new GraphQLError('Not authenticated', { extensions: { code: 'UNAUTHENTICATED' } });
+      }
+      const safeLimit = Math.min(Math.max(limit ?? 50, 1), 200);
+      const safeOffset = Math.max(offset ?? 0, 0);
+      const result = await pool.query(
+        `SELECT m.*, u.username AS user_username, u.display_name AS user_display_name
+         FROM movies m
+         LEFT JOIN users u ON m.requested_by = u.id
+         WHERE m.watched_at IS NOT NULL
+         ORDER BY m.watched_at DESC
+         LIMIT $1 OFFSET $2`,
+        [safeLimit, safeOffset],
+      );
+      return result.rows;
+    },
   },
   Mutation: {
     addMovie: async (
@@ -1892,6 +1924,143 @@ export const resolvers = {
 
       return { movieId, interested };
     },
+
+    setMovieTag: async (
+      _: any,
+      { movieId, tagSlug, value }: { movieId: string; tagSlug: string; value?: string },
+      context: any,
+    ) => {
+      if (!context.user) {
+        throw new GraphQLError('Not authenticated', { extensions: { code: 'UNAUTHENTICATED' } });
+      }
+      const userId = context.user.userId;
+
+      const tagResult = await pool.query('SELECT * FROM tags WHERE slug = $1', [tagSlug]);
+      if (tagResult.rows.length === 0) {
+        throw new GraphQLError('Tag not found', { extensions: { code: 'NOT_FOUND' } });
+      }
+      const tag = tagResult.rows[0];
+
+      const movieResult = await pool.query('SELECT id, title FROM movies WHERE id = $1', [movieId]);
+      if (movieResult.rows.length === 0) {
+        throw new GraphQLError('Movie not found', { extensions: { code: 'NOT_FOUND' } });
+      }
+
+      const result = await pool.query(
+        `INSERT INTO movie_user_tags (movie_id, user_id, tag_id, value, updated_at)
+         VALUES ($1, $2, $3, $4, NOW())
+         ON CONFLICT (movie_id, user_id, tag_id)
+         DO UPDATE SET value = $4, updated_at = NOW()
+         RETURNING *`,
+        [movieId, userId, tag.id, value ?? null],
+      );
+
+      const userResult = await pool.query(
+        'SELECT id, username, display_name FROM users WHERE id = $1',
+        [userId],
+      );
+
+      await logAudit(
+        userId,
+        'MOVIE_TAG_SET',
+        'movie',
+        String(movieId),
+        { tag: tagSlug, value: value ?? null, title: movieResult.rows[0].title },
+        context.ipAddress ?? 'unknown',
+      );
+
+      const row = result.rows[0];
+      const u = userResult.rows[0];
+      return {
+        tag: { id: String(tag.id), slug: tag.slug, label: tag.label, valueType: tag.value_type },
+        user: { id: String(u.id), username: u.username, display_name: u.display_name },
+        value: row.value,
+        createdAt:
+          row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at),
+      };
+    },
+
+    removeMovieTag: async (
+      _: any,
+      { movieId, tagSlug }: { movieId: string; tagSlug: string },
+      context: any,
+    ) => {
+      if (!context.user) {
+        throw new GraphQLError('Not authenticated', { extensions: { code: 'UNAUTHENTICATED' } });
+      }
+      const userId = context.user.userId;
+
+      const tagResult = await pool.query('SELECT id FROM tags WHERE slug = $1', [tagSlug]);
+      if (tagResult.rows.length === 0) {
+        return false;
+      }
+
+      const movieResult = await pool.query('SELECT id, title FROM movies WHERE id = $1', [movieId]);
+
+      const result = await pool.query(
+        'DELETE FROM movie_user_tags WHERE movie_id = $1 AND user_id = $2 AND tag_id = $3 RETURNING id',
+        [movieId, userId, tagResult.rows[0].id],
+      );
+
+      if (result.rows.length > 0) {
+        await logAudit(
+          userId,
+          'MOVIE_TAG_REMOVE',
+          'movie',
+          String(movieId),
+          { tag: tagSlug, title: movieResult.rows[0]?.title },
+          context.ipAddress ?? 'unknown',
+        );
+      }
+
+      return result.rows.length > 0;
+    },
+
+    unwatchMovie: async (_: any, { id }: { id: string }, context: any) => {
+      if (!context.user) {
+        throw new GraphQLError('Not authenticated', { extensions: { code: 'UNAUTHENTICATED' } });
+      }
+      const movieCheck = await pool.query('SELECT * FROM movies WHERE id = $1', [id]);
+      if (movieCheck.rows.length === 0) {
+        throw new GraphQLError('Movie not found', { extensions: { code: 'NOT_FOUND' } });
+      }
+      if (!movieCheck.rows[0].watched_at) {
+        throw new GraphQLError('Movie is not marked as watched', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+      if (!context.user.isAdmin && movieCheck.rows[0].requested_by !== context.user.userId) {
+        throw new GraphQLError('Not authorized', { extensions: { code: 'FORBIDDEN' } });
+      }
+
+      const result = await pool.query(
+        `UPDATE movies
+         SET watched_at = NULL,
+             rank = (SELECT COALESCE(MAX(rank), 0) + 1 FROM movies WHERE watched_at IS NULL)
+         WHERE id = $1
+         RETURNING *`,
+        [id],
+      );
+      const movie = result.rows[0];
+      const userRow = await pool.query('SELECT username, display_name FROM users WHERE id = $1', [
+        movie.requested_by,
+      ]);
+
+      await logAudit(
+        context.user.userId,
+        'MOVIE_UNWATCH',
+        'movie',
+        String(id),
+        { title: movie.title },
+        context.ipAddress ?? 'unknown',
+      );
+
+      return {
+        ...movie,
+        user_username: userRow.rows[0]?.username,
+        user_display_name: userRow.rows[0]?.display_name,
+      };
+    },
   },
   Movie: {
     requester: (parent: any) => {
@@ -1899,6 +2068,42 @@ export const resolvers = {
         return parent.user_display_name || parent.user_username || parent.requester || 'Unknown';
       }
       return parent.requester || 'Unknown';
+    },
+    myTags: async (parent: any, _: any, context: any) => {
+      if (!context.user) return [];
+      const result = await pool.query(
+        `SELECT mut.*, t.slug, t.label, t.value_type,
+                u.id AS uid, u.username, u.display_name
+         FROM movie_user_tags mut
+         JOIN tags t ON mut.tag_id = t.id
+         JOIN users u ON mut.user_id = u.id
+         WHERE mut.movie_id = $1 AND mut.user_id = $2`,
+        [parent.id, context.user.userId],
+      );
+      return result.rows.map((r: any) => ({
+        tag: { id: String(r.tag_id), slug: r.slug, label: r.label, valueType: r.value_type },
+        user: { id: String(r.uid), username: r.username, display_name: r.display_name },
+        value: r.value,
+        createdAt: r.created_at instanceof Date ? r.created_at.toISOString() : String(r.created_at),
+      }));
+    },
+    userTags: async (parent: any) => {
+      const result = await pool.query(
+        `SELECT mut.*, t.slug, t.label, t.value_type,
+                u.id AS uid, u.username, u.display_name
+         FROM movie_user_tags mut
+         JOIN tags t ON mut.tag_id = t.id
+         JOIN users u ON mut.user_id = u.id
+         WHERE mut.movie_id = $1
+         ORDER BY mut.created_at`,
+        [parent.id],
+      );
+      return result.rows.map((r: any) => ({
+        tag: { id: String(r.tag_id), slug: r.slug, label: r.label, valueType: r.value_type },
+        user: { id: String(r.uid), username: r.username, display_name: r.display_name },
+        value: r.value,
+        createdAt: r.created_at instanceof Date ? r.created_at.toISOString() : String(r.created_at),
+      }));
     },
     date_submitted: (parent: any) => {
       const date =

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -8,6 +8,8 @@ export const typeDefs = `#graphql
     elo_rank: Float
     tmdb_id: Int
     watched_at: String
+    myTags: [MovieUserTag!]!
+    userTags: [MovieUserTag!]!
   }
 
   type TmdbMovie {
@@ -141,6 +143,22 @@ export const typeDefs = `#graphql
     interested: Boolean!
   }
 
+  """Tag definition (e.g. 'seen', 'podcast-ep'). Extensible — new tags can be added to the DB."""
+  type Tag {
+    id: ID!
+    slug: String!
+    label: String!
+    valueType: String!
+  }
+
+  """A per-user tag on a movie. Boolean tags have null value; number/text tags carry a value."""
+  type MovieUserTag {
+    tag: Tag!
+    user: ConnectionUser!
+    value: String
+    createdAt: String!
+  }
+
   type Query {
     appInfo: AppInfo!
     movies: [Movie!]!
@@ -161,6 +179,8 @@ export const typeDefs = `#graphql
     newMoviesFromConnections: [PendingReviewMovie!]!
     soloMovies: [Movie!]!
     passedMovieIds: [ID!]!
+    tags: [Tag!]!
+    watchedMovies(limit: Int, offset: Int): [Movie!]!
   }
 
   type ImportResult {
@@ -203,5 +223,8 @@ export const typeDefs = `#graphql
     respondToConnectionRequest(connectionId: ID!, accept: Boolean!): UserConnection!
     removeConnection(connectionId: ID!): Boolean!
     setMovieInterest(movieId: ID!, interested: Boolean!): SetInterestResult!
+    setMovieTag(movieId: ID!, tagSlug: String!, value: String): MovieUserTag!
+    removeMovieTag(movieId: ID!, tagSlug: String!): Boolean!
+    unwatchMovie(id: ID!): Movie!
   }
 `;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Box, Typography, CircularProgress } from '@mui/joy';
 import HomePage from './components/home/Homepage';
 import ThisOrThat from './components/home/ThisOrThat';
 import CombinedList from './components/home/CombinedList';
+import WatchHistory from './components/home/WatchHistory';
 import { Login } from './components/auth/Login';
 import { ForgotPassword } from './components/auth/ForgotPassword';
 import { ResetPassword } from './components/auth/ResetPassword';
@@ -14,7 +15,7 @@ import { useAuth } from './contexts/AuthContext';
 const GIT_BRANCH = process.env.REACT_APP_GIT_BRANCH;
 const IS_TEST_ENV = GIT_BRANCH && GIT_BRANCH !== 'master';
 
-type ViewName = 'movies' | 'this-or-that' | 'combined-list' | 'admin';
+type ViewName = 'movies' | 'this-or-that' | 'combined-list' | 'history' | 'admin';
 
 const App = () => {
   const { isAuthenticated, isLoading, user } = useAuth();
@@ -94,6 +95,10 @@ const App = () => {
       return <CombinedList />;
     }
 
+    if (currentView === 'history' && isAuthenticated) {
+      return <WatchHistory />;
+    }
+
     return (
       <HomePage
         onShowThisOrThat={() => setCurrentView('this-or-that')}
@@ -135,6 +140,7 @@ const App = () => {
         onShowMovies={() => setCurrentView('movies')}
         onShowThisOrThat={() => setCurrentView('this-or-that')}
         onShowCombinedList={() => setCurrentView('combined-list')}
+        onShowHistory={() => setCurrentView('history')}
         onShowAdmin={() => setCurrentView('admin')}
         onShowLogin={() => setShowLogin(true)}
       />

--- a/src/components/common/Navbar.tsx
+++ b/src/components/common/Navbar.tsx
@@ -3,13 +3,14 @@ import { Box, Button, Typography, IconButton, Divider } from '@mui/joy';
 import { useAuth } from '../../contexts/AuthContext';
 import { getGravatarUrl } from '../../utils/gravatar';
 
-type ViewName = 'movies' | 'this-or-that' | 'combined-list' | 'admin';
+type ViewName = 'movies' | 'this-or-that' | 'combined-list' | 'history' | 'admin';
 
 interface NavbarProps {
   currentView: ViewName;
   onShowMovies: () => void;
   onShowThisOrThat: () => void;
   onShowCombinedList: () => void;
+  onShowHistory: () => void;
   onShowAdmin: () => void;
   onShowLogin: () => void;
 }
@@ -19,6 +20,7 @@ export const Navbar: React.FC<NavbarProps> = ({
   onShowMovies,
   onShowThisOrThat,
   onShowCombinedList,
+  onShowHistory,
   onShowAdmin,
   onShowLogin,
 }) => {
@@ -77,6 +79,25 @@ export const Navbar: React.FC<NavbarProps> = ({
           }}
         >
           Combined
+        </Button>
+      )}
+      {isAuthenticated && (
+        <Button
+          variant={currentView === 'history' ? 'soft' : 'plain'}
+          color="neutral"
+          size="sm"
+          onClick={() => {
+            onShowHistory();
+            setMobileOpen(false);
+          }}
+          sx={{
+            fontWeight: 600,
+            color: currentView === 'history' ? 'primary.400' : 'text.tertiary',
+            '&:hover': { color: 'primary.300' },
+            fontSize: '0.8rem',
+          }}
+        >
+          History
         </Button>
       )}
       {isAuthenticated && user?.is_admin && (

--- a/src/components/home/Homepage.tsx
+++ b/src/components/home/Homepage.tsx
@@ -229,6 +229,7 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
   const [matchFlowOpen, setMatchFlowOpen] = useState(false);
   const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
   const [lastAddedMovieId, setLastAddedMovieId] = useState<string | null>(null);
+  const [askSeenMovieId, setAskSeenMovieId] = useState<string | null>(null);
 
   // Connections data (only when authenticated)
   const { data: connectionsData } = useQuery(MY_CONNECTIONS, { skip: !isAuthenticated });
@@ -557,31 +558,68 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
                       added by {item.addedBy.display_name || item.addedBy.username}
                     </Typography>
                   </Box>
-                  <Box sx={{ display: 'flex', gap: 0.5 }}>
-                    <Button
-                      size="sm"
-                      variant="soft"
-                      color="success"
-                      onClick={() =>
-                        setMovieInterest({
-                          variables: { movieId: item.movie.id, interested: true },
-                        })
-                      }
-                    >
-                      I'm in
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="plain"
-                      color="neutral"
-                      onClick={() =>
-                        setMovieInterest({
-                          variables: { movieId: item.movie.id, interested: false },
-                        })
-                      }
-                    >
-                      Pass
-                    </Button>
+                  <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
+                    {askSeenMovieId === item.movie.id ? (
+                      <>
+                        <Typography level="body-xs" sx={{ color: 'text.tertiary', mr: 0.5 }}>
+                          Seen it?
+                        </Typography>
+                        <Button
+                          size="sm"
+                          variant="soft"
+                          color="warning"
+                          onClick={async () => {
+                            setAskSeenMovieId(null);
+                            await setMovieInterest({
+                              variables: { movieId: item.movie.id, interested: true },
+                            });
+                            try {
+                              await setMovieTag({
+                                variables: { movieId: item.movie.id, tagSlug: 'seen' },
+                              });
+                            } catch {}
+                          }}
+                        >
+                          Yes
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="plain"
+                          color="neutral"
+                          onClick={() => {
+                            setAskSeenMovieId(null);
+                            setMovieInterest({
+                              variables: { movieId: item.movie.id, interested: true },
+                            });
+                          }}
+                        >
+                          No
+                        </Button>
+                      </>
+                    ) : (
+                      <>
+                        <Button
+                          size="sm"
+                          variant="soft"
+                          color="success"
+                          onClick={() => setAskSeenMovieId(item.movie.id)}
+                        >
+                          I'm in
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="plain"
+                          color="neutral"
+                          onClick={() =>
+                            setMovieInterest({
+                              variables: { movieId: item.movie.id, interested: false },
+                            })
+                          }
+                        >
+                          Pass
+                        </Button>
+                      </>
+                    )}
                   </Box>
                 </Box>
               ))}

--- a/src/components/home/Homepage.tsx
+++ b/src/components/home/Homepage.tsx
@@ -15,6 +15,8 @@ import {
   SET_MOVIE_INTEREST,
   SOLO_MOVIES,
   PASSED_MOVIE_IDS,
+  SET_MOVIE_TAG,
+  REMOVE_MOVIE_TAG,
 } from '../../graphql/queries';
 import {
   Autocomplete,
@@ -27,6 +29,7 @@ import {
   IconButton,
   ListItemContent,
   CircularProgress,
+  Tooltip,
 } from '@mui/joy';
 import TmdbMatchFlow from './TmdbMatchFlow';
 import { Movie } from '../../models/Movies';
@@ -58,6 +61,7 @@ interface MovieRowProps {
   canMarkWatched: boolean;
   onMarkWatched: (id: string, title: string) => void;
   onDelete: (id: string, title: string) => void;
+  onToggleSeen: (id: string, currentlySeen: boolean) => void;
   isAuthenticated: boolean;
 }
 
@@ -67,95 +71,144 @@ const MovieRow: React.FC<MovieRowProps> = ({
   canMarkWatched,
   onMarkWatched,
   onDelete,
+  onToggleSeen,
   isAuthenticated,
-}) => (
-  <tr>
-    {/* Title */}
-    <td style={{ verticalAlign: 'middle', padding: '12px 16px' }}>
-      <Typography level="body-sm" sx={{ fontWeight: 600, color: 'text.primary' }}>
-        {movie.title}
-      </Typography>
-    </td>
+}) => {
+  const isSeen = movie.myTags?.some((t) => t.tag.slug === 'seen') ?? false;
+  const seenByUsers = (movie.userTags ?? []).filter((t) => t.tag.slug === 'seen');
+  const seenCount = seenByUsers.length;
+  const seenNames = seenByUsers.map((t) => t.user.display_name || t.user.username);
 
-    {/* Suggested by */}
-    <td style={{ verticalAlign: 'middle', padding: '12px 16px' }}>
-      <Chip size="sm" variant="soft" color="neutral" sx={{ fontWeight: 500 }}>
-        {movie.requester}
-      </Chip>
-    </td>
-
-    {/* Date */}
-    <td style={{ verticalAlign: 'middle', padding: '12px 16px', whiteSpace: 'nowrap' }}>
-      <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
-        {new Date(movie.date_submitted).toLocaleDateString(undefined, {
-          year: 'numeric',
-          month: 'short',
-          day: 'numeric',
-        })}
-      </Typography>
-    </td>
-
-    {/* TMDB */}
-    <td style={{ verticalAlign: 'middle', padding: '12px 8px', textAlign: 'center' }}>
-      {movie.tmdb_id ? (
-        <a
-          href={`https://www.themoviedb.org/movie/${movie.tmdb_id}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{ color: 'var(--joy-palette-primary-500)', fontSize: '0.75rem' }}
-        >
-          ↗
-        </a>
-      ) : null}
-    </td>
-
-    {/* Actions */}
-    {(canMarkWatched || isAdmin) && (
-      <td
-        style={{
-          verticalAlign: 'middle',
-          padding: '0 12px',
-          textAlign: 'right',
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {canMarkWatched && (
-          <IconButton
-            size="sm"
-            color="success"
-            variant="plain"
-            onClick={() => onMarkWatched(movie.id, movie.title)}
-            title={`Mark "${movie.title}" as watched`}
-            sx={{
-              opacity: 0.5,
-              transition: 'opacity 0.15s',
-              '&:hover': { opacity: 1 },
-              mr: isAdmin ? 0.5 : 0,
-            }}
-          >
-            ✓
-          </IconButton>
-        )}
-        {isAdmin && (
-          <IconButton
-            size="sm"
-            color="danger"
-            variant="plain"
-            onClick={() => onDelete(movie.id, movie.title)}
-            title={`Remove "${movie.title}"`}
-            sx={{
-              opacity: 0.5,
-              transition: 'opacity 0.15s',
-              '&:hover': { opacity: 1 },
-            }}
-          >
-            ✕
-          </IconButton>
-        )}
+  return (
+    <tr>
+      {/* Title */}
+      <td style={{ verticalAlign: 'middle', padding: '12px 16px' }}>
+        <Typography level="body-sm" sx={{ fontWeight: 600, color: 'text.primary' }}>
+          {movie.title}
+        </Typography>
       </td>
-    )}
-  </tr>
-);
+
+      {/* Suggested by */}
+      <td style={{ verticalAlign: 'middle', padding: '12px 16px' }}>
+        <Chip size="sm" variant="soft" color="neutral" sx={{ fontWeight: 500 }}>
+          {movie.requester}
+        </Chip>
+      </td>
+
+      {/* Date */}
+      <td style={{ verticalAlign: 'middle', padding: '12px 16px', whiteSpace: 'nowrap' }}>
+        <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
+          {new Date(movie.date_submitted).toLocaleDateString(undefined, {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+          })}
+        </Typography>
+      </td>
+
+      {/* TMDB */}
+      <td style={{ verticalAlign: 'middle', padding: '12px 8px', textAlign: 'center' }}>
+        {movie.tmdb_id ? (
+          <a
+            href={`https://www.themoviedb.org/movie/${movie.tmdb_id}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: 'var(--joy-palette-primary-500)', fontSize: '0.75rem' }}
+          >
+            ↗
+          </a>
+        ) : null}
+      </td>
+
+      {/* Seen it */}
+      {isAuthenticated && (
+        <td style={{ verticalAlign: 'middle', padding: '0 4px', textAlign: 'center' }}>
+          <Tooltip
+            title={
+              seenCount > 0
+                ? `Seen by: ${seenNames.join(', ')}`
+                : isSeen
+                  ? 'Remove "Seen it"'
+                  : "I've seen this"
+            }
+            placement="top"
+            arrow
+          >
+            <IconButton
+              size="sm"
+              variant="plain"
+              color={isSeen ? 'warning' : 'neutral'}
+              onClick={() => onToggleSeen(movie.id, isSeen)}
+              sx={{
+                opacity: isSeen ? 0.9 : 0.35,
+                transition: 'opacity 0.15s',
+                '&:hover': { opacity: 1 },
+                fontSize: '0.85rem',
+              }}
+            >
+              {isSeen ? '👁' : '👁‍🗨'}
+              {seenCount > 0 && (
+                <Typography
+                  component="span"
+                  level="body-xs"
+                  sx={{ ml: 0.25, fontWeight: 700, fontSize: '0.6rem' }}
+                >
+                  {seenCount}
+                </Typography>
+              )}
+            </IconButton>
+          </Tooltip>
+        </td>
+      )}
+
+      {/* Actions */}
+      {(canMarkWatched || isAdmin) && (
+        <td
+          style={{
+            verticalAlign: 'middle',
+            padding: '0 12px',
+            textAlign: 'right',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {canMarkWatched && (
+            <IconButton
+              size="sm"
+              color="success"
+              variant="plain"
+              onClick={() => onMarkWatched(movie.id, movie.title)}
+              title={`Mark "${movie.title}" as done`}
+              sx={{
+                opacity: 0.5,
+                transition: 'opacity 0.15s',
+                '&:hover': { opacity: 1 },
+                mr: isAdmin ? 0.5 : 0,
+              }}
+            >
+              ✓
+            </IconButton>
+          )}
+          {isAdmin && (
+            <IconButton
+              size="sm"
+              color="danger"
+              variant="plain"
+              onClick={() => onDelete(movie.id, movie.title)}
+              title={`Remove "${movie.title}"`}
+              sx={{
+                opacity: 0.5,
+                transition: 'opacity 0.15s',
+                '&:hover': { opacity: 1 },
+              }}
+            >
+              ✕
+            </IconButton>
+          )}
+        </td>
+      )}
+    </tr>
+  );
+};
 
 // ── Page ──────────────────────────────────────────────────────────────────────
 
@@ -175,6 +228,7 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
   const [errorMessage, setErrorMessage] = useState('');
   const [matchFlowOpen, setMatchFlowOpen] = useState(false);
   const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
+  const [lastAddedMovieId, setLastAddedMovieId] = useState<string | null>(null);
 
   // Connections data (only when authenticated)
   const { data: connectionsData } = useQuery(MY_CONNECTIONS, { skip: !isAuthenticated });
@@ -201,6 +255,13 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
     skip: !isAuthenticated,
     pollInterval: 10000,
   });
+  const [setMovieTag] = useMutation(SET_MOVIE_TAG, {
+    refetchQueries: [{ query: GET_MOVIES }],
+  });
+  const [removeMovieTag] = useMutation(REMOVE_MOVIE_TAG, {
+    refetchQueries: [{ query: GET_MOVIES }],
+  });
+
   const [setMovieInterest] = useMutation(SET_MOVIE_INTEREST, {
     refetchQueries: [
       { query: NEW_MOVIES_FROM_CONNECTIONS },
@@ -266,12 +327,23 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
   );
 
   const handleMarkWatched = async (id: string, movieTitle: string) => {
-    if (!window.confirm(`Mark "${movieTitle}" as watched? It will be removed from the watchlist.`))
-      return;
+    if (!window.confirm(`Mark "${movieTitle}" as done? It'll move to your watch history.`)) return;
     try {
       await markWatched({ variables: { id } });
     } catch (err: any) {
-      setErrorMessage(`Error marking movie as watched: ${err.message}`);
+      setErrorMessage(`Error marking movie as done: ${err.message}`);
+    }
+  };
+
+  const handleToggleSeen = async (id: string, currentlySeen: boolean) => {
+    try {
+      if (currentlySeen) {
+        await removeMovieTag({ variables: { movieId: id, tagSlug: 'seen' } });
+      } else {
+        await setMovieTag({ variables: { movieId: id, tagSlug: 'seen' } });
+      }
+    } catch (err: any) {
+      setErrorMessage(`Error updating tag: ${err.message}`);
     }
   };
 
@@ -303,12 +375,18 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
       return;
     }
     try {
-      await addMovie({ variables: { title: title.trim(), tmdb_id: tmdbId } });
+      const { data: addData } = await addMovie({
+        variables: { title: title.trim(), tmdb_id: tmdbId },
+      });
       setSuccessMessage('Added to the list!');
+      setLastAddedMovieId(addData?.addMovie?.id ?? null);
       setTitle('');
       setTmdbId(null);
       setTmdbOptions([]);
-      setTimeout(() => setSuccessMessage(''), 3000);
+      setTimeout(() => {
+        setSuccessMessage('');
+        setLastAddedMovieId(null);
+      }, 5000);
     } catch (error: any) {
       setErrorMessage(`Error: ${error.message}`);
     }
@@ -320,6 +398,7 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
     1 + // suggested by
     1 + // added
     1 + // tmdb
+    (isAuthenticated ? 1 : 0) + // seen
     (isAuthenticated ? 1 : 0); // actions
 
   return (
@@ -607,12 +686,39 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
             </form>
 
             {successMessage && (
-              <Typography
-                level="body-sm"
-                sx={{ textAlign: 'center', mt: 1.5, color: 'success.400', fontWeight: 600 }}
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 1.5,
+                  mt: 1.5,
+                }}
               >
-                {successMessage}
-              </Typography>
+                <Typography level="body-sm" sx={{ color: 'success.400', fontWeight: 600 }}>
+                  {successMessage}
+                </Typography>
+                {lastAddedMovieId && (
+                  <Button
+                    size="sm"
+                    variant="soft"
+                    color="neutral"
+                    onClick={async () => {
+                      try {
+                        await setMovieTag({
+                          variables: { movieId: lastAddedMovieId, tagSlug: 'seen' },
+                        });
+                        setLastAddedMovieId(null);
+                      } catch (err: any) {
+                        setErrorMessage(`Error: ${err.message}`);
+                      }
+                    }}
+                    sx={{ fontSize: '0.75rem', py: 0.25 }}
+                  >
+                    I've seen this
+                  </Button>
+                )}
+              </Box>
             )}
             {errorMessage && (
               <Typography
@@ -809,6 +915,7 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
                         canMarkWatched={true}
                         onMarkWatched={handleMarkWatched}
                         onDelete={handleDelete}
+                        onToggleSeen={handleToggleSeen}
                         isAuthenticated={isAuthenticated}
                       />
                     ))}
@@ -900,6 +1007,21 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
                     {isAuthenticated && (
                       <th
                         style={{
+                          padding: '10px 4px',
+                          textAlign: 'center',
+                          fontSize: '0.7rem',
+                          fontWeight: 700,
+                          textTransform: 'uppercase',
+                          letterSpacing: '0.08em',
+                          color: 'var(--mn-text-muted)',
+                        }}
+                      >
+                        Seen
+                      </th>
+                    )}
+                    {isAuthenticated && (
+                      <th
+                        style={{
                           padding: '10px 12px',
                           textAlign: 'right',
                           fontSize: '0.7rem',
@@ -939,6 +1061,7 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
                         }
                         onMarkWatched={handleMarkWatched}
                         onDelete={handleDelete}
+                        onToggleSeen={handleToggleSeen}
                         isAuthenticated={isAuthenticated}
                       />
                     ))

--- a/src/components/home/WatchHistory.tsx
+++ b/src/components/home/WatchHistory.tsx
@@ -1,0 +1,235 @@
+import React, { useState } from 'react';
+import { useQuery, useMutation } from '@apollo/client';
+import { Box, Button, Typography, Sheet, Chip, IconButton, Tooltip } from '@mui/joy';
+import { WATCHED_MOVIES, UNWATCH_MOVIE, GET_MOVIES } from '../../graphql/queries';
+import { useAuth } from '../../contexts/AuthContext';
+
+const PAGE_SIZE = 25;
+
+const WatchHistory: React.FC = () => {
+  const { user } = useAuth();
+  const isAdmin = user?.is_admin ?? false;
+  const [offset, setOffset] = useState(0);
+
+  const { data, loading } = useQuery(WATCHED_MOVIES, {
+    variables: { limit: PAGE_SIZE, offset },
+    fetchPolicy: 'cache-and-network',
+  });
+
+  const [unwatchMovie] = useMutation(UNWATCH_MOVIE, {
+    refetchQueries: [
+      { query: WATCHED_MOVIES, variables: { limit: PAGE_SIZE, offset } },
+      { query: GET_MOVIES },
+    ],
+  });
+
+  const movies = data?.watchedMovies ?? [];
+
+  const handleUnwatch = async (id: string, title: string) => {
+    if (!window.confirm(`Put "${title}" back in the queue? It'll appear at the end of the list.`))
+      return;
+    try {
+      await unwatchMovie({ variables: { id } });
+    } catch (err: any) {
+      alert(`Error: ${err.message}`);
+    }
+  };
+
+  return (
+    <Box
+      component="main"
+      sx={{
+        flex: 1,
+        bgcolor: 'background.body',
+        px: { xs: 2, sm: 3, md: 4 },
+        py: { xs: 3, sm: 5 },
+      }}
+    >
+      <Box sx={{ maxWidth: 900, mx: 'auto' }}>
+        <Box sx={{ textAlign: 'center', mb: { xs: 3, sm: 4 } }}>
+          <Typography level="h2" sx={{ fontWeight: 800, letterSpacing: '-0.02em', mb: 0.5 }}>
+            Watch History
+          </Typography>
+          <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
+            Movies you&rsquo;ve already watched together
+          </Typography>
+        </Box>
+
+        {loading && movies.length === 0 && (
+          <Typography level="body-sm" sx={{ textAlign: 'center', color: 'text.tertiary' }}>
+            Loading...
+          </Typography>
+        )}
+
+        {!loading && movies.length === 0 && (
+          <Typography level="body-sm" sx={{ textAlign: 'center', color: 'text.tertiary', py: 6 }}>
+            No movies watched yet. Get watching!
+          </Typography>
+        )}
+
+        {movies.length > 0 && (
+          <Sheet
+            variant="outlined"
+            sx={{
+              borderRadius: 'md',
+              overflow: 'clip',
+              borderColor: 'var(--mn-border-vis)',
+            }}
+          >
+            <Box sx={{ overflowX: 'auto' }}>
+              <table
+                style={{
+                  width: '100%',
+                  minWidth: 480,
+                  borderCollapse: 'collapse',
+                  tableLayout: 'auto',
+                }}
+              >
+                <thead>
+                  <tr
+                    style={{
+                      background: 'var(--mn-bg-elevated)',
+                      borderBottom: '1px solid var(--mn-border-vis)',
+                    }}
+                  >
+                    {['Title', 'Suggested by', 'Watched'].map((label) => (
+                      <th
+                        key={label}
+                        style={{
+                          padding: '10px 16px',
+                          textAlign: 'left',
+                          fontSize: '0.7rem',
+                          fontWeight: 700,
+                          textTransform: 'uppercase',
+                          letterSpacing: '0.08em',
+                          color: 'var(--mn-text-muted)',
+                        }}
+                      >
+                        {label}
+                      </th>
+                    ))}
+                    <th
+                      style={{
+                        padding: '10px 12px',
+                        textAlign: 'right',
+                        fontSize: '0.7rem',
+                        fontWeight: 700,
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.08em',
+                        color: 'var(--mn-text-muted)',
+                      }}
+                    />
+                  </tr>
+                </thead>
+                <tbody>
+                  {movies.map((movie: any) => {
+                    const canUnwatch = isAdmin || String(movie.requested_by) === String(user?.id);
+                    return (
+                      <tr key={movie.id}>
+                        <td style={{ verticalAlign: 'middle', padding: '12px 16px' }}>
+                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            <Typography
+                              level="body-sm"
+                              sx={{ fontWeight: 600, color: 'text.primary' }}
+                            >
+                              {movie.title}
+                            </Typography>
+                            {movie.tmdb_id && (
+                              <a
+                                href={`https://www.themoviedb.org/movie/${movie.tmdb_id}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                style={{
+                                  color: 'var(--joy-palette-primary-500)',
+                                  fontSize: '0.75rem',
+                                }}
+                              >
+                                ↗
+                              </a>
+                            )}
+                          </Box>
+                        </td>
+                        <td style={{ verticalAlign: 'middle', padding: '12px 16px' }}>
+                          <Chip size="sm" variant="soft" color="neutral" sx={{ fontWeight: 500 }}>
+                            {movie.requester}
+                          </Chip>
+                        </td>
+                        <td
+                          style={{
+                            verticalAlign: 'middle',
+                            padding: '12px 16px',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
+                            {movie.watched_at
+                              ? new Date(movie.watched_at).toLocaleDateString(undefined, {
+                                  year: 'numeric',
+                                  month: 'short',
+                                  day: 'numeric',
+                                })
+                              : '—'}
+                          </Typography>
+                        </td>
+                        <td
+                          style={{
+                            verticalAlign: 'middle',
+                            padding: '0 12px',
+                            textAlign: 'right',
+                          }}
+                        >
+                          {canUnwatch && (
+                            <Tooltip title="Watch again — put back in queue" arrow>
+                              <IconButton
+                                size="sm"
+                                color="primary"
+                                variant="plain"
+                                onClick={() => handleUnwatch(movie.id, movie.title)}
+                                sx={{
+                                  opacity: 0.5,
+                                  transition: 'opacity 0.15s',
+                                  '&:hover': { opacity: 1 },
+                                  fontSize: '0.8rem',
+                                }}
+                              >
+                                ↩
+                              </IconButton>
+                            </Tooltip>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </Box>
+          </Sheet>
+        )}
+
+        {/* Pagination */}
+        {(offset > 0 || movies.length === PAGE_SIZE) && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', gap: 1, mt: 2 }}>
+            <Button
+              variant="plain"
+              size="sm"
+              disabled={offset === 0}
+              onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="plain"
+              size="sm"
+              disabled={movies.length < PAGE_SIZE}
+              onClick={() => setOffset(offset + PAGE_SIZE)}
+            >
+              Next
+            </Button>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default WatchHistory;

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -10,6 +10,23 @@ export const GET_MOVIES = gql`
       date_submitted
       elo_rank
       tmdb_id
+      myTags {
+        tag {
+          slug
+          label
+        }
+      }
+      userTags {
+        tag {
+          slug
+          label
+        }
+        user {
+          id
+          display_name
+          username
+        }
+      }
     }
   }
 `;
@@ -523,5 +540,64 @@ export const SOLO_MOVIES = gql`
 export const PASSED_MOVIE_IDS = gql`
   query PassedMovieIds {
     passedMovieIds
+  }
+`;
+
+export const GET_TAGS = gql`
+  query GetTags {
+    tags {
+      id
+      slug
+      label
+      valueType
+    }
+  }
+`;
+
+export const SET_MOVIE_TAG = gql`
+  mutation SetMovieTag($movieId: ID!, $tagSlug: String!, $value: String) {
+    setMovieTag(movieId: $movieId, tagSlug: $tagSlug, value: $value) {
+      tag {
+        slug
+        label
+      }
+      user {
+        id
+        display_name
+        username
+      }
+      value
+      createdAt
+    }
+  }
+`;
+
+export const REMOVE_MOVIE_TAG = gql`
+  mutation RemoveMovieTag($movieId: ID!, $tagSlug: String!) {
+    removeMovieTag(movieId: $movieId, tagSlug: $tagSlug)
+  }
+`;
+
+export const WATCHED_MOVIES = gql`
+  query WatchedMovies($limit: Int, $offset: Int) {
+    watchedMovies(limit: $limit, offset: $offset) {
+      id
+      title
+      requester
+      requested_by
+      date_submitted
+      watched_at
+      tmdb_id
+    }
+  }
+`;
+
+export const UNWATCH_MOVIE = gql`
+  mutation UnwatchMovie($id: ID!) {
+    unwatchMovie(id: $id) {
+      id
+      title
+      watched_at
+    }
   }
 `;

--- a/src/models/Movies.ts
+++ b/src/models/Movies.ts
@@ -1,3 +1,9 @@
+export type MovieUserTag = {
+  tag: { slug: string; label: string };
+  user: { id: string; display_name?: string | null; username: string };
+  value?: string | null;
+};
+
 export type Movie = {
   id: string;
   title: string;
@@ -7,4 +13,6 @@ export type Movie = {
   elo_rank: number | null;
   tmdb_id?: number | null;
   watched_at?: string | null;
+  myTags?: MovieUserTag[];
+  userTags?: MovieUserTag[];
 };


### PR DESCRIPTION
## Summary
- Adds a generic per-user movie tagging system (`tags` + `movie_user_tags` tables) — first tag: "Seen it"
- Renames "Mark watched" → "Done" for clearer UX terminology
- Adds a "Watch History" view with "Watch again" to re-queue movies
- Extensible for future tags (e.g. podcast episode ordering)

## Test plan
- [ ] Migration creates `tags` and `movie_user_tags` tables with "seen" seed
- [ ] `setMovieTag` / `removeMovieTag` mutations work with auth checks
- [ ] `unwatchMovie` clears `watched_at` and re-ranks movie into queue
- [ ] "Seen it" eye icon toggles per-user on movie rows
- [ ] "Done" wording replaces "Mark watched" in UI
- [ ] History view shows watched movies with "Watch again" button
- [ ] All backend tests pass (tag resolvers, unwatch resolver)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)