### PR TITLE
feat: UX fixes — poster scaling + list thumbnails

### DIFF
--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -211,6 +211,7 @@ export const resolvers = {
         // Authenticated: order by personal Elo (unrated movies at bottom)
         const result = await pool.query(
           `SELECT m.id, m.title, m.requested_by, m.date_submitted, m.rank, m.tmdb_id, m.watched_at,
+                  m.poster_path,
                   COALESCE(ume.elo_rating, m.elo_rank) AS elo_rank,
                   u.username AS user_username, u.display_name AS user_display_name
            FROM movies m
@@ -225,7 +226,7 @@ export const resolvers = {
       // Unauthenticated: order by global elo_rank
       const result = await pool.query(
         `SELECT m.id, m.title, m.requested_by, m.date_submitted, m.rank, m.tmdb_id, m.watched_at,
-                m.elo_rank,
+                m.poster_path, m.elo_rank,
                 u.username AS user_username, u.display_name AS user_display_name
          FROM movies m
          LEFT JOIN users u ON m.requested_by = u.id
@@ -237,7 +238,7 @@ export const resolvers = {
     movie: async (_: any, { id }: { id: string }) => {
       const result = await pool.query(
         `SELECT m.id, m.title, m.requested_by, m.date_submitted, m.rank, m.tmdb_id, m.watched_at,
-                m.elo_rank,
+                m.poster_path, m.elo_rank,
                 u.username AS user_username, u.display_name AS user_display_name
          FROM movies m
          LEFT JOIN users u ON m.requested_by = u.id
@@ -2120,6 +2121,9 @@ export const resolvers = {
     },
     elo_rank: (parent: any) => {
       return parent.elo_rank != null ? Number(parent.elo_rank) : null;
+    },
+    poster_url: (parent: any) => {
+      return parent.poster_path ? `https://image.tmdb.org/t/p/w92${parent.poster_path}` : null;
     },
   },
   User: {

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -8,6 +8,7 @@ export const typeDefs = `#graphql
     elo_rank: Float
     tmdb_id: Int
     watched_at: String
+    poster_url: String
     myTags: [MovieUserTag!]!
     userTags: [MovieUserTag!]!
   }

--- a/src/components/home/Homepage.tsx
+++ b/src/components/home/Homepage.tsx
@@ -82,10 +82,35 @@ const MovieRow: React.FC<MovieRowProps> = ({
   return (
     <tr>
       {/* Title */}
-      <td style={{ verticalAlign: 'middle', padding: '12px 16px' }}>
-        <Typography level="body-sm" sx={{ fontWeight: 600, color: 'text.primary' }}>
-          {movie.title}
-        </Typography>
+      <td style={{ verticalAlign: 'middle', padding: '8px 16px' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          {movie.poster_url ? (
+            <img
+              src={movie.poster_url}
+              alt=""
+              style={{
+                width: 28,
+                height: 42,
+                objectFit: 'cover',
+                borderRadius: 3,
+                flexShrink: 0,
+              }}
+            />
+          ) : (
+            <Box
+              sx={{
+                width: 28,
+                height: 42,
+                bgcolor: 'background.level2',
+                borderRadius: '3px',
+                flexShrink: 0,
+              }}
+            />
+          )}
+          <Typography level="body-sm" sx={{ fontWeight: 600, color: 'text.primary' }}>
+            {movie.title}
+          </Typography>
+        </Box>
       </td>
 
       {/* Suggested by */}

--- a/src/components/home/MovieCompareCard.tsx
+++ b/src/components/home/MovieCompareCard.tsx
@@ -46,7 +46,8 @@ const MovieCompareCard: React.FC<MovieCompareCardProps> = ({ movie, onPick, disa
     <Box
       sx={{
         width: '100%',
-        aspectRatio: { xs: '3/4', sm: '2/3' },
+        maxHeight: { xs: 'calc(50dvh - 80px)', sm: 'calc(70dvh - 100px)' },
+        aspectRatio: '2/3',
         bgcolor: 'background.level2',
         display: 'flex',
         alignItems: 'center',
@@ -58,7 +59,7 @@ const MovieCompareCard: React.FC<MovieCompareCardProps> = ({ movie, onPick, disa
         <img
           src={movie.poster_url}
           alt={movie.title}
-          style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+          style={{ width: '100%', height: '100%', objectFit: 'contain' }}
         />
       ) : (
         <Typography level="body-sm" sx={{ color: 'text.tertiary', textAlign: 'center', px: 2 }}>

--- a/src/components/home/MovieCompareCard.tsx
+++ b/src/components/home/MovieCompareCard.tsx
@@ -69,8 +69,19 @@ const MovieCompareCard: React.FC<MovieCompareCardProps> = ({ movie, onPick, disa
     </Box>
 
     {/* Info */}
-    <Box sx={{ p: { xs: 1, sm: 2 }, flex: 1, display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-      <Typography level="title-sm" sx={{ fontWeight: 700, fontSize: { xs: '0.8rem', sm: '1rem' } }}>
+    <Box
+      sx={{
+        p: { xs: 0.75, sm: 1.5 },
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: { xs: 0.25, sm: 0.5 },
+      }}
+    >
+      <Typography
+        level="title-sm"
+        sx={{ fontWeight: 700, fontSize: { xs: '0.75rem', sm: '0.95rem' }, lineHeight: 1.3 }}
+      >
         {movie.title}
         {movie.release_year && (
           <Typography component="span" level="body-xs" sx={{ color: 'text.secondary', ml: 0.5 }}>
@@ -80,15 +91,24 @@ const MovieCompareCard: React.FC<MovieCompareCardProps> = ({ movie, onPick, disa
       </Typography>
 
       {movie.director && (
-        <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
-          Directed by {movie.director}
+        <Typography
+          level="body-xs"
+          sx={{ color: 'text.secondary', fontSize: { xs: '0.65rem', sm: '0.75rem' } }}
+        >
+          {movie.director}
         </Typography>
       )}
 
       {movie.cast.length > 0 && (
-        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.25 }}>
           {movie.cast.map((name) => (
-            <Chip key={name} size="sm" variant="soft" color="neutral">
+            <Chip
+              key={name}
+              size="sm"
+              variant="soft"
+              color="neutral"
+              sx={{ '--Chip-minHeight': '20px', fontSize: { xs: '0.6rem', sm: '0.7rem' } }}
+            >
               {name}
             </Chip>
           ))}
@@ -96,9 +116,15 @@ const MovieCompareCard: React.FC<MovieCompareCardProps> = ({ movie, onPick, disa
       )}
 
       {movie.tags.length > 0 && (
-        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.25 }}>
           {movie.tags.map((tag) => (
-            <Chip key={tag} size="sm" variant="outlined" color="primary">
+            <Chip
+              key={tag}
+              size="sm"
+              variant="outlined"
+              color="primary"
+              sx={{ '--Chip-minHeight': '20px', fontSize: { xs: '0.6rem', sm: '0.7rem' } }}
+            >
               {tag}
             </Chip>
           ))}
@@ -111,17 +137,18 @@ const MovieCompareCard: React.FC<MovieCompareCardProps> = ({ movie, onPick, disa
         </Typography>
       )}
 
-      <Box sx={{ mt: 'auto', pt: 1 }}>
+      <Box sx={{ mt: 'auto', pt: { xs: 0.5, sm: 0.75 } }}>
         <Button
           variant="solid"
           color="primary"
           fullWidth
+          size="sm"
           disabled={disabled}
           onClick={(e) => {
             e.stopPropagation();
             onPick(movie.id);
           }}
-          sx={{ fontWeight: 700, color: '#0d0f1a' }}
+          sx={{ fontWeight: 700, color: '#0d0f1a', fontSize: { xs: '0.75rem', sm: '0.875rem' } }}
         >
           Pick This One
         </Button>

--- a/src/components/home/ThisOrThat.tsx
+++ b/src/components/home/ThisOrThat.tsx
@@ -237,7 +237,11 @@ const ThisOrThat: React.FC = () => {
                   >
                     <Skeleton
                       variant="rectangular"
-                      sx={{ width: '100%', aspectRatio: { xs: '3/4', sm: '2/3' } }}
+                      sx={{
+                        width: '100%',
+                        aspectRatio: '2/3',
+                        maxHeight: { xs: 'calc(50dvh - 80px)', sm: 'calc(70dvh - 100px)' },
+                      }}
                     />
                     <Box sx={{ p: { xs: 1, sm: 2 } }}>
                       <Skeleton variant="text" sx={{ width: '70%', mb: 1 }} />

--- a/src/components/home/ThisOrThat.tsx
+++ b/src/components/home/ThisOrThat.tsx
@@ -151,23 +151,30 @@ const ThisOrThat: React.FC = () => {
       sx={{
         flex: 1,
         bgcolor: 'background.body',
-        px: { xs: 2, sm: 3, md: 4 },
-        py: { xs: 3, sm: 5 },
+        px: { xs: 1.5, sm: 3, md: 4 },
+        py: { xs: 1.5, sm: 3 },
       }}
     >
       <Box sx={{ maxWidth: 900, mx: 'auto' }}>
-        {/* Header */}
-        <Box sx={{ textAlign: 'center', mb: { xs: 3, sm: 4 } }}>
-          <Typography level="h2" sx={{ fontWeight: 800, letterSpacing: '-0.02em', mb: 0.5 }}>
+        {/* Header + Tabs */}
+        <Box sx={{ textAlign: 'center', mb: { xs: 1.5, sm: 2.5 } }}>
+          <Typography
+            level="h3"
+            sx={{
+              fontWeight: 800,
+              letterSpacing: '-0.02em',
+              fontSize: { xs: '1.1rem', sm: '1.5rem' },
+            }}
+          >
             This or That
           </Typography>
-          <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
+          <Typography level="body-xs" sx={{ color: 'text.secondary', mb: { xs: 1, sm: 1.5 } }}>
             Pick which movie you'd rather watch
           </Typography>
         </Box>
 
         {/* Tabs */}
-        <Box sx={{ display: 'flex', justifyContent: 'center', gap: 1, mb: 3 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'center', gap: 1, mb: { xs: 1.5, sm: 2.5 } }}>
           <Button
             variant={tab === 'compare' ? 'soft' : 'plain'}
             color="neutral"
@@ -197,7 +204,7 @@ const ThisOrThat: React.FC = () => {
             {sessionCount > 0 && (
               <Typography
                 level="body-xs"
-                sx={{ textAlign: 'center', mb: 2, color: 'text.tertiary' }}
+                sx={{ textAlign: 'center', mb: { xs: 1, sm: 1.5 }, color: 'text.tertiary' }}
               >
                 {sessionCount} comparison{sessionCount !== 1 ? 's' : ''} this session
               </Typography>
@@ -218,7 +225,7 @@ const ThisOrThat: React.FC = () => {
                 sx={{
                   display: 'flex',
                   flexDirection: 'row',
-                  gap: { xs: 1.5, sm: 3 },
+                  gap: { xs: 1, sm: 2.5 },
                   justifyContent: 'center',
                 }}
               >
@@ -243,12 +250,12 @@ const ThisOrThat: React.FC = () => {
                         maxHeight: { xs: 'calc(50dvh - 80px)', sm: 'calc(70dvh - 100px)' },
                       }}
                     />
-                    <Box sx={{ p: { xs: 1, sm: 2 } }}>
-                      <Skeleton variant="text" sx={{ width: '70%', mb: 1 }} />
-                      <Skeleton variant="text" sx={{ width: '50%', mb: 1 }} />
+                    <Box sx={{ p: { xs: 0.75, sm: 1.5 } }}>
+                      <Skeleton variant="text" sx={{ width: '70%', mb: 0.5 }} />
+                      <Skeleton variant="text" sx={{ width: '50%', mb: 0.5 }} />
                       <Skeleton
                         variant="rectangular"
-                        sx={{ width: '100%', height: 36, borderRadius: 'sm' }}
+                        sx={{ width: '100%', height: 32, borderRadius: 'sm' }}
                       />
                     </Box>
                   </Box>
@@ -262,7 +269,7 @@ const ThisOrThat: React.FC = () => {
                 sx={{
                   display: 'flex',
                   flexDirection: 'row',
-                  gap: { xs: 1.5, sm: 3 },
+                  gap: { xs: 1, sm: 2.5 },
                   justifyContent: 'center',
                   alignItems: 'stretch',
                   opacity: fading ? 0 : 1,

--- a/src/components/home/WatchHistory.tsx
+++ b/src/components/home/WatchHistory.tsx
@@ -126,8 +126,31 @@ const WatchHistory: React.FC = () => {
                     const canUnwatch = isAdmin || String(movie.requested_by) === String(user?.id);
                     return (
                       <tr key={movie.id}>
-                        <td style={{ verticalAlign: 'middle', padding: '12px 16px' }}>
+                        <td style={{ verticalAlign: 'middle', padding: '8px 16px' }}>
                           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            {movie.poster_url ? (
+                              <img
+                                src={movie.poster_url}
+                                alt=""
+                                style={{
+                                  width: 28,
+                                  height: 42,
+                                  objectFit: 'cover',
+                                  borderRadius: 3,
+                                  flexShrink: 0,
+                                }}
+                              />
+                            ) : (
+                              <Box
+                                sx={{
+                                  width: 28,
+                                  height: 42,
+                                  bgcolor: 'background.level2',
+                                  borderRadius: '3px',
+                                  flexShrink: 0,
+                                }}
+                              />
+                            )}
                             <Typography
                               level="body-sm"
                               sx={{ fontWeight: 600, color: 'text.primary' }}

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -10,6 +10,7 @@ export const GET_MOVIES = gql`
       date_submitted
       elo_rank
       tmdb_id
+      poster_url
       myTags {
         tag {
           slug
@@ -533,6 +534,7 @@ export const SOLO_MOVIES = gql`
       requested_by
       date_submitted
       tmdb_id
+      poster_url
     }
   }
 `;
@@ -588,6 +590,7 @@ export const WATCHED_MOVIES = gql`
       date_submitted
       watched_at
       tmdb_id
+      poster_url
     }
   }
 `;

--- a/src/models/Movies.ts
+++ b/src/models/Movies.ts
@@ -13,6 +13,7 @@ export type Movie = {
   elo_rank: number | null;
   tmdb_id?: number | null;
   watched_at?: string | null;
+  poster_url?: string | null;
   myTags?: MovieUserTag[];
   userTags?: MovieUserTag[];
 };


### PR DESCRIPTION
## Summary
- **This or That** poster cards now use `objectFit: contain` with viewport-relative (`dvh`) max-height constraints so full posters are always visible on both mobile and desktop without cropping
- **Movie list tables** (queue, watch history, solo queue) now show a small 28×42px poster thumbnail next to each movie title via a new `poster_url` field on the `Movie` GraphQL type

## Test plan
- [ ] Open This or That on mobile — both posters should be fully visible without scrolling
- [ ] Open This or That on desktop — posters scale up but remain contained within cards
- [ ] Movie list shows poster thumbnails next to titles (or a neutral placeholder if no TMDB match)
- [ ] Watch history shows the same thumbnails
- [ ] Solo queue shows thumbnails
- [ ] Movies without TMDB data show a small gray placeholder box

🤖 Generated with [Claude Code](https://claude.com/claude-code)