### PR TITLE
feat: UX overhaul — toast, confirm dialogs, loading states, mobile cards

### DIFF
--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -21,6 +21,9 @@ import {
 import { GET_USERS, CREATE_USER, UPDATE_USER, DELETE_USER } from '../../graphql/queries';
 import { User } from '../../models/User';
 import { getGravatarUrl } from '../../utils/gravatar';
+import { useToast } from '../../contexts/ToastContext';
+import { useConfirm } from '../../hooks/useConfirm';
+import ConfirmDialog from '../common/ConfirmDialog';
 
 const thStyle: React.CSSProperties = {
   padding: '10px 16px',
@@ -36,6 +39,8 @@ const thStyle: React.CSSProperties = {
 };
 
 export const UserManagement: React.FC = () => {
+  const { showError } = useToast();
+  const { confirm, dialogProps: confirmDialogProps } = useConfirm();
   const [open, setOpen] = useState(false);
   const [editingUser, setEditingUser] = useState<User | null>(null);
   const [formData, setFormData] = useState({
@@ -68,7 +73,7 @@ export const UserManagement: React.FC = () => {
 
   const [deleteUser] = useMutation(DELETE_USER, {
     onCompleted: () => refetch(),
-    onError: (err) => alert(err.message),
+    onError: (err) => showError(err.message),
   });
 
   const handleOpen = (user?: User) => {
@@ -140,7 +145,13 @@ export const UserManagement: React.FC = () => {
   };
 
   const handleDelete = async (id: string) => {
-    if (window.confirm('Delete this user?')) {
+    const ok = await confirm({
+      title: 'Delete user?',
+      message: 'This action cannot be undone.',
+      confirmText: 'Delete',
+      confirmColor: 'danger',
+    });
+    if (ok) {
       await deleteUser({ variables: { id } });
     }
   };
@@ -385,6 +396,8 @@ export const UserManagement: React.FC = () => {
           </form>
         </ModalDialog>
       </Modal>
+
+      <ConfirmDialog {...confirmDialogProps} />
     </Box>
   );
 };

--- a/src/components/common/ConfirmDialog.tsx
+++ b/src/components/common/ConfirmDialog.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Modal, ModalDialog, Typography, Button, Box, Divider } from '@mui/joy';
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+  confirmColor?: 'danger' | 'primary' | 'warning' | 'success';
+  loading?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
+  open,
+  title,
+  message,
+  confirmText = 'Confirm',
+  cancelText = 'Cancel',
+  confirmColor = 'primary',
+  loading = false,
+  onConfirm,
+  onCancel,
+}) => (
+  <Modal open={open} onClose={onCancel}>
+    <ModalDialog
+      sx={{
+        maxWidth: 400,
+        width: '100%',
+        p: 3,
+        bgcolor: 'background.level1',
+        borderColor: 'var(--mn-border-vis)',
+      }}
+    >
+      <Typography level="title-md" sx={{ fontWeight: 700, mb: 0.5 }}>
+        {title}
+      </Typography>
+      <Typography level="body-sm" sx={{ color: 'text.secondary', mb: 2 }}>
+        {message}
+      </Typography>
+      <Divider sx={{ mb: 2 }} />
+      <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
+        <Button variant="plain" color="neutral" onClick={onCancel} disabled={loading}>
+          {cancelText}
+        </Button>
+        <Button
+          variant="solid"
+          color={confirmColor}
+          onClick={onConfirm}
+          loading={loading}
+          sx={{
+            fontWeight: 700,
+            ...(confirmColor === 'primary' ? { color: '#0d0f1a' } : {}),
+          }}
+        >
+          {confirmText}
+        </Button>
+      </Box>
+    </ModalDialog>
+  </Modal>
+);
+
+export default ConfirmDialog;

--- a/src/components/home/AddMovieForm.tsx
+++ b/src/components/home/AddMovieForm.tsx
@@ -1,0 +1,156 @@
+import React, { useState, useEffect } from 'react';
+import { useLazyQuery, useMutation } from '@apollo/client';
+import { Box, Button, Autocomplete, AutocompleteOption, ListItemContent } from '@mui/joy';
+import { SEARCH_TMDB, ADD_MOVIE, SET_MOVIE_TAG, GET_MOVIES } from '../../graphql/queries';
+import { useToast } from '../../contexts/ToastContext';
+import { useDebounce } from '../../utils/useDebounce';
+
+type TmdbOption = {
+  tmdb_id: number;
+  title: string;
+  release_year: string | null;
+  overview: string | null;
+};
+
+const AddMovieForm: React.FC = () => {
+  const { showSuccess, showError } = useToast();
+  const [title, setTitle] = useState('');
+  const [tmdbId, setTmdbId] = useState<number | null>(null);
+  const [tmdbOptions, setTmdbOptions] = useState<TmdbOption[]>([]);
+  const [lastAddedMovieId, setLastAddedMovieId] = useState<string | null>(null);
+
+  const debouncedTitle = useDebounce(title, 400);
+
+  const [searchTmdb, { loading: tmdbSearching }] = useLazyQuery(SEARCH_TMDB, {
+    onCompleted: (d) => setTmdbOptions(d.searchTmdb || []),
+    onError: () => setTmdbOptions([]),
+  });
+
+  useEffect(() => {
+    if (debouncedTitle.trim().length >= 2) {
+      searchTmdb({ variables: { query: debouncedTitle } });
+    } else {
+      setTmdbOptions([]);
+    }
+  }, [debouncedTitle, searchTmdb]);
+
+  const [addMovie, { loading: adding }] = useMutation(ADD_MOVIE, {
+    refetchQueries: [{ query: GET_MOVIES }],
+  });
+
+  const [setMovieTag] = useMutation(SET_MOVIE_TAG, {
+    refetchQueries: [{ query: GET_MOVIES }],
+  });
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!title.trim()) {
+      showError('Please enter a movie title.');
+      return;
+    }
+    try {
+      const { data: addData } = await addMovie({
+        variables: { title: title.trim(), tmdb_id: tmdbId },
+      });
+      showSuccess('Added to the list!');
+      setLastAddedMovieId(addData?.addMovie?.id ?? null);
+      setTitle('');
+      setTmdbId(null);
+      setTmdbOptions([]);
+      setTimeout(() => setLastAddedMovieId(null), 5000);
+    } catch (error: any) {
+      showError(`Error: ${error.message}`);
+    }
+  };
+
+  const handleMarkSeen = async () => {
+    if (!lastAddedMovieId) return;
+    try {
+      await setMovieTag({ variables: { movieId: lastAddedMovieId, tagSlug: 'seen' } });
+      setLastAddedMovieId(null);
+    } catch (err: any) {
+      showError(`Error: ${err.message}`);
+    }
+  };
+
+  const isSearching = tmdbSearching || (debouncedTitle !== title && title.trim().length >= 2);
+
+  return (
+    <Box sx={{ mb: 4 }}>
+      <form onSubmit={handleSubmit}>
+        <Box sx={{ display: 'flex', gap: 1, maxWidth: 520, mx: 'auto' }}>
+          <Autocomplete
+            freeSolo
+            loading={isSearching}
+            options={tmdbOptions}
+            getOptionLabel={(option) =>
+              typeof option === 'string'
+                ? option
+                : option.release_year
+                  ? `${option.title} (${option.release_year})`
+                  : option.title
+            }
+            inputValue={title}
+            onInputChange={(_, value) => {
+              setTitle(value);
+              if (!value) setTmdbId(null);
+            }}
+            onChange={(_, value) => {
+              if (value && typeof value !== 'string') {
+                setTitle(value.title);
+                setTmdbId(value.tmdb_id);
+              }
+            }}
+            renderOption={(props, option) => (
+              <AutocompleteOption {...props} key={option.tmdb_id}>
+                <ListItemContent>
+                  <strong>{option.title}</strong>
+                  {option.release_year && ` (${option.release_year})`}
+                </ListItemContent>
+              </AutocompleteOption>
+            )}
+            placeholder="Suggest a movie title..."
+            sx={{
+              flex: 1,
+              bgcolor: 'background.surface',
+              '--Input-focusedHighlight': 'var(--joy-palette-primary-500)',
+            }}
+          />
+          <Button
+            type="submit"
+            color="primary"
+            variant="solid"
+            loading={adding}
+            sx={{ fontWeight: 700, color: '#0d0f1a', px: 3 }}
+          >
+            Add
+          </Button>
+        </Box>
+      </form>
+
+      {lastAddedMovieId && (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 1.5,
+            mt: 1.5,
+          }}
+        >
+          <Button
+            size="sm"
+            variant="soft"
+            color="neutral"
+            onClick={handleMarkSeen}
+            sx={{ fontSize: '0.75rem', py: 0.25 }}
+          >
+            I've seen this
+          </Button>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default AddMovieForm;

--- a/src/components/home/CombinedList.tsx
+++ b/src/components/home/CombinedList.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useQuery, useLazyQuery, useMutation } from '@apollo/client';
-import { Box, Typography, Button, Sheet, Chip, Input, CircularProgress, Alert } from '@mui/joy';
+import { Box, Typography, Button, Sheet, Chip, Input, CircularProgress } from '@mui/joy';
 import {
   SEARCH_USERS,
   MY_CONNECTIONS,
@@ -9,12 +9,15 @@ import {
   RESPOND_TO_CONNECTION_REQUEST,
   REMOVE_CONNECTION,
 } from '../../graphql/queries';
+import { useToast } from '../../contexts/ToastContext';
+import { useConfirm } from '../../hooks/useConfirm';
+import ConfirmDialog from '../common/ConfirmDialog';
 
 const CombinedList: React.FC = () => {
+  const { showSuccess, showError } = useToast();
+  const { confirm, dialogProps } = useConfirm();
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<any[]>([]);
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState<string | null>(null);
 
   const [searchUsers, { loading: searchLoading }] = useLazyQuery(SEARCH_USERS, {
     fetchPolicy: 'network-only',
@@ -29,13 +32,13 @@ const CombinedList: React.FC = () => {
   const [sendRequest, { loading: sendingRequest }] = useMutation(SEND_CONNECTION_REQUEST, {
     onCompleted: (data) => {
       const status = data.sendConnectionRequest.status;
-      setSuccess(status === 'accepted' ? 'Connected! (mutual request)' : 'Request sent!');
+      showSuccess(status === 'accepted' ? 'Connected! (mutual request)' : 'Request sent!');
       setSearchQuery('');
       setSearchResults([]);
       refetchPending();
       refetchConnections();
     },
-    onError: (err) => setError(err.message),
+    onError: (err) => showError(err.message),
   });
 
   const [respond] = useMutation(RESPOND_TO_CONNECTION_REQUEST, {
@@ -43,12 +46,12 @@ const CombinedList: React.FC = () => {
       refetchPending();
       refetchConnections();
     },
-    onError: (err) => setError(err.message),
+    onError: (err) => showError(err.message),
   });
 
   const [removeConnection] = useMutation(REMOVE_CONNECTION, {
     onCompleted: () => refetchConnections(),
-    onError: (err) => setError(err.message),
+    onError: (err) => showError(err.message),
   });
 
   // Debounced search
@@ -62,17 +65,6 @@ const CombinedList: React.FC = () => {
     }, 400);
     return () => clearTimeout(timer);
   }, [searchQuery, searchUsers]);
-
-  // Auto-clear alerts
-  useEffect(() => {
-    if (error || success) {
-      const timer = setTimeout(() => {
-        setError(null);
-        setSuccess(null);
-      }, 4000);
-      return () => clearTimeout(timer);
-    }
-  }, [error, success]);
 
   const incomingPending =
     pendingData?.pendingConnectionRequests?.filter((r: any) => r.direction === 'received') || [];
@@ -100,18 +92,6 @@ const CombinedList: React.FC = () => {
             Connect with friends to see combined movie rankings on the home page
           </Typography>
         </Box>
-
-        {/* Alerts */}
-        {error && (
-          <Alert color="danger" sx={{ mb: 2 }}>
-            {error}
-          </Alert>
-        )}
-        {success && (
-          <Alert color="success" sx={{ mb: 2 }}>
-            {success}
-          </Alert>
-        )}
 
         {/* Search */}
         <Sheet
@@ -297,12 +277,14 @@ const CombinedList: React.FC = () => {
                   size="sm"
                   variant="plain"
                   color="danger"
-                  onClick={() => {
-                    if (
-                      window.confirm(
-                        `Remove connection with ${conn.user.display_name || conn.user.username}?`,
-                      )
-                    ) {
+                  onClick={async () => {
+                    const ok = await confirm({
+                      title: 'Remove connection?',
+                      message: `You will no longer see combined rankings with ${conn.user.display_name || conn.user.username}.`,
+                      confirmText: 'Remove',
+                      confirmColor: 'danger',
+                    });
+                    if (ok) {
                       removeConnection({ variables: { connectionId: conn.id } });
                     }
                   }}
@@ -315,6 +297,8 @@ const CombinedList: React.FC = () => {
           </Box>
         </Sheet>
       </Box>
+
+      <ConfirmDialog {...dialogProps} />
     </Box>
   );
 };

--- a/src/components/home/ConnectionBanners.tsx
+++ b/src/components/home/ConnectionBanners.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { Box, Button, Typography, Sheet } from '@mui/joy';
+
+interface ConnectionBannersProps {
+  incomingPending: any[];
+  pendingMovies: any[];
+  askSeenMovieId: string | null;
+  setAskSeenMovieId: (id: string | null) => void;
+  onShowConnections?: () => void;
+  onSetInterest: (movieId: string, interested: boolean) => void;
+  onSetSeenTag: (movieId: string) => Promise<void>;
+}
+
+const ConnectionBanners: React.FC<ConnectionBannersProps> = ({
+  incomingPending,
+  pendingMovies,
+  askSeenMovieId,
+  setAskSeenMovieId,
+  onShowConnections,
+  onSetInterest,
+  onSetSeenTag,
+}) => (
+  <>
+    {/* Pending connection request banner */}
+    {incomingPending.length > 0 && (
+      <Box
+        sx={{
+          mb: 3,
+          p: 1.5,
+          borderRadius: 'md',
+          bgcolor: 'warning.softBg',
+          border: '1px solid',
+          borderColor: 'warning.outlinedBorder',
+          textAlign: 'center',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 1,
+        }}
+      >
+        <Typography level="body-sm" sx={{ color: 'warning.softColor' }}>
+          {incomingPending.length === 1
+            ? `${incomingPending[0].user.display_name || incomingPending[0].user.username} wants to connect`
+            : `${incomingPending.length} pending connection requests`}
+        </Typography>
+        {onShowConnections && (
+          <Button
+            variant="soft"
+            color="warning"
+            size="sm"
+            onClick={onShowConnections}
+            sx={{ fontWeight: 700 }}
+          >
+            View
+          </Button>
+        )}
+      </Box>
+    )}
+
+    {/* New movies from connections — review banner */}
+    {pendingMovies.length > 0 && (
+      <Sheet
+        variant="outlined"
+        sx={{
+          mb: 3,
+          p: 2,
+          borderRadius: 'md',
+          bgcolor: 'primary.softBg',
+          borderColor: 'primary.outlinedBorder',
+        }}
+      >
+        <Typography level="title-sm" sx={{ fontWeight: 700, mb: 1.5, color: 'primary.softColor' }}>
+          New movies from your connections
+        </Typography>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+          {pendingMovies.map((item: any) => (
+            <Box
+              key={item.movie.id}
+              sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                p: 1,
+                borderRadius: 'sm',
+                bgcolor: 'background.level1',
+              }}
+            >
+              <Box>
+                <Typography level="body-sm" sx={{ fontWeight: 600 }}>
+                  {item.movie.title}
+                </Typography>
+                <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+                  added by {item.addedBy.display_name || item.addedBy.username}
+                </Typography>
+              </Box>
+              <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
+                {askSeenMovieId === item.movie.id ? (
+                  <>
+                    <Typography level="body-xs" sx={{ color: 'text.tertiary', mr: 0.5 }}>
+                      Seen it?
+                    </Typography>
+                    <Button
+                      size="sm"
+                      variant="soft"
+                      color="warning"
+                      onClick={async () => {
+                        setAskSeenMovieId(null);
+                        onSetInterest(item.movie.id, true);
+                        try {
+                          await onSetSeenTag(item.movie.id);
+                        } catch {}
+                      }}
+                    >
+                      Yes
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="plain"
+                      color="neutral"
+                      onClick={() => {
+                        setAskSeenMovieId(null);
+                        onSetInterest(item.movie.id, true);
+                      }}
+                    >
+                      No
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <Button
+                      size="sm"
+                      variant="soft"
+                      color="success"
+                      onClick={() => setAskSeenMovieId(item.movie.id)}
+                    >
+                      I'm in
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="plain"
+                      color="neutral"
+                      onClick={() => onSetInterest(item.movie.id, false)}
+                    >
+                      Pass
+                    </Button>
+                  </>
+                )}
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      </Sheet>
+    )}
+  </>
+);
+
+export default ConnectionBanners;

--- a/src/components/home/Homepage.tsx
+++ b/src/components/home/Homepage.tsx
@@ -221,11 +221,28 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
           <Typography level="h2" sx={{ fontWeight: 800, letterSpacing: '-0.02em', mb: 0.5 }}>
             Movie List
           </Typography>
-          <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
-            {movies.length === 0
-              ? 'No movies yet — suggest one!'
-              : `${movies.length} movie${movies.length !== 1 ? 's' : ''} in the queue`}
-          </Typography>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 1,
+              flexWrap: 'wrap',
+            }}
+          >
+            <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
+              {movies.length === 0
+                ? 'No movies yet — suggest one!'
+                : `${movies.length} movie${movies.length !== 1 ? 's' : ''} in the queue`}
+            </Typography>
+            {movies.length >= 2 && (
+              <ThisOrThatBanner
+                hasEloData={hasEloData}
+                isAuthenticated={isAuthenticated}
+                onShowThisOrThat={onShowThisOrThat}
+              />
+            )}
+          </Box>
         </Box>
 
         {/* View selector */}
@@ -248,15 +265,6 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
             onShowConnections={onShowConnections}
             onSetInterest={handleSetInterest}
             onSetSeenTag={handleSetSeenTag}
-          />
-        )}
-
-        {/* This or That indicator */}
-        {!isCombinedView && !isSoloView && movies.length >= 2 && (
-          <ThisOrThatBanner
-            hasEloData={hasEloData}
-            isAuthenticated={isAuthenticated}
-            onShowThisOrThat={onShowThisOrThat}
           />
         )}
 

--- a/src/components/home/Homepage.tsx
+++ b/src/components/home/Homepage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useQuery, useMutation } from '@apollo/client';
 import { Box, Button, Typography, Sheet, Chip, CircularProgress, Skeleton } from '@mui/joy';
 import {
@@ -91,6 +91,14 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
   });
 
   const connections = connectionsData?.myConnections || [];
+
+  // Default to first connection's combined view if one exists
+  useEffect(() => {
+    if (connections.length > 0 && selectedConnectionId === null) {
+      setSelectedConnectionId(connections[0].id);
+    }
+  }, [connections]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const incomingPending =
     pendingData?.pendingConnectionRequests?.filter((r: any) => r.direction === 'received') || [];
   const isSoloView = selectedConnectionId === 'solo';
@@ -253,7 +261,7 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
         )}
 
         {/* Add movie form */}
-        {isAuthenticated && !isCombinedView && !isSoloView && <AddMovieForm />}
+        {isAuthenticated && <AddMovieForm />}
 
         {/* TMDB match flow */}
         {isAuthenticated && unmatchedMovies.length > 0 && !isCombinedView && !isSoloView && (
@@ -454,10 +462,11 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
 
             {/* Cards — visible on mobile */}
             <Box sx={{ display: { xs: 'block', sm: 'none' } }}>
-              {soloMovies.map((movie) => (
+              {soloMovies.map((movie, idx) => (
                 <MovieCard
                   key={movie.id}
                   movie={movie}
+                  rank={idx + 1}
                   isAdmin={isAdmin}
                   canMarkWatched={true}
                   onMarkWatched={handleMarkWatched}
@@ -601,10 +610,11 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
                     No movies yet. Be the first to suggest one!
                   </Typography>
                 ) : (
-                  movies.map((movie) => (
+                  movies.map((movie, idx) => (
                     <MovieCard
                       key={movie.id}
                       movie={movie}
+                      rank={idx + 1}
                       isAdmin={isAdmin}
                       canMarkWatched={
                         isAdmin ||

--- a/src/components/home/Homepage.tsx
+++ b/src/components/home/Homepage.tsx
@@ -1,11 +1,10 @@
-import React, { useState, useEffect } from 'react';
-import { useQuery, useMutation, useLazyQuery } from '@apollo/client';
+import React, { useState } from 'react';
+import { useQuery, useMutation } from '@apollo/client';
+import { Box, Button, Typography, Sheet, Chip, CircularProgress, Skeleton } from '@mui/joy';
 import {
   GET_MOVIES,
-  ADD_MOVIE,
   DELETE_MOVIE,
   MARK_WATCHED,
-  SEARCH_TMDB,
   SEED_MOVIES,
   GET_APP_INFO,
   MY_CONNECTIONS,
@@ -18,222 +17,18 @@ import {
   SET_MOVIE_TAG,
   REMOVE_MOVIE_TAG,
 } from '../../graphql/queries';
-import {
-  Autocomplete,
-  AutocompleteOption,
-  Box,
-  Button,
-  Typography,
-  Sheet,
-  Chip,
-  IconButton,
-  ListItemContent,
-  CircularProgress,
-  Tooltip,
-} from '@mui/joy';
 import TmdbMatchFlow from './TmdbMatchFlow';
+import MovieRow from './MovieRow';
+import MovieCard from './MovieCard';
+import AddMovieForm from './AddMovieForm';
+import ViewSelector from './ViewSelector';
+import ConnectionBanners from './ConnectionBanners';
+import ThisOrThatBanner from './ThisOrThatBanner';
+import ConfirmDialog from '../common/ConfirmDialog';
 import { Movie } from '../../models/Movies';
 import { useAuth } from '../../contexts/AuthContext';
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-type TmdbOption = {
-  tmdb_id: number;
-  title: string;
-  release_year: string | null;
-  overview: string | null;
-};
-
-function useDebounce<T>(value: T, delay: number): T {
-  const [debouncedValue, setDebouncedValue] = useState<T>(value);
-  useEffect(() => {
-    const handler = setTimeout(() => setDebouncedValue(value), delay);
-    return () => clearTimeout(handler);
-  }, [value, delay]);
-  return debouncedValue;
-}
-
-// ── Movie row ─────────────────────────────────────────────────────────────────
-
-interface MovieRowProps {
-  movie: Movie;
-  isAdmin: boolean;
-  canMarkWatched: boolean;
-  onMarkWatched: (id: string, title: string) => void;
-  onDelete: (id: string, title: string) => void;
-  onToggleSeen: (id: string, currentlySeen: boolean) => void;
-  isAuthenticated: boolean;
-}
-
-const MovieRow: React.FC<MovieRowProps> = ({
-  movie,
-  isAdmin,
-  canMarkWatched,
-  onMarkWatched,
-  onDelete,
-  onToggleSeen,
-  isAuthenticated,
-}) => {
-  const isSeen = movie.myTags?.some((t) => t.tag.slug === 'seen') ?? false;
-  const seenByUsers = (movie.userTags ?? []).filter((t) => t.tag.slug === 'seen');
-  const seenCount = seenByUsers.length;
-  const seenNames = seenByUsers.map((t) => t.user.display_name || t.user.username);
-
-  return (
-    <tr>
-      {/* Title */}
-      <td style={{ verticalAlign: 'middle', padding: '8px 16px' }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          {movie.poster_url ? (
-            <img
-              src={movie.poster_url}
-              alt=""
-              style={{
-                width: 28,
-                height: 42,
-                objectFit: 'cover',
-                borderRadius: 3,
-                flexShrink: 0,
-              }}
-            />
-          ) : (
-            <Box
-              sx={{
-                width: 28,
-                height: 42,
-                bgcolor: 'background.level2',
-                borderRadius: '3px',
-                flexShrink: 0,
-              }}
-            />
-          )}
-          <Typography level="body-sm" sx={{ fontWeight: 600, color: 'text.primary' }}>
-            {movie.title}
-          </Typography>
-        </Box>
-      </td>
-
-      {/* Suggested by */}
-      <td style={{ verticalAlign: 'middle', padding: '12px 16px' }}>
-        <Chip size="sm" variant="soft" color="neutral" sx={{ fontWeight: 500 }}>
-          {movie.requester}
-        </Chip>
-      </td>
-
-      {/* Date */}
-      <td style={{ verticalAlign: 'middle', padding: '12px 16px', whiteSpace: 'nowrap' }}>
-        <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
-          {new Date(movie.date_submitted).toLocaleDateString(undefined, {
-            year: 'numeric',
-            month: 'short',
-            day: 'numeric',
-          })}
-        </Typography>
-      </td>
-
-      {/* TMDB */}
-      <td style={{ verticalAlign: 'middle', padding: '12px 8px', textAlign: 'center' }}>
-        {movie.tmdb_id ? (
-          <a
-            href={`https://www.themoviedb.org/movie/${movie.tmdb_id}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ color: 'var(--joy-palette-primary-500)', fontSize: '0.75rem' }}
-          >
-            ↗
-          </a>
-        ) : null}
-      </td>
-
-      {/* Seen it */}
-      {isAuthenticated && (
-        <td style={{ verticalAlign: 'middle', padding: '0 4px', textAlign: 'center' }}>
-          <Tooltip
-            title={
-              seenCount > 0
-                ? `Seen by: ${seenNames.join(', ')}`
-                : isSeen
-                  ? 'Remove "Seen it"'
-                  : "I've seen this"
-            }
-            placement="top"
-            arrow
-          >
-            <IconButton
-              size="sm"
-              variant="plain"
-              color={isSeen ? 'warning' : 'neutral'}
-              onClick={() => onToggleSeen(movie.id, isSeen)}
-              sx={{
-                opacity: isSeen ? 0.9 : 0.35,
-                transition: 'opacity 0.15s',
-                '&:hover': { opacity: 1 },
-                fontSize: '0.85rem',
-              }}
-            >
-              {isSeen ? '👁' : '👁‍🗨'}
-              {seenCount > 0 && (
-                <Typography
-                  component="span"
-                  level="body-xs"
-                  sx={{ ml: 0.25, fontWeight: 700, fontSize: '0.6rem' }}
-                >
-                  {seenCount}
-                </Typography>
-              )}
-            </IconButton>
-          </Tooltip>
-        </td>
-      )}
-
-      {/* Actions */}
-      {(canMarkWatched || isAdmin) && (
-        <td
-          style={{
-            verticalAlign: 'middle',
-            padding: '0 12px',
-            textAlign: 'right',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {canMarkWatched && (
-            <IconButton
-              size="sm"
-              color="success"
-              variant="plain"
-              onClick={() => onMarkWatched(movie.id, movie.title)}
-              title={`Mark "${movie.title}" as done`}
-              sx={{
-                opacity: 0.5,
-                transition: 'opacity 0.15s',
-                '&:hover': { opacity: 1 },
-                mr: isAdmin ? 0.5 : 0,
-              }}
-            >
-              ✓
-            </IconButton>
-          )}
-          {isAdmin && (
-            <IconButton
-              size="sm"
-              color="danger"
-              variant="plain"
-              onClick={() => onDelete(movie.id, movie.title)}
-              title={`Remove "${movie.title}"`}
-              sx={{
-                opacity: 0.5,
-                transition: 'opacity 0.15s',
-                '&:hover': { opacity: 1 },
-              }}
-            >
-              ✕
-            </IconButton>
-          )}
-        </td>
-      )}
-    </tr>
-  );
-};
+import { useToast } from '../../contexts/ToastContext';
+import { useConfirm } from '../../hooks/useConfirm';
 
 // ── Page ──────────────────────────────────────────────────────────────────────
 
@@ -244,16 +39,12 @@ interface HomePageProps {
 
 const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections }) => {
   const { isAuthenticated, user } = useAuth();
+  const { showError } = useToast();
+  const { confirm, dialogProps } = useConfirm();
   const isAdmin = user?.is_admin ?? false;
 
-  const [title, setTitle] = useState('');
-  const [tmdbId, setTmdbId] = useState<number | null>(null);
-  const [tmdbOptions, setTmdbOptions] = useState<TmdbOption[]>([]);
-  const [successMessage, setSuccessMessage] = useState('');
-  const [errorMessage, setErrorMessage] = useState('');
   const [matchFlowOpen, setMatchFlowOpen] = useState(false);
   const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
-  const [lastAddedMovieId, setLastAddedMovieId] = useState<string | null>(null);
   const [askSeenMovieId, setAskSeenMovieId] = useState<string | null>(null);
 
   // Connections data (only when authenticated)
@@ -264,7 +55,7 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
   });
   const { data: combinedData, loading: combinedLoading } = useQuery(COMBINED_LIST, {
     variables: { connectionId: selectedConnectionId },
-    skip: !selectedConnectionId,
+    skip: !selectedConnectionId || selectedConnectionId === 'solo',
     fetchPolicy: 'cache-and-network',
   });
 
@@ -308,28 +99,8 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
   const soloMovies: Movie[] = soloData?.soloMovies ?? [];
   const passedMovieIds: Set<string> = new Set(passedData?.passedMovieIds ?? []);
 
-  const debouncedTitle = useDebounce(title, 400);
+  const { data, loading: moviesLoading } = useQuery(GET_MOVIES, { pollInterval: 5000 });
 
-  const { data } = useQuery(GET_MOVIES, {
-    pollInterval: 5000,
-  });
-
-  const [searchTmdb] = useLazyQuery(SEARCH_TMDB, {
-    onCompleted: (d) => setTmdbOptions(d.searchTmdb || []),
-    onError: () => setTmdbOptions([]),
-  });
-
-  useEffect(() => {
-    if (debouncedTitle.trim().length >= 2) {
-      searchTmdb({ variables: { query: debouncedTitle } });
-    } else {
-      setTmdbOptions([]);
-    }
-  }, [debouncedTitle, searchTmdb]);
-
-  const [addMovie] = useMutation(ADD_MOVIE, {
-    refetchQueries: [{ query: GET_MOVIES }],
-  });
   const [markWatched] = useMutation(MARK_WATCHED, {
     refetchQueries: [{ query: GET_MOVIES }],
   });
@@ -353,11 +124,17 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
   );
 
   const handleMarkWatched = async (id: string, movieTitle: string) => {
-    if (!window.confirm(`Mark "${movieTitle}" as done? It'll move to your watch history.`)) return;
+    const ok = await confirm({
+      title: 'Mark as done?',
+      message: `"${movieTitle}" will move to your watch history.`,
+      confirmText: 'Done',
+      confirmColor: 'success',
+    });
+    if (!ok) return;
     try {
       await markWatched({ variables: { id } });
     } catch (err: any) {
-      setErrorMessage(`Error marking movie as done: ${err.message}`);
+      showError(`Error marking movie as done: ${err.message}`);
     }
   };
 
@@ -369,53 +146,46 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
         await setMovieTag({ variables: { movieId: id, tagSlug: 'seen' } });
       }
     } catch (err: any) {
-      setErrorMessage(`Error updating tag: ${err.message}`);
+      showError(`Error updating tag: ${err.message}`);
     }
   };
 
   const handleDelete = async (id: string, movieTitle: string) => {
-    if (!window.confirm(`Remove "${movieTitle}" from the list?`)) return;
+    const ok = await confirm({
+      title: 'Remove movie?',
+      message: `"${movieTitle}" will be permanently removed from the list.`,
+      confirmText: 'Remove',
+      confirmColor: 'danger',
+    });
+    if (!ok) return;
     try {
       await deleteMovie({ variables: { id } });
     } catch (err: any) {
-      setErrorMessage(`Error removing movie: ${err.message}`);
+      showError(`Error removing movie: ${err.message}`);
     }
   };
 
   const handleSeed = async () => {
-    if (!window.confirm('This will DELETE all existing movies and seed 30 new ones. Continue?'))
-      return;
+    const ok = await confirm({
+      title: 'Seed movies?',
+      message: 'This will DELETE all existing movies and seed 30 new ones.',
+      confirmText: 'Seed',
+      confirmColor: 'warning',
+    });
+    if (!ok) return;
     try {
       await seedMovies();
-      setSuccessMessage('Seeded 30 movies!');
-      setTimeout(() => setSuccessMessage(''), 3000);
     } catch (err: any) {
-      setErrorMessage(`Seed failed: ${err.message}`);
+      showError(`Seed failed: ${err.message}`);
     }
   };
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    if (!title.trim()) {
-      setErrorMessage('Please enter a movie title.');
-      return;
-    }
-    try {
-      const { data: addData } = await addMovie({
-        variables: { title: title.trim(), tmdb_id: tmdbId },
-      });
-      setSuccessMessage('Added to the list!');
-      setLastAddedMovieId(addData?.addMovie?.id ?? null);
-      setTitle('');
-      setTmdbId(null);
-      setTmdbOptions([]);
-      setTimeout(() => {
-        setSuccessMessage('');
-        setLastAddedMovieId(null);
-      }, 5000);
-    } catch (error: any) {
-      setErrorMessage(`Error: ${error.message}`);
-    }
+  const handleSetInterest = (movieId: string, interested: boolean) => {
+    setMovieInterest({ variables: { movieId, interested } });
+  };
+
+  const handleSetSeenTag = async (movieId: string) => {
+    await setMovieTag({ variables: { movieId, tagSlug: 'seen' } });
   };
 
   // Column count for colSpan calculations
@@ -450,352 +220,43 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
           </Typography>
         </Box>
 
-        {/* View selector — segmented control */}
+        {/* View selector */}
         {isAuthenticated && (connections.length > 0 || soloMovies.length > 0) && (
-          <Box
-            sx={{
-              display: 'flex',
-              justifyContent: 'center',
-              flexWrap: 'wrap',
-              gap: 0.5,
-              mb: 3,
-            }}
-          >
-            <Button
-              variant={!isCombinedView && !isSoloView ? 'soft' : 'plain'}
-              color="neutral"
-              size="sm"
-              onClick={() => setSelectedConnectionId(null)}
-              sx={{
-                fontWeight: 600,
-                color: !isCombinedView && !isSoloView ? 'primary.400' : 'text.secondary',
-                '&:hover': { color: 'primary.300' },
-              }}
-            >
-              My List
-            </Button>
-            {connections.map((conn: any) => (
-              <Button
-                key={conn.id}
-                variant={selectedConnectionId === conn.id ? 'soft' : 'plain'}
-                color="neutral"
-                size="sm"
-                onClick={() => setSelectedConnectionId(conn.id)}
-                sx={{
-                  fontWeight: 600,
-                  color: selectedConnectionId === conn.id ? 'primary.400' : 'text.secondary',
-                  '&:hover': { color: 'primary.300' },
-                }}
-              >
-                {conn.user.display_name || conn.user.username} + Me
-              </Button>
-            ))}
-            {soloMovies.length > 0 && (
-              <Button
-                variant={isSoloView ? 'soft' : 'plain'}
-                color="neutral"
-                size="sm"
-                onClick={() => setSelectedConnectionId('solo')}
-                sx={{
-                  fontWeight: 600,
-                  color: isSoloView ? 'primary.400' : 'text.secondary',
-                  '&:hover': { color: 'primary.300' },
-                }}
-              >
-                Solo Queue
-              </Button>
-            )}
-          </Box>
+          <ViewSelector
+            connections={connections}
+            soloMovieCount={soloMovies.length}
+            selectedConnectionId={selectedConnectionId}
+            onSelect={setSelectedConnectionId}
+          />
         )}
 
-        {/* Pending connection request banner */}
-        {isAuthenticated && incomingPending.length > 0 && (
-          <Box
-            sx={{
-              mb: 3,
-              p: 1.5,
-              borderRadius: 'md',
-              bgcolor: 'warning.softBg',
-              border: '1px solid',
-              borderColor: 'warning.outlinedBorder',
-              textAlign: 'center',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: 1,
-            }}
-          >
-            <Typography level="body-sm" sx={{ color: 'warning.softColor' }}>
-              {incomingPending.length === 1
-                ? `${incomingPending[0].user.display_name || incomingPending[0].user.username} wants to connect`
-                : `${incomingPending.length} pending connection requests`}
-            </Typography>
-            {onShowConnections && (
-              <Button
-                variant="soft"
-                color="warning"
-                size="sm"
-                onClick={onShowConnections}
-                sx={{ fontWeight: 700 }}
-              >
-                View
-              </Button>
-            )}
-          </Box>
-        )}
-
-        {/* New movies from connections — review banner */}
-        {isAuthenticated && !isCombinedView && !isSoloView && pendingMovies.length > 0 && (
-          <Sheet
-            variant="outlined"
-            sx={{
-              mb: 3,
-              p: 2,
-              borderRadius: 'md',
-              bgcolor: 'primary.softBg',
-              borderColor: 'primary.outlinedBorder',
-            }}
-          >
-            <Typography
-              level="title-sm"
-              sx={{ fontWeight: 700, mb: 1.5, color: 'primary.softColor' }}
-            >
-              New movies from your connections
-            </Typography>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-              {pendingMovies.map((item: any) => (
-                <Box
-                  key={item.movie.id}
-                  sx={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                    p: 1,
-                    borderRadius: 'sm',
-                    bgcolor: 'background.level1',
-                  }}
-                >
-                  <Box>
-                    <Typography level="body-sm" sx={{ fontWeight: 600 }}>
-                      {item.movie.title}
-                    </Typography>
-                    <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
-                      added by {item.addedBy.display_name || item.addedBy.username}
-                    </Typography>
-                  </Box>
-                  <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
-                    {askSeenMovieId === item.movie.id ? (
-                      <>
-                        <Typography level="body-xs" sx={{ color: 'text.tertiary', mr: 0.5 }}>
-                          Seen it?
-                        </Typography>
-                        <Button
-                          size="sm"
-                          variant="soft"
-                          color="warning"
-                          onClick={async () => {
-                            setAskSeenMovieId(null);
-                            await setMovieInterest({
-                              variables: { movieId: item.movie.id, interested: true },
-                            });
-                            try {
-                              await setMovieTag({
-                                variables: { movieId: item.movie.id, tagSlug: 'seen' },
-                              });
-                            } catch {}
-                          }}
-                        >
-                          Yes
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="plain"
-                          color="neutral"
-                          onClick={() => {
-                            setAskSeenMovieId(null);
-                            setMovieInterest({
-                              variables: { movieId: item.movie.id, interested: true },
-                            });
-                          }}
-                        >
-                          No
-                        </Button>
-                      </>
-                    ) : (
-                      <>
-                        <Button
-                          size="sm"
-                          variant="soft"
-                          color="success"
-                          onClick={() => setAskSeenMovieId(item.movie.id)}
-                        >
-                          I'm in
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="plain"
-                          color="neutral"
-                          onClick={() =>
-                            setMovieInterest({
-                              variables: { movieId: item.movie.id, interested: false },
-                            })
-                          }
-                        >
-                          Pass
-                        </Button>
-                      </>
-                    )}
-                  </Box>
-                </Box>
-              ))}
-            </Box>
-          </Sheet>
+        {/* Connection banners (personal view only) */}
+        {isAuthenticated && !isCombinedView && !isSoloView && (
+          <ConnectionBanners
+            incomingPending={incomingPending}
+            pendingMovies={pendingMovies}
+            askSeenMovieId={askSeenMovieId}
+            setAskSeenMovieId={setAskSeenMovieId}
+            onShowConnections={onShowConnections}
+            onSetInterest={handleSetInterest}
+            onSetSeenTag={handleSetSeenTag}
+          />
         )}
 
         {/* This or That indicator */}
         {!isCombinedView && !isSoloView && movies.length >= 2 && (
-          <Box
-            sx={{
-              mb: 3,
-              p: 1.5,
-              borderRadius: 'md',
-              bgcolor: 'primary.softBg',
-              border: '1px solid',
-              borderColor: 'primary.outlinedBorder',
-              textAlign: 'center',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: 1,
-            }}
-          >
-            {isAuthenticated ? (
-              <>
-                <Typography level="body-sm" sx={{ color: 'primary.softColor' }}>
-                  {hasEloData
-                    ? 'Keep ranking movies!'
-                    : 'Rate movies to get your personal ranking.'}
-                </Typography>
-                {onShowThisOrThat && (
-                  <Button
-                    variant="soft"
-                    color="primary"
-                    size="sm"
-                    onClick={onShowThisOrThat}
-                    sx={{ fontWeight: 700 }}
-                  >
-                    This or That
-                  </Button>
-                )}
-              </>
-            ) : (
-              <Typography level="body-sm" sx={{ color: 'primary.softColor' }}>
-                Sign in to rank movies with This or That
-              </Typography>
-            )}
-          </Box>
+          <ThisOrThatBanner
+            hasEloData={hasEloData}
+            isAuthenticated={isAuthenticated}
+            onShowThisOrThat={onShowThisOrThat}
+          />
         )}
 
         {/* Add movie form */}
-        {isAuthenticated && (
-          <Box sx={{ mb: 4 }}>
-            <form onSubmit={handleSubmit}>
-              <Box sx={{ display: 'flex', gap: 1, maxWidth: 520, mx: 'auto' }}>
-                <Autocomplete
-                  freeSolo
-                  options={tmdbOptions}
-                  getOptionLabel={(option) =>
-                    typeof option === 'string'
-                      ? option
-                      : option.release_year
-                        ? `${option.title} (${option.release_year})`
-                        : option.title
-                  }
-                  inputValue={title}
-                  onInputChange={(_, value) => {
-                    setTitle(value);
-                    if (!value) setTmdbId(null);
-                  }}
-                  onChange={(_, value) => {
-                    if (value && typeof value !== 'string') {
-                      setTitle(value.title);
-                      setTmdbId(value.tmdb_id);
-                    }
-                  }}
-                  renderOption={(props, option) => (
-                    <AutocompleteOption {...props} key={option.tmdb_id}>
-                      <ListItemContent>
-                        <strong>{option.title}</strong>
-                        {option.release_year && ` (${option.release_year})`}
-                      </ListItemContent>
-                    </AutocompleteOption>
-                  )}
-                  placeholder="Suggest a movie title..."
-                  sx={{
-                    flex: 1,
-                    bgcolor: 'background.surface',
-                    '--Input-focusedHighlight': 'var(--joy-palette-primary-500)',
-                  }}
-                />
-                <Button
-                  type="submit"
-                  color="primary"
-                  variant="solid"
-                  sx={{ fontWeight: 700, color: '#0d0f1a', px: 3 }}
-                >
-                  Add
-                </Button>
-              </Box>
-            </form>
-
-            {successMessage && (
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  gap: 1.5,
-                  mt: 1.5,
-                }}
-              >
-                <Typography level="body-sm" sx={{ color: 'success.400', fontWeight: 600 }}>
-                  {successMessage}
-                </Typography>
-                {lastAddedMovieId && (
-                  <Button
-                    size="sm"
-                    variant="soft"
-                    color="neutral"
-                    onClick={async () => {
-                      try {
-                        await setMovieTag({
-                          variables: { movieId: lastAddedMovieId, tagSlug: 'seen' },
-                        });
-                        setLastAddedMovieId(null);
-                      } catch (err: any) {
-                        setErrorMessage(`Error: ${err.message}`);
-                      }
-                    }}
-                    sx={{ fontSize: '0.75rem', py: 0.25 }}
-                  >
-                    I've seen this
-                  </Button>
-                )}
-              </Box>
-            )}
-            {errorMessage && (
-              <Typography
-                level="body-sm"
-                sx={{ textAlign: 'center', mt: 1.5, color: 'danger.400', fontWeight: 600 }}
-              >
-                {errorMessage}
-              </Typography>
-            )}
-          </Box>
-        )}
+        {isAuthenticated && !isCombinedView && !isSoloView && <AddMovieForm />}
 
         {/* TMDB match flow */}
-        {isAuthenticated && unmatchedMovies.length > 0 && (
+        {isAuthenticated && unmatchedMovies.length > 0 && !isCombinedView && !isSoloView && (
           <Box sx={{ textAlign: 'center', mb: 3 }}>
             <Button
               variant="outlined"
@@ -849,7 +310,7 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
                       <table
                         style={{
                           width: '100%',
-                          minWidth: 480,
+                          minWidth: 360,
                           borderCollapse: 'collapse',
                           tableLayout: 'auto',
                         }}
@@ -952,187 +413,213 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
                 Your connections passed on these — watch them on your own!
               </Typography>
             </Box>
-            <Sheet
-              variant="outlined"
-              sx={{
-                borderRadius: 'md',
-                overflow: 'clip',
-                borderColor: 'var(--mn-border-vis)',
-              }}
-            >
-              <Box sx={{ overflowX: 'auto' }}>
-                <table
-                  style={{
-                    width: '100%',
-                    minWidth: 540,
-                    borderCollapse: 'collapse',
-                    tableLayout: 'auto',
-                  }}
-                >
-                  <tbody>
-                    {soloMovies.map((movie) => (
-                      <MovieRow
-                        key={movie.id}
-                        movie={movie}
-                        isAdmin={isAdmin}
-                        canMarkWatched={true}
-                        onMarkWatched={handleMarkWatched}
-                        onDelete={handleDelete}
-                        onToggleSeen={handleToggleSeen}
-                        isAuthenticated={isAuthenticated}
-                      />
-                    ))}
-                  </tbody>
-                </table>
-              </Box>
-            </Sheet>
+
+            {/* Table — hidden on mobile */}
+            <Box sx={{ display: { xs: 'none', sm: 'block' } }}>
+              <Sheet
+                variant="outlined"
+                sx={{
+                  borderRadius: 'md',
+                  overflow: 'clip',
+                  borderColor: 'var(--mn-border-vis)',
+                }}
+              >
+                <Box sx={{ overflowX: 'auto' }}>
+                  <table
+                    style={{
+                      width: '100%',
+                      minWidth: 540,
+                      borderCollapse: 'collapse',
+                      tableLayout: 'auto',
+                    }}
+                  >
+                    <tbody>
+                      {soloMovies.map((movie) => (
+                        <MovieRow
+                          key={movie.id}
+                          movie={movie}
+                          isAdmin={isAdmin}
+                          canMarkWatched={true}
+                          onMarkWatched={handleMarkWatched}
+                          onDelete={handleDelete}
+                          onToggleSeen={handleToggleSeen}
+                          isAuthenticated={isAuthenticated}
+                        />
+                      ))}
+                    </tbody>
+                  </table>
+                </Box>
+              </Sheet>
+            </Box>
+
+            {/* Cards — visible on mobile */}
+            <Box sx={{ display: { xs: 'block', sm: 'none' } }}>
+              {soloMovies.map((movie) => (
+                <MovieCard
+                  key={movie.id}
+                  movie={movie}
+                  isAdmin={isAdmin}
+                  canMarkWatched={true}
+                  onMarkWatched={handleMarkWatched}
+                  onDelete={handleDelete}
+                  onToggleSeen={handleToggleSeen}
+                  isAuthenticated={isAuthenticated}
+                />
+              ))}
+            </Box>
           </>
         )}
 
-        {/* Movie table (personal view) */}
+        {/* Movie list (personal view) */}
         {!isCombinedView && !isSoloView && (
-          <Sheet
-            variant="outlined"
-            sx={{
-              borderRadius: 'md',
-              overflow: 'clip',
-              borderColor: 'var(--mn-border-vis)',
-            }}
-          >
-            <Box sx={{ overflowX: 'auto' }}>
-              <table
-                style={{
-                  width: '100%',
-                  minWidth: 540,
-                  borderCollapse: 'collapse',
-                  tableLayout: 'auto',
+          <>
+            {/* Loading skeleton */}
+            {moviesLoading && !data && (
+              <Sheet
+                variant="outlined"
+                sx={{
+                  borderRadius: 'md',
+                  overflow: 'clip',
+                  borderColor: 'var(--mn-border-vis)',
                 }}
               >
-                <thead>
-                  <tr
-                    style={{
-                      background: 'var(--mn-bg-elevated)',
-                      borderBottom: '1px solid var(--mn-border-vis)',
-                    }}
+                <Box sx={{ p: 0 }}>
+                  {[0, 1, 2, 3, 4].map((i) => (
+                    <Box
+                      key={i}
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 1,
+                        p: '8px 16px',
+                        borderBottom: '1px solid var(--mn-border)',
+                      }}
+                    >
+                      <Skeleton
+                        variant="rectangular"
+                        sx={{ width: 28, height: 42, borderRadius: '3px', flexShrink: 0 }}
+                      />
+                      <Skeleton variant="text" sx={{ width: `${60 + (i % 3) * 15}%` }} />
+                    </Box>
+                  ))}
+                </Box>
+              </Sheet>
+            )}
+
+            {/* Table — hidden on mobile */}
+            {data && (
+              <Box sx={{ display: { xs: 'none', sm: 'block' } }}>
+                <Sheet
+                  variant="outlined"
+                  sx={{
+                    borderRadius: 'md',
+                    overflow: 'clip',
+                    borderColor: 'var(--mn-border-vis)',
+                  }}
+                >
+                  <Box sx={{ overflowX: 'auto' }}>
+                    <table
+                      style={{
+                        width: '100%',
+                        minWidth: 540,
+                        borderCollapse: 'collapse',
+                        tableLayout: 'auto',
+                      }}
+                    >
+                      <thead>
+                        <tr
+                          style={{
+                            background: 'var(--mn-bg-elevated)',
+                            borderBottom: '1px solid var(--mn-border-vis)',
+                          }}
+                        >
+                          {['Title', 'Suggested by', 'Added'].map((label) => (
+                            <th key={label} style={thStyle}>
+                              {label}
+                            </th>
+                          ))}
+                          <th style={{ ...thStyle, textAlign: 'center', padding: '10px 8px' }}>
+                            TMDB
+                          </th>
+                          {isAuthenticated && (
+                            <th style={{ ...thStyle, textAlign: 'center', padding: '10px 4px' }}>
+                              Seen
+                            </th>
+                          )}
+                          {isAuthenticated && (
+                            <th style={{ ...thStyle, textAlign: 'right', padding: '10px 12px' }} />
+                          )}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {movies.length === 0 ? (
+                          <tr>
+                            <td
+                              colSpan={colCount}
+                              style={{
+                                padding: '48px 16px',
+                                textAlign: 'center',
+                                color: 'var(--mn-text-muted)',
+                                fontSize: '0.875rem',
+                              }}
+                            >
+                              No movies yet. Be the first to suggest one!
+                            </td>
+                          </tr>
+                        ) : (
+                          movies.map((movie) => (
+                            <MovieRow
+                              key={movie.id}
+                              movie={movie}
+                              isAdmin={isAdmin}
+                              canMarkWatched={
+                                isAdmin ||
+                                (isAuthenticated && String(movie.requested_by) === String(user?.id))
+                              }
+                              onMarkWatched={handleMarkWatched}
+                              onDelete={handleDelete}
+                              onToggleSeen={handleToggleSeen}
+                              isAuthenticated={isAuthenticated}
+                            />
+                          ))
+                        )}
+                      </tbody>
+                    </table>
+                  </Box>
+                </Sheet>
+              </Box>
+            )}
+
+            {/* Cards — visible on mobile */}
+            {data && (
+              <Box sx={{ display: { xs: 'block', sm: 'none' } }}>
+                {movies.length === 0 ? (
+                  <Typography
+                    level="body-sm"
+                    sx={{ textAlign: 'center', color: 'text.tertiary', py: 6 }}
                   >
-                    <th
-                      style={{
-                        padding: '10px 16px',
-                        textAlign: 'left',
-                        fontSize: '0.7rem',
-                        fontWeight: 700,
-                        textTransform: 'uppercase',
-                        letterSpacing: '0.08em',
-                        color: 'var(--mn-text-muted)',
-                      }}
-                    >
-                      Title
-                    </th>
-                    <th
-                      style={{
-                        padding: '10px 16px',
-                        textAlign: 'left',
-                        fontSize: '0.7rem',
-                        fontWeight: 700,
-                        textTransform: 'uppercase',
-                        letterSpacing: '0.08em',
-                        color: 'var(--mn-text-muted)',
-                      }}
-                    >
-                      Suggested by
-                    </th>
-                    <th
-                      style={{
-                        padding: '10px 16px',
-                        textAlign: 'left',
-                        fontSize: '0.7rem',
-                        fontWeight: 700,
-                        textTransform: 'uppercase',
-                        letterSpacing: '0.08em',
-                        color: 'var(--mn-text-muted)',
-                      }}
-                    >
-                      Added
-                    </th>
-                    <th
-                      style={{
-                        padding: '10px 8px',
-                        textAlign: 'center',
-                        fontSize: '0.7rem',
-                        fontWeight: 700,
-                        textTransform: 'uppercase',
-                        letterSpacing: '0.08em',
-                        color: 'var(--mn-text-muted)',
-                      }}
-                    >
-                      TMDB
-                    </th>
-                    {isAuthenticated && (
-                      <th
-                        style={{
-                          padding: '10px 4px',
-                          textAlign: 'center',
-                          fontSize: '0.7rem',
-                          fontWeight: 700,
-                          textTransform: 'uppercase',
-                          letterSpacing: '0.08em',
-                          color: 'var(--mn-text-muted)',
-                        }}
-                      >
-                        Seen
-                      </th>
-                    )}
-                    {isAuthenticated && (
-                      <th
-                        style={{
-                          padding: '10px 12px',
-                          textAlign: 'right',
-                          fontSize: '0.7rem',
-                          fontWeight: 700,
-                          textTransform: 'uppercase',
-                          letterSpacing: '0.08em',
-                          color: 'var(--mn-text-muted)',
-                        }}
-                      />
-                    )}
-                  </tr>
-                </thead>
-                <tbody>
-                  {movies.length === 0 ? (
-                    <tr>
-                      <td
-                        colSpan={colCount}
-                        style={{
-                          padding: '48px 16px',
-                          textAlign: 'center',
-                          color: 'var(--mn-text-muted)',
-                          fontSize: '0.875rem',
-                        }}
-                      >
-                        No movies yet. Be the first to suggest one!
-                      </td>
-                    </tr>
-                  ) : (
-                    movies.map((movie) => (
-                      <MovieRow
-                        key={movie.id}
-                        movie={movie}
-                        isAdmin={isAdmin}
-                        canMarkWatched={
-                          isAdmin ||
-                          (isAuthenticated && String(movie.requested_by) === String(user?.id))
-                        }
-                        onMarkWatched={handleMarkWatched}
-                        onDelete={handleDelete}
-                        onToggleSeen={handleToggleSeen}
-                        isAuthenticated={isAuthenticated}
-                      />
-                    ))
-                  )}
-                </tbody>
-              </table>
-            </Box>
-          </Sheet>
+                    No movies yet. Be the first to suggest one!
+                  </Typography>
+                ) : (
+                  movies.map((movie) => (
+                    <MovieCard
+                      key={movie.id}
+                      movie={movie}
+                      isAdmin={isAdmin}
+                      canMarkWatched={
+                        isAdmin ||
+                        (isAuthenticated && String(movie.requested_by) === String(user?.id))
+                      }
+                      onMarkWatched={handleMarkWatched}
+                      onDelete={handleDelete}
+                      onToggleSeen={handleToggleSeen}
+                      isAuthenticated={isAuthenticated}
+                    />
+                  ))
+                )}
+              </Box>
+            )}
+          </>
         )}
 
         {/* Seed button — admin only, test env only */}
@@ -1150,8 +637,20 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
           </Box>
         )}
       </Box>
+
+      <ConfirmDialog {...dialogProps} />
     </Box>
   );
+};
+
+const thStyle: React.CSSProperties = {
+  padding: '10px 16px',
+  textAlign: 'left',
+  fontSize: '0.7rem',
+  fontWeight: 700,
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  color: 'var(--mn-text-muted)',
 };
 
 const combinedThStyle: React.CSSProperties = {

--- a/src/components/home/MovieCard.tsx
+++ b/src/components/home/MovieCard.tsx
@@ -4,6 +4,7 @@ import { Movie } from '../../models/Movies';
 
 interface MovieCardProps {
   movie: Movie;
+  rank?: number;
   isAdmin: boolean;
   canMarkWatched: boolean;
   onMarkWatched: (id: string, title: string) => void;
@@ -14,6 +15,7 @@ interface MovieCardProps {
 
 const MovieCard: React.FC<MovieCardProps> = ({
   movie,
+  rank,
   isAdmin,
   canMarkWatched,
   onMarkWatched,
@@ -37,6 +39,22 @@ const MovieCard: React.FC<MovieCardProps> = ({
       }}
     >
       <Box sx={{ display: 'flex', gap: 1.5 }}>
+        {/* Rank */}
+        {rank != null && (
+          <Typography
+            level="body-xs"
+            sx={{
+              fontWeight: 700,
+              color: rank <= 3 ? 'primary.400' : 'text.tertiary',
+              minWidth: 20,
+              textAlign: 'right',
+              pt: 0.5,
+              flexShrink: 0,
+            }}
+          >
+            {rank}
+          </Typography>
+        )}
         {/* Poster */}
         {movie.poster_url ? (
           <img

--- a/src/components/home/MovieCard.tsx
+++ b/src/components/home/MovieCard.tsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import { Box, Typography, Chip, IconButton, Tooltip, Sheet } from '@mui/joy';
+import { Movie } from '../../models/Movies';
+
+interface MovieCardProps {
+  movie: Movie;
+  isAdmin: boolean;
+  canMarkWatched: boolean;
+  onMarkWatched: (id: string, title: string) => void;
+  onDelete: (id: string, title: string) => void;
+  onToggleSeen: (id: string, currentlySeen: boolean) => void;
+  isAuthenticated: boolean;
+}
+
+const MovieCard: React.FC<MovieCardProps> = ({
+  movie,
+  isAdmin,
+  canMarkWatched,
+  onMarkWatched,
+  onDelete,
+  onToggleSeen,
+  isAuthenticated,
+}) => {
+  const isSeen = movie.myTags?.some((t) => t.tag.slug === 'seen') ?? false;
+  const seenByUsers = (movie.userTags ?? []).filter((t) => t.tag.slug === 'seen');
+  const seenCount = seenByUsers.length;
+  const seenNames = seenByUsers.map((t) => t.user.display_name || t.user.username);
+
+  return (
+    <Sheet
+      variant="outlined"
+      sx={{
+        borderRadius: 'md',
+        mb: 1,
+        p: 1.5,
+        borderColor: 'var(--mn-border-vis)',
+      }}
+    >
+      <Box sx={{ display: 'flex', gap: 1.5 }}>
+        {/* Poster */}
+        {movie.poster_url ? (
+          <img
+            src={movie.poster_url}
+            alt=""
+            style={{
+              width: 40,
+              height: 60,
+              objectFit: 'cover',
+              borderRadius: 4,
+              flexShrink: 0,
+            }}
+          />
+        ) : (
+          <Box
+            sx={{
+              width: 40,
+              height: 60,
+              bgcolor: 'background.level2',
+              borderRadius: '4px',
+              flexShrink: 0,
+            }}
+          />
+        )}
+
+        {/* Details */}
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography level="body-sm" sx={{ fontWeight: 600, color: 'text.primary' }}>
+            {movie.title}
+            {movie.tmdb_id && (
+              <a
+                href={`https://www.themoviedb.org/movie/${movie.tmdb_id}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  color: 'var(--joy-palette-primary-500)',
+                  fontSize: '0.7rem',
+                  marginLeft: 4,
+                }}
+              >
+                ↗
+              </a>
+            )}
+          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.25 }}>
+            <Chip
+              size="sm"
+              variant="soft"
+              color="neutral"
+              sx={{ fontWeight: 500, fontSize: '0.65rem' }}
+            >
+              {movie.requester}
+            </Chip>
+            <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+              {new Date(movie.date_submitted).toLocaleDateString(undefined, {
+                month: 'short',
+                day: 'numeric',
+              })}
+            </Typography>
+          </Box>
+        </Box>
+      </Box>
+
+      {/* Actions */}
+      {(isAuthenticated || canMarkWatched || isAdmin) && (
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: 0.5,
+            mt: 1,
+            pt: 0.5,
+            borderTop: '1px solid',
+            borderColor: 'var(--mn-border)',
+          }}
+        >
+          {isAuthenticated && (
+            <Tooltip
+              title={
+                seenCount > 0
+                  ? `Seen by: ${seenNames.join(', ')}`
+                  : isSeen
+                    ? 'Remove "Seen it"'
+                    : "I've seen this"
+              }
+              arrow
+            >
+              <IconButton
+                size="sm"
+                variant="plain"
+                color={isSeen ? 'warning' : 'neutral'}
+                onClick={() => onToggleSeen(movie.id, isSeen)}
+                sx={{
+                  opacity: isSeen ? 0.9 : 0.35,
+                  '&:hover': { opacity: 1 },
+                  fontSize: '0.85rem',
+                  minWidth: 36,
+                  minHeight: 36,
+                }}
+              >
+                {isSeen ? '👁' : '👁‍🗨'}
+                {seenCount > 0 && (
+                  <Typography
+                    component="span"
+                    level="body-xs"
+                    sx={{ ml: 0.25, fontWeight: 700, fontSize: '0.6rem' }}
+                  >
+                    {seenCount}
+                  </Typography>
+                )}
+              </IconButton>
+            </Tooltip>
+          )}
+          {canMarkWatched && (
+            <IconButton
+              size="sm"
+              color="success"
+              variant="soft"
+              onClick={() => onMarkWatched(movie.id, movie.title)}
+              sx={{ minWidth: 36, minHeight: 36 }}
+            >
+              ✓
+            </IconButton>
+          )}
+          {isAdmin && (
+            <IconButton
+              size="sm"
+              color="danger"
+              variant="soft"
+              onClick={() => onDelete(movie.id, movie.title)}
+              sx={{ minWidth: 36, minHeight: 36 }}
+            >
+              ✕
+            </IconButton>
+          )}
+        </Box>
+      )}
+    </Sheet>
+  );
+};
+
+export default MovieCard;

--- a/src/components/home/MovieCompareCard.tsx
+++ b/src/components/home/MovieCompareCard.tsx
@@ -35,6 +35,11 @@ const MovieCompareCard: React.FC<MovieCompareCardProps> = ({ movie, onPick, disa
         outline: 'none',
         borderColor: 'divider',
       },
+      '& .Mui-focusVisible': {
+        outline: 'none',
+        boxShadow: 'none',
+        '--joy-focus-thickness': '0px',
+      },
       '&:hover': disabled
         ? {}
         : {
@@ -156,7 +161,7 @@ const MovieCompareCard: React.FC<MovieCompareCardProps> = ({ movie, onPick, disa
             fontWeight: 700,
             color: '#0d0f1a',
             fontSize: { xs: '0.75rem', sm: '0.875rem' },
-            '&:focus, &:focus-visible': {
+            '&:focus, &:focus-visible, &.Mui-focusVisible': {
               outline: 'none',
               outlineOffset: 0,
               boxShadow: 'none',

--- a/src/components/home/MovieCompareCard.tsx
+++ b/src/components/home/MovieCompareCard.tsx
@@ -20,7 +20,11 @@ interface MovieCompareCardProps {
 
 const MovieCompareCard: React.FC<MovieCompareCardProps> = ({ movie, onPick, disabled }) => (
   <Box
-    onClick={() => !disabled && onPick(movie.id)}
+    onClick={() => {
+      if (disabled) return;
+      (document.activeElement as HTMLElement)?.blur();
+      onPick(movie.id);
+    }}
     sx={{
       flex: 1,
       cursor: disabled ? 'default' : 'pointer',
@@ -155,6 +159,7 @@ const MovieCompareCard: React.FC<MovieCompareCardProps> = ({ movie, onPick, disa
           disabled={disabled}
           onClick={(e) => {
             e.stopPropagation();
+            (e.currentTarget as HTMLElement).blur();
             onPick(movie.id);
           }}
           sx={{

--- a/src/components/home/MovieCompareCard.tsx
+++ b/src/components/home/MovieCompareCard.tsx
@@ -31,7 +31,10 @@ const MovieCompareCard: React.FC<MovieCompareCardProps> = ({ movie, onPick, disa
       borderColor: 'divider',
       transition: 'border-color 0.2s, transform 0.15s, box-shadow 0.2s',
       opacity: disabled ? 0.5 : 1,
-      '&:focus, &:focus-visible': { outline: 'none' },
+      '&:focus, &:focus-visible, &:focus-within': {
+        outline: 'none',
+        borderColor: 'divider',
+      },
       '&:hover': disabled
         ? {}
         : {
@@ -153,7 +156,12 @@ const MovieCompareCard: React.FC<MovieCompareCardProps> = ({ movie, onPick, disa
             fontWeight: 700,
             color: '#0d0f1a',
             fontSize: { xs: '0.75rem', sm: '0.875rem' },
-            '&:focus, &:focus-visible': { outline: 'none', outlineOffset: 0 },
+            '&:focus, &:focus-visible': {
+              outline: 'none',
+              outlineOffset: 0,
+              boxShadow: 'none',
+              '--joy-focus-thickness': '0px',
+            },
           }}
         >
           Pick This One

--- a/src/components/home/MovieCompareCard.tsx
+++ b/src/components/home/MovieCompareCard.tsx
@@ -31,6 +31,7 @@ const MovieCompareCard: React.FC<MovieCompareCardProps> = ({ movie, onPick, disa
       borderColor: 'divider',
       transition: 'border-color 0.2s, transform 0.15s, box-shadow 0.2s',
       opacity: disabled ? 0.5 : 1,
+      '&:focus, &:focus-visible': { outline: 'none' },
       '&:hover': disabled
         ? {}
         : {
@@ -148,7 +149,12 @@ const MovieCompareCard: React.FC<MovieCompareCardProps> = ({ movie, onPick, disa
             e.stopPropagation();
             onPick(movie.id);
           }}
-          sx={{ fontWeight: 700, color: '#0d0f1a', fontSize: { xs: '0.75rem', sm: '0.875rem' } }}
+          sx={{
+            fontWeight: 700,
+            color: '#0d0f1a',
+            fontSize: { xs: '0.75rem', sm: '0.875rem' },
+            '&:focus, &:focus-visible': { outline: 'none', outlineOffset: 0 },
+          }}
         >
           Pick This One
         </Button>

--- a/src/components/home/MovieRow.tsx
+++ b/src/components/home/MovieRow.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import { Box, Typography, Chip, IconButton, Tooltip } from '@mui/joy';
+import { Movie } from '../../models/Movies';
+
+export interface MovieRowProps {
+  movie: Movie;
+  isAdmin: boolean;
+  canMarkWatched: boolean;
+  onMarkWatched: (id: string, title: string) => void;
+  onDelete: (id: string, title: string) => void;
+  onToggleSeen: (id: string, currentlySeen: boolean) => void;
+  isAuthenticated: boolean;
+}
+
+const MovieRow: React.FC<MovieRowProps> = ({
+  movie,
+  isAdmin,
+  canMarkWatched,
+  onMarkWatched,
+  onDelete,
+  onToggleSeen,
+  isAuthenticated,
+}) => {
+  const isSeen = movie.myTags?.some((t) => t.tag.slug === 'seen') ?? false;
+  const seenByUsers = (movie.userTags ?? []).filter((t) => t.tag.slug === 'seen');
+  const seenCount = seenByUsers.length;
+  const seenNames = seenByUsers.map((t) => t.user.display_name || t.user.username);
+
+  return (
+    <tr>
+      {/* Title */}
+      <td style={{ verticalAlign: 'middle', padding: '8px 16px' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          {movie.poster_url ? (
+            <img
+              src={movie.poster_url}
+              alt=""
+              style={{
+                width: 28,
+                height: 42,
+                objectFit: 'cover',
+                borderRadius: 3,
+                flexShrink: 0,
+              }}
+            />
+          ) : (
+            <Box
+              sx={{
+                width: 28,
+                height: 42,
+                bgcolor: 'background.level2',
+                borderRadius: '3px',
+                flexShrink: 0,
+              }}
+            />
+          )}
+          <Typography level="body-sm" sx={{ fontWeight: 600, color: 'text.primary' }}>
+            {movie.title}
+          </Typography>
+        </Box>
+      </td>
+
+      {/* Suggested by */}
+      <td style={{ verticalAlign: 'middle', padding: '12px 16px' }}>
+        <Chip size="sm" variant="soft" color="neutral" sx={{ fontWeight: 500 }}>
+          {movie.requester}
+        </Chip>
+      </td>
+
+      {/* Date */}
+      <td style={{ verticalAlign: 'middle', padding: '12px 16px', whiteSpace: 'nowrap' }}>
+        <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
+          {new Date(movie.date_submitted).toLocaleDateString(undefined, {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+          })}
+        </Typography>
+      </td>
+
+      {/* TMDB */}
+      <td style={{ verticalAlign: 'middle', padding: '12px 8px', textAlign: 'center' }}>
+        {movie.tmdb_id ? (
+          <a
+            href={`https://www.themoviedb.org/movie/${movie.tmdb_id}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: 'var(--joy-palette-primary-500)', fontSize: '0.75rem' }}
+          >
+            ↗
+          </a>
+        ) : null}
+      </td>
+
+      {/* Seen it */}
+      {isAuthenticated && (
+        <td style={{ verticalAlign: 'middle', padding: '0 4px', textAlign: 'center' }}>
+          <Tooltip
+            title={
+              seenCount > 0
+                ? `Seen by: ${seenNames.join(', ')}`
+                : isSeen
+                  ? 'Remove "Seen it"'
+                  : "I've seen this"
+            }
+            placement="top"
+            arrow
+          >
+            <IconButton
+              size="sm"
+              variant="plain"
+              color={isSeen ? 'warning' : 'neutral'}
+              onClick={() => onToggleSeen(movie.id, isSeen)}
+              sx={{
+                opacity: isSeen ? 0.9 : 0.35,
+                transition: 'opacity 0.15s',
+                '&:hover': { opacity: 1 },
+                fontSize: '0.85rem',
+              }}
+            >
+              {isSeen ? '👁' : '👁‍🗨'}
+              {seenCount > 0 && (
+                <Typography
+                  component="span"
+                  level="body-xs"
+                  sx={{ ml: 0.25, fontWeight: 700, fontSize: '0.6rem' }}
+                >
+                  {seenCount}
+                </Typography>
+              )}
+            </IconButton>
+          </Tooltip>
+        </td>
+      )}
+
+      {/* Actions */}
+      {(canMarkWatched || isAdmin) && (
+        <td
+          style={{
+            verticalAlign: 'middle',
+            padding: '0 12px',
+            textAlign: 'right',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {canMarkWatched && (
+            <IconButton
+              size="sm"
+              color="success"
+              variant="plain"
+              onClick={() => onMarkWatched(movie.id, movie.title)}
+              title={`Mark "${movie.title}" as done`}
+              sx={{
+                opacity: 0.5,
+                transition: 'opacity 0.15s',
+                '&:hover': { opacity: 1 },
+                mr: isAdmin ? 0.5 : 0,
+              }}
+            >
+              ✓
+            </IconButton>
+          )}
+          {isAdmin && (
+            <IconButton
+              size="sm"
+              color="danger"
+              variant="plain"
+              onClick={() => onDelete(movie.id, movie.title)}
+              title={`Remove "${movie.title}"`}
+              sx={{
+                opacity: 0.5,
+                transition: 'opacity 0.15s',
+                '&:hover': { opacity: 1 },
+              }}
+            >
+              ✕
+            </IconButton>
+          )}
+        </td>
+      )}
+    </tr>
+  );
+};
+
+export default MovieRow;

--- a/src/components/home/ThisOrThat.tsx
+++ b/src/components/home/ThisOrThat.tsx
@@ -287,6 +287,7 @@ const ThisOrThat: React.FC = () => {
               >
                 <Box sx={{ flex: 1, maxWidth: { sm: 360 }, display: 'flex' }}>
                   <MovieCompareCard
+                    key={pair.movieA.id}
                     movie={pair.movieA}
                     onPick={handlePick}
                     disabled={recording || fading}
@@ -310,6 +311,7 @@ const ThisOrThat: React.FC = () => {
 
                 <Box sx={{ flex: 1, maxWidth: { sm: 360 }, display: 'flex' }}>
                   <MovieCompareCard
+                    key={pair.movieB.id}
                     movie={pair.movieB}
                     onPick={handlePick}
                     disabled={recording || fading}

--- a/src/components/home/ThisOrThat.tsx
+++ b/src/components/home/ThisOrThat.tsx
@@ -9,10 +9,13 @@ import {
 } from '../../graphql/queries';
 import { Box, Typography, Button, Sheet, Chip, Skeleton } from '@mui/joy';
 import MovieCompareCard from './MovieCompareCard';
+import ConfirmDialog from '../common/ConfirmDialog';
+import { useConfirm } from '../../hooks/useConfirm';
 
 type Tab = 'compare' | 'rankings';
 
 const ThisOrThat: React.FC = () => {
+  const { confirm, dialogProps } = useConfirm();
   const [tab, setTab] = useState<Tab>('compare');
   const [sessionCount, setSessionCount] = useState(0);
   const [seenIds, setSeenIds] = useState<string[]>([]);
@@ -130,7 +133,13 @@ const ThisOrThat: React.FC = () => {
   };
 
   const handleReset = async (movieId: string, title: string) => {
-    if (!window.confirm(`Reset all your comparisons for "${title}"?`)) return;
+    const ok = await confirm({
+      title: 'Reset comparisons?',
+      message: `All your comparisons for "${title}" will be removed.`,
+      confirmText: 'Reset',
+      confirmColor: 'danger',
+    });
+    if (!ok) return;
     try {
       await resetComparisons({ variables: { movieId } });
     } catch (err: any) {
@@ -405,6 +414,8 @@ const ThisOrThat: React.FC = () => {
           </>
         )}
       </Box>
+
+      <ConfirmDialog {...dialogProps} />
     </Box>
   );
 };

--- a/src/components/home/ThisOrThatBanner.tsx
+++ b/src/components/home/ThisOrThatBanner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Button, Typography } from '@mui/joy';
+import { Chip } from '@mui/joy';
 
 interface ThisOrThatBannerProps {
   hasEloData: boolean;
@@ -11,45 +11,27 @@ const ThisOrThatBanner: React.FC<ThisOrThatBannerProps> = ({
   hasEloData,
   isAuthenticated,
   onShowThisOrThat,
-}) => (
-  <Box
-    sx={{
-      mb: 3,
-      p: 1.5,
-      borderRadius: 'md',
-      bgcolor: 'primary.softBg',
-      border: '1px solid',
-      borderColor: 'primary.outlinedBorder',
-      textAlign: 'center',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      gap: 1,
-    }}
-  >
-    {isAuthenticated ? (
-      <>
-        <Typography level="body-sm" sx={{ color: 'primary.softColor' }}>
-          {hasEloData ? 'Keep ranking movies!' : 'Rate movies to get your personal ranking.'}
-        </Typography>
-        {onShowThisOrThat && (
-          <Button
-            variant="soft"
-            color="primary"
-            size="sm"
-            onClick={onShowThisOrThat}
-            sx={{ fontWeight: 700 }}
-          >
-            This or That
-          </Button>
-        )}
-      </>
-    ) : (
-      <Typography level="body-sm" sx={{ color: 'primary.softColor' }}>
-        Sign in to rank movies with This or That
-      </Typography>
-    )}
-  </Box>
-);
+}) => {
+  if (!isAuthenticated || !onShowThisOrThat) return null;
+
+  return (
+    <Chip
+      variant="soft"
+      color="primary"
+      size="sm"
+      onClick={onShowThisOrThat}
+      sx={{
+        cursor: 'pointer',
+        fontWeight: 600,
+        fontSize: '0.7rem',
+        opacity: 0.75,
+        transition: 'opacity 0.15s',
+        '&:hover': { opacity: 1 },
+      }}
+    >
+      {hasEloData ? '▸ Keep ranking' : '▸ Rank movies'}
+    </Chip>
+  );
+};
 
 export default ThisOrThatBanner;

--- a/src/components/home/ThisOrThatBanner.tsx
+++ b/src/components/home/ThisOrThatBanner.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Box, Button, Typography } from '@mui/joy';
+
+interface ThisOrThatBannerProps {
+  hasEloData: boolean;
+  isAuthenticated: boolean;
+  onShowThisOrThat?: () => void;
+}
+
+const ThisOrThatBanner: React.FC<ThisOrThatBannerProps> = ({
+  hasEloData,
+  isAuthenticated,
+  onShowThisOrThat,
+}) => (
+  <Box
+    sx={{
+      mb: 3,
+      p: 1.5,
+      borderRadius: 'md',
+      bgcolor: 'primary.softBg',
+      border: '1px solid',
+      borderColor: 'primary.outlinedBorder',
+      textAlign: 'center',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 1,
+    }}
+  >
+    {isAuthenticated ? (
+      <>
+        <Typography level="body-sm" sx={{ color: 'primary.softColor' }}>
+          {hasEloData ? 'Keep ranking movies!' : 'Rate movies to get your personal ranking.'}
+        </Typography>
+        {onShowThisOrThat && (
+          <Button
+            variant="soft"
+            color="primary"
+            size="sm"
+            onClick={onShowThisOrThat}
+            sx={{ fontWeight: 700 }}
+          >
+            This or That
+          </Button>
+        )}
+      </>
+    ) : (
+      <Typography level="body-sm" sx={{ color: 'primary.softColor' }}>
+        Sign in to rank movies with This or That
+      </Typography>
+    )}
+  </Box>
+);
+
+export default ThisOrThatBanner;

--- a/src/components/home/ViewSelector.tsx
+++ b/src/components/home/ViewSelector.tsx
@@ -32,19 +32,6 @@ const ViewSelector: React.FC<ViewSelectorProps> = ({
         mb: 3,
       }}
     >
-      <Button
-        variant={!isCombinedView && !isSoloView ? 'soft' : 'plain'}
-        color="neutral"
-        size="sm"
-        onClick={() => onSelect(null)}
-        sx={{
-          fontWeight: 600,
-          color: !isCombinedView && !isSoloView ? 'primary.400' : 'text.secondary',
-          '&:hover': { color: 'primary.300' },
-        }}
-      >
-        My List
-      </Button>
       {connections.map((conn) => (
         <Button
           key={conn.id}
@@ -76,6 +63,19 @@ const ViewSelector: React.FC<ViewSelectorProps> = ({
           Solo Queue
         </Button>
       )}
+      <Button
+        variant={!isCombinedView && !isSoloView ? 'soft' : 'plain'}
+        color="neutral"
+        size="sm"
+        onClick={() => onSelect(null)}
+        sx={{
+          fontWeight: 600,
+          color: !isCombinedView && !isSoloView ? 'primary.400' : 'text.secondary',
+          '&:hover': { color: 'primary.300' },
+        }}
+      >
+        My Requested
+      </Button>
     </Box>
   );
 };

--- a/src/components/home/ViewSelector.tsx
+++ b/src/components/home/ViewSelector.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Box, Button } from '@mui/joy';
+
+interface Connection {
+  id: string;
+  user: { display_name?: string; username: string };
+}
+
+interface ViewSelectorProps {
+  connections: Connection[];
+  soloMovieCount: number;
+  selectedConnectionId: string | null;
+  onSelect: (connectionId: string | null) => void;
+}
+
+const ViewSelector: React.FC<ViewSelectorProps> = ({
+  connections,
+  soloMovieCount,
+  selectedConnectionId,
+  onSelect,
+}) => {
+  const isSoloView = selectedConnectionId === 'solo';
+  const isCombinedView = selectedConnectionId !== null && !isSoloView;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        flexWrap: 'wrap',
+        gap: 0.5,
+        mb: 3,
+      }}
+    >
+      <Button
+        variant={!isCombinedView && !isSoloView ? 'soft' : 'plain'}
+        color="neutral"
+        size="sm"
+        onClick={() => onSelect(null)}
+        sx={{
+          fontWeight: 600,
+          color: !isCombinedView && !isSoloView ? 'primary.400' : 'text.secondary',
+          '&:hover': { color: 'primary.300' },
+        }}
+      >
+        My List
+      </Button>
+      {connections.map((conn) => (
+        <Button
+          key={conn.id}
+          variant={selectedConnectionId === conn.id ? 'soft' : 'plain'}
+          color="neutral"
+          size="sm"
+          onClick={() => onSelect(conn.id)}
+          sx={{
+            fontWeight: 600,
+            color: selectedConnectionId === conn.id ? 'primary.400' : 'text.secondary',
+            '&:hover': { color: 'primary.300' },
+          }}
+        >
+          {conn.user.display_name || conn.user.username} + Me
+        </Button>
+      ))}
+      {soloMovieCount > 0 && (
+        <Button
+          variant={isSoloView ? 'soft' : 'plain'}
+          color="neutral"
+          size="sm"
+          onClick={() => onSelect('solo')}
+          sx={{
+            fontWeight: 600,
+            color: isSoloView ? 'primary.400' : 'text.secondary',
+            '&:hover': { color: 'primary.300' },
+          }}
+        >
+          Solo Queue
+        </Button>
+      )}
+    </Box>
+  );
+};
+
+export default ViewSelector;

--- a/src/components/home/WatchHistory.tsx
+++ b/src/components/home/WatchHistory.tsx
@@ -1,13 +1,28 @@
 import React, { useState } from 'react';
 import { useQuery, useMutation } from '@apollo/client';
-import { Box, Button, Typography, Sheet, Chip, IconButton, Tooltip } from '@mui/joy';
+import {
+  Box,
+  Button,
+  Typography,
+  Sheet,
+  Chip,
+  IconButton,
+  Tooltip,
+  CircularProgress,
+} from '@mui/joy';
 import { WATCHED_MOVIES, UNWATCH_MOVIE, GET_MOVIES } from '../../graphql/queries';
 import { useAuth } from '../../contexts/AuthContext';
+import { useToast } from '../../contexts/ToastContext';
+import { useConfirm } from '../../hooks/useConfirm';
+import ConfirmDialog from '../common/ConfirmDialog';
+import WatchHistoryCard from './WatchHistoryCard';
 
 const PAGE_SIZE = 25;
 
 const WatchHistory: React.FC = () => {
   const { user } = useAuth();
+  const { showError } = useToast();
+  const { confirm, dialogProps } = useConfirm();
   const isAdmin = user?.is_admin ?? false;
   const [offset, setOffset] = useState(0);
 
@@ -26,12 +41,17 @@ const WatchHistory: React.FC = () => {
   const movies = data?.watchedMovies ?? [];
 
   const handleUnwatch = async (id: string, title: string) => {
-    if (!window.confirm(`Put "${title}" back in the queue? It'll appear at the end of the list.`))
-      return;
+    const ok = await confirm({
+      title: 'Watch again?',
+      message: `"${title}" will go back to the end of the queue.`,
+      confirmText: 'Requeue',
+      confirmColor: 'primary',
+    });
+    if (!ok) return;
     try {
       await unwatchMovie({ variables: { id } });
     } catch (err: any) {
-      alert(`Error: ${err.message}`);
+      showError(`Error: ${err.message}`);
     }
   };
 
@@ -56,9 +76,9 @@ const WatchHistory: React.FC = () => {
         </Box>
 
         {loading && movies.length === 0 && (
-          <Typography level="body-sm" sx={{ textAlign: 'center', color: 'text.tertiary' }}>
-            Loading...
-          </Typography>
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+            <CircularProgress size="md" color="primary" />
+          </Box>
         )}
 
         {!loading && movies.length === 0 && (
@@ -68,165 +88,188 @@ const WatchHistory: React.FC = () => {
         )}
 
         {movies.length > 0 && (
-          <Sheet
-            variant="outlined"
-            sx={{
-              borderRadius: 'md',
-              overflow: 'clip',
-              borderColor: 'var(--mn-border-vis)',
-            }}
-          >
-            <Box sx={{ overflowX: 'auto' }}>
-              <table
-                style={{
-                  width: '100%',
-                  minWidth: 480,
-                  borderCollapse: 'collapse',
-                  tableLayout: 'auto',
+          <>
+            {/* Table — hidden on mobile */}
+            <Box sx={{ display: { xs: 'none', sm: 'block' } }}>
+              <Sheet
+                variant="outlined"
+                sx={{
+                  borderRadius: 'md',
+                  overflow: 'clip',
+                  borderColor: 'var(--mn-border-vis)',
                 }}
               >
-                <thead>
-                  <tr
+                <Box sx={{ overflowX: 'auto' }}>
+                  <table
                     style={{
-                      background: 'var(--mn-bg-elevated)',
-                      borderBottom: '1px solid var(--mn-border-vis)',
+                      width: '100%',
+                      minWidth: 480,
+                      borderCollapse: 'collapse',
+                      tableLayout: 'auto',
                     }}
                   >
-                    {['Title', 'Suggested by', 'Watched'].map((label) => (
-                      <th
-                        key={label}
+                    <thead>
+                      <tr
                         style={{
-                          padding: '10px 16px',
-                          textAlign: 'left',
-                          fontSize: '0.7rem',
-                          fontWeight: 700,
-                          textTransform: 'uppercase',
-                          letterSpacing: '0.08em',
-                          color: 'var(--mn-text-muted)',
+                          background: 'var(--mn-bg-elevated)',
+                          borderBottom: '1px solid var(--mn-border-vis)',
                         }}
                       >
-                        {label}
-                      </th>
-                    ))}
-                    <th
-                      style={{
-                        padding: '10px 12px',
-                        textAlign: 'right',
-                        fontSize: '0.7rem',
-                        fontWeight: 700,
-                        textTransform: 'uppercase',
-                        letterSpacing: '0.08em',
-                        color: 'var(--mn-text-muted)',
-                      }}
-                    />
-                  </tr>
-                </thead>
-                <tbody>
-                  {movies.map((movie: any) => {
-                    const canUnwatch = isAdmin || String(movie.requested_by) === String(user?.id);
-                    return (
-                      <tr key={movie.id}>
-                        <td style={{ verticalAlign: 'middle', padding: '8px 16px' }}>
-                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                            {movie.poster_url ? (
-                              <img
-                                src={movie.poster_url}
-                                alt=""
-                                style={{
-                                  width: 28,
-                                  height: 42,
-                                  objectFit: 'cover',
-                                  borderRadius: 3,
-                                  flexShrink: 0,
-                                }}
-                              />
-                            ) : (
-                              <Box
-                                sx={{
-                                  width: 28,
-                                  height: 42,
-                                  bgcolor: 'background.level2',
-                                  borderRadius: '3px',
-                                  flexShrink: 0,
-                                }}
-                              />
-                            )}
-                            <Typography
-                              level="body-sm"
-                              sx={{ fontWeight: 600, color: 'text.primary' }}
-                            >
-                              {movie.title}
-                            </Typography>
-                            {movie.tmdb_id && (
-                              <a
-                                href={`https://www.themoviedb.org/movie/${movie.tmdb_id}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                style={{
-                                  color: 'var(--joy-palette-primary-500)',
-                                  fontSize: '0.75rem',
-                                }}
-                              >
-                                ↗
-                              </a>
-                            )}
-                          </Box>
-                        </td>
-                        <td style={{ verticalAlign: 'middle', padding: '12px 16px' }}>
-                          <Chip size="sm" variant="soft" color="neutral" sx={{ fontWeight: 500 }}>
-                            {movie.requester}
-                          </Chip>
-                        </td>
-                        <td
+                        {['Title', 'Suggested by', 'Watched'].map((label) => (
+                          <th
+                            key={label}
+                            style={{
+                              padding: '10px 16px',
+                              textAlign: 'left',
+                              fontSize: '0.7rem',
+                              fontWeight: 700,
+                              textTransform: 'uppercase',
+                              letterSpacing: '0.08em',
+                              color: 'var(--mn-text-muted)',
+                            }}
+                          >
+                            {label}
+                          </th>
+                        ))}
+                        <th
                           style={{
-                            verticalAlign: 'middle',
-                            padding: '12px 16px',
-                            whiteSpace: 'nowrap',
-                          }}
-                        >
-                          <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
-                            {movie.watched_at
-                              ? new Date(movie.watched_at).toLocaleDateString(undefined, {
-                                  year: 'numeric',
-                                  month: 'short',
-                                  day: 'numeric',
-                                })
-                              : '—'}
-                          </Typography>
-                        </td>
-                        <td
-                          style={{
-                            verticalAlign: 'middle',
-                            padding: '0 12px',
+                            padding: '10px 12px',
                             textAlign: 'right',
+                            fontSize: '0.7rem',
+                            fontWeight: 700,
+                            textTransform: 'uppercase',
+                            letterSpacing: '0.08em',
+                            color: 'var(--mn-text-muted)',
                           }}
-                        >
-                          {canUnwatch && (
-                            <Tooltip title="Watch again — put back in queue" arrow>
-                              <IconButton
-                                size="sm"
-                                color="primary"
-                                variant="plain"
-                                onClick={() => handleUnwatch(movie.id, movie.title)}
-                                sx={{
-                                  opacity: 0.5,
-                                  transition: 'opacity 0.15s',
-                                  '&:hover': { opacity: 1 },
-                                  fontSize: '0.8rem',
-                                }}
-                              >
-                                ↩
-                              </IconButton>
-                            </Tooltip>
-                          )}
-                        </td>
+                        />
                       </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
+                    </thead>
+                    <tbody>
+                      {movies.map((movie: any) => {
+                        const canUnwatch =
+                          isAdmin || String(movie.requested_by) === String(user?.id);
+                        return (
+                          <tr key={movie.id}>
+                            <td style={{ verticalAlign: 'middle', padding: '8px 16px' }}>
+                              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                {movie.poster_url ? (
+                                  <img
+                                    src={movie.poster_url}
+                                    alt=""
+                                    style={{
+                                      width: 28,
+                                      height: 42,
+                                      objectFit: 'cover',
+                                      borderRadius: 3,
+                                      flexShrink: 0,
+                                    }}
+                                  />
+                                ) : (
+                                  <Box
+                                    sx={{
+                                      width: 28,
+                                      height: 42,
+                                      bgcolor: 'background.level2',
+                                      borderRadius: '3px',
+                                      flexShrink: 0,
+                                    }}
+                                  />
+                                )}
+                                <Typography
+                                  level="body-sm"
+                                  sx={{ fontWeight: 600, color: 'text.primary' }}
+                                >
+                                  {movie.title}
+                                </Typography>
+                                {movie.tmdb_id && (
+                                  <a
+                                    href={`https://www.themoviedb.org/movie/${movie.tmdb_id}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    style={{
+                                      color: 'var(--joy-palette-primary-500)',
+                                      fontSize: '0.75rem',
+                                    }}
+                                  >
+                                    ↗
+                                  </a>
+                                )}
+                              </Box>
+                            </td>
+                            <td style={{ verticalAlign: 'middle', padding: '12px 16px' }}>
+                              <Chip
+                                size="sm"
+                                variant="soft"
+                                color="neutral"
+                                sx={{ fontWeight: 500 }}
+                              >
+                                {movie.requester}
+                              </Chip>
+                            </td>
+                            <td
+                              style={{
+                                verticalAlign: 'middle',
+                                padding: '12px 16px',
+                                whiteSpace: 'nowrap',
+                              }}
+                            >
+                              <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
+                                {movie.watched_at
+                                  ? new Date(movie.watched_at).toLocaleDateString(undefined, {
+                                      year: 'numeric',
+                                      month: 'short',
+                                      day: 'numeric',
+                                    })
+                                  : '—'}
+                              </Typography>
+                            </td>
+                            <td
+                              style={{
+                                verticalAlign: 'middle',
+                                padding: '0 12px',
+                                textAlign: 'right',
+                              }}
+                            >
+                              {canUnwatch && (
+                                <Tooltip title="Watch again — put back in queue" arrow>
+                                  <IconButton
+                                    size="sm"
+                                    color="primary"
+                                    variant="plain"
+                                    onClick={() => handleUnwatch(movie.id, movie.title)}
+                                    sx={{
+                                      opacity: 0.5,
+                                      transition: 'opacity 0.15s',
+                                      '&:hover': { opacity: 1 },
+                                      fontSize: '0.8rem',
+                                    }}
+                                  >
+                                    ↩
+                                  </IconButton>
+                                </Tooltip>
+                              )}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </Box>
+              </Sheet>
             </Box>
-          </Sheet>
+
+            {/* Cards — visible on mobile */}
+            <Box sx={{ display: { xs: 'block', sm: 'none' } }}>
+              {movies.map((movie: any) => (
+                <WatchHistoryCard
+                  key={movie.id}
+                  movie={movie}
+                  canUnwatch={isAdmin || String(movie.requested_by) === String(user?.id)}
+                  onUnwatch={handleUnwatch}
+                />
+              ))}
+            </Box>
+          </>
         )}
 
         {/* Pagination */}
@@ -251,6 +294,8 @@ const WatchHistory: React.FC = () => {
           </Box>
         )}
       </Box>
+
+      <ConfirmDialog {...dialogProps} />
     </Box>
   );
 };

--- a/src/components/home/WatchHistoryCard.tsx
+++ b/src/components/home/WatchHistoryCard.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { Box, Typography, Chip, IconButton, Tooltip, Sheet } from '@mui/joy';
+
+interface WatchHistoryCardProps {
+  movie: any;
+  canUnwatch: boolean;
+  onUnwatch: (id: string, title: string) => void;
+}
+
+const WatchHistoryCard: React.FC<WatchHistoryCardProps> = ({ movie, canUnwatch, onUnwatch }) => (
+  <Sheet
+    variant="outlined"
+    sx={{
+      borderRadius: 'md',
+      mb: 1,
+      p: 1.5,
+      borderColor: 'var(--mn-border-vis)',
+    }}
+  >
+    <Box sx={{ display: 'flex', gap: 1.5 }}>
+      {/* Poster */}
+      {movie.poster_url ? (
+        <img
+          src={movie.poster_url}
+          alt=""
+          style={{
+            width: 40,
+            height: 60,
+            objectFit: 'cover',
+            borderRadius: 4,
+            flexShrink: 0,
+          }}
+        />
+      ) : (
+        <Box
+          sx={{
+            width: 40,
+            height: 60,
+            bgcolor: 'background.level2',
+            borderRadius: '4px',
+            flexShrink: 0,
+          }}
+        />
+      )}
+
+      {/* Details */}
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Typography level="body-sm" sx={{ fontWeight: 600, color: 'text.primary' }}>
+          {movie.title}
+          {movie.tmdb_id && (
+            <a
+              href={`https://www.themoviedb.org/movie/${movie.tmdb_id}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                color: 'var(--joy-palette-primary-500)',
+                fontSize: '0.7rem',
+                marginLeft: 4,
+              }}
+            >
+              ↗
+            </a>
+          )}
+        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.25 }}>
+          <Chip
+            size="sm"
+            variant="soft"
+            color="neutral"
+            sx={{ fontWeight: 500, fontSize: '0.65rem' }}
+          >
+            {movie.requester}
+          </Chip>
+          <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+            {movie.watched_at
+              ? new Date(movie.watched_at).toLocaleDateString(undefined, {
+                  month: 'short',
+                  day: 'numeric',
+                })
+              : '—'}
+          </Typography>
+        </Box>
+      </Box>
+
+      {/* Requeue action */}
+      {canUnwatch && (
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <Tooltip title="Watch again — put back in queue" arrow>
+            <IconButton
+              size="sm"
+              color="primary"
+              variant="soft"
+              onClick={() => onUnwatch(movie.id, movie.title)}
+              sx={{ minWidth: 36, minHeight: 36 }}
+            >
+              ↩
+            </IconButton>
+          </Tooltip>
+        </Box>
+      )}
+    </Box>
+  </Sheet>
+);
+
+export default WatchHistoryCard;

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -1,0 +1,71 @@
+import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+import { Snackbar, Typography, Box } from '@mui/joy';
+
+type ToastColor = 'success' | 'danger' | 'warning' | 'neutral';
+
+interface Toast {
+  message: string;
+  color: ToastColor;
+  autoHideDuration: number;
+}
+
+interface ToastContextType {
+  showToast: (message: string, color?: ToastColor, duration?: number) => void;
+  showSuccess: (message: string) => void;
+  showError: (message: string) => void;
+}
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined);
+
+export const ToastProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [open, setOpen] = useState(false);
+  const [toast, setToast] = useState<Toast>({
+    message: '',
+    color: 'neutral',
+    autoHideDuration: 4000,
+  });
+
+  const showToast = useCallback(
+    (message: string, color: ToastColor = 'neutral', duration?: number) => {
+      setToast({
+        message,
+        color,
+        autoHideDuration: duration ?? (color === 'danger' ? 6000 : 4000),
+      });
+      setOpen(true);
+    },
+    [],
+  );
+
+  const showSuccess = useCallback((message: string) => showToast(message, 'success'), [showToast]);
+  const showError = useCallback((message: string) => showToast(message, 'danger'), [showToast]);
+
+  return (
+    <ToastContext.Provider value={{ showToast, showSuccess, showError }}>
+      {children}
+      <Snackbar
+        open={open}
+        onClose={() => setOpen(false)}
+        autoHideDuration={toast.autoHideDuration}
+        color={toast.color}
+        variant="soft"
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        sx={{ minWidth: 240, maxWidth: 420 }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Typography level="body-sm" sx={{ fontWeight: 600 }}>
+            {toast.message}
+          </Typography>
+        </Box>
+      </Snackbar>
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => {
+  const context = useContext(ToastContext);
+  if (context === undefined) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return context;
+};

--- a/src/contexts/__tests__/ToastContext.test.tsx
+++ b/src/contexts/__tests__/ToastContext.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ToastProvider, useToast } from '../ToastContext';
+
+// Minimal MUI Joy mock — Snackbar renders children when open
+jest.mock('@mui/joy', () => {
+  const actual = jest.requireActual('@mui/joy');
+  return {
+    ...actual,
+    Snackbar: ({ open, children, color }: any) =>
+      open ? (
+        <div data-testid="snackbar" data-color={color}>
+          {children}
+        </div>
+      ) : null,
+  };
+});
+
+function TestConsumer() {
+  const { showSuccess, showError, showToast } = useToast();
+  return (
+    <div>
+      <button data-testid="success-btn" onClick={() => showSuccess('Done!')}>
+        Success
+      </button>
+      <button data-testid="error-btn" onClick={() => showError('Oops!')}>
+        Error
+      </button>
+      <button data-testid="toast-btn" onClick={() => showToast('Info', 'warning', 3000)}>
+        Toast
+      </button>
+    </div>
+  );
+}
+
+describe('ToastProvider', () => {
+  it('showSuccess renders a success snackbar', () => {
+    render(
+      <ToastProvider>
+        <TestConsumer />
+      </ToastProvider>,
+    );
+    act(() => {
+      screen.getByTestId('success-btn').click();
+    });
+    const snackbar = screen.getByTestId('snackbar');
+    expect(snackbar).toHaveAttribute('data-color', 'success');
+    expect(snackbar).toHaveTextContent('Done!');
+  });
+
+  it('showError renders a danger snackbar', () => {
+    render(
+      <ToastProvider>
+        <TestConsumer />
+      </ToastProvider>,
+    );
+    act(() => {
+      screen.getByTestId('error-btn').click();
+    });
+    const snackbar = screen.getByTestId('snackbar');
+    expect(snackbar).toHaveAttribute('data-color', 'danger');
+    expect(snackbar).toHaveTextContent('Oops!');
+  });
+
+  it('showToast renders with custom color', () => {
+    render(
+      <ToastProvider>
+        <TestConsumer />
+      </ToastProvider>,
+    );
+    act(() => {
+      screen.getByTestId('toast-btn').click();
+    });
+    const snackbar = screen.getByTestId('snackbar');
+    expect(snackbar).toHaveAttribute('data-color', 'warning');
+    expect(snackbar).toHaveTextContent('Info');
+  });
+});
+
+describe('useToast', () => {
+  it('throws when used outside ToastProvider', () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    expect(() => render(<TestConsumer />)).toThrow('useToast must be used within a ToastProvider');
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/hooks/useConfirm.ts
+++ b/src/hooks/useConfirm.ts
@@ -1,0 +1,68 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { ConfirmDialogProps } from '../components/common/ConfirmDialog';
+
+interface ConfirmOptions {
+  title: string;
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+  confirmColor?: 'danger' | 'primary' | 'warning' | 'success';
+}
+
+export function useConfirm() {
+  const resolveRef = useRef<((value: boolean) => void) | null>(null);
+  const [dialogState, setDialogState] = useState<{
+    open: boolean;
+    title: string;
+    message: string;
+    confirmText?: string;
+    cancelText?: string;
+    confirmColor?: 'danger' | 'primary' | 'warning' | 'success';
+  }>({
+    open: false,
+    title: '',
+    message: '',
+  });
+
+  // Resolve false on unmount to prevent dangling promises
+  useEffect(() => {
+    return () => {
+      if (resolveRef.current) {
+        resolveRef.current(false);
+        resolveRef.current = null;
+      }
+    };
+  }, []);
+
+  const confirm = useCallback((options: ConfirmOptions): Promise<boolean> => {
+    return new Promise((resolve) => {
+      resolveRef.current = resolve;
+      setDialogState({ open: true, ...options });
+    });
+  }, []);
+
+  const handleConfirm = useCallback(() => {
+    setDialogState((s) => ({ ...s, open: false }));
+    resolveRef.current?.(true);
+    resolveRef.current = null;
+  }, []);
+
+  const handleCancel = useCallback(() => {
+    setDialogState((s) => ({ ...s, open: false }));
+    resolveRef.current?.(false);
+    resolveRef.current = null;
+  }, []);
+
+  const dialogProps: ConfirmDialogProps = {
+    open: dialogState.open,
+    title: dialogState.title,
+    message: dialogState.message,
+    confirmText: dialogState.confirmText,
+    cancelText: dialogState.cancelText,
+    confirmColor: dialogState.confirmColor,
+    onConfirm: handleConfirm,
+    onCancel: handleCancel,
+  };
+
+  return { confirm, dialogProps };
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 import client from './graphql/client';
 import { AuthProvider } from './contexts/AuthContext';
+import { ToastProvider } from './contexts/ToastContext';
 import theme from './theme';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
@@ -14,11 +15,13 @@ root.render(
   <React.StrictMode>
     <CssVarsProvider theme={theme} defaultMode="dark">
       <CssBaseline />
-      <ApolloProvider client={client}>
-        <AuthProvider>
-          <App />
-        </AuthProvider>
-      </ApolloProvider>
+      <ToastProvider>
+        <ApolloProvider client={client}>
+          <AuthProvider>
+            <App />
+          </AuthProvider>
+        </ApolloProvider>
+      </ToastProvider>
     </CssVarsProvider>
   </React.StrictMode>,
 );

--- a/src/utils/useDebounce.ts
+++ b/src/utils/useDebounce.ts
@@ -1,0 +1,10 @@
+import { useState, useEffect } from 'react';
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+  return debouncedValue;
+}


### PR DESCRIPTION
## Summary
- Replace all `window.confirm()`/`alert()` calls with themed MUI Joy `ConfirmDialog` (color-coded by severity: red for delete, green for done, gold for seed)
- Add centralized `ToastContext` with MUI Joy `Snackbar` for success/error notifications across the app
- Add skeleton/spinner loading states for initial movie list load, watch history, form submission, and TMDB autocomplete
- Introduce responsive card layout on mobile (`xs` breakpoint) for movie list, solo queue, and watch history — tables on `sm+`
- Decompose `Homepage.tsx` (1,173 → ~400 lines) into focused sub-components: `MovieRow`, `AddMovieForm`, `ViewSelector`, `ConnectionBanners`, `ThisOrThatBanner`

## New files
| File | Purpose |
|------|---------|
| `src/contexts/ToastContext.tsx` | Snackbar notification provider + `useToast()` hook |
| `src/components/common/ConfirmDialog.tsx` | Reusable themed confirmation modal |
| `src/hooks/useConfirm.ts` | Promise-based confirm hook (`await confirm({...})`) |
| `src/utils/useDebounce.ts` | Extracted generic debounce hook |
| `src/components/home/MovieRow.tsx` | Extracted movie table row |
| `src/components/home/AddMovieForm.tsx` | Extracted add movie form with TMDB autocomplete |
| `src/components/home/ViewSelector.tsx` | Extracted view segmented control |
| `src/components/home/ConnectionBanners.tsx` | Extracted connection request + new movies banners |
| `src/components/home/ThisOrThatBanner.tsx` | Extracted This or That CTA banner |
| `src/components/home/MovieCard.tsx` | Mobile card layout for movie list |
| `src/components/home/WatchHistoryCard.tsx` | Mobile card layout for watch history |

## Test plan
- [x] Frontend tests pass (23/23, 5 suites)
- [x] Backend tests pass (249/249, 14 suites)
- [x] Zero `window.confirm` or `alert()` calls remain in codebase
- [ ] Manual: verify confirm dialogs show correct colors (red for delete, green for done)
- [ ] Manual: verify toast notifications appear bottom-center on success/error
- [ ] Manual: resize to mobile width — verify card layout replaces tables
- [ ] Manual: verify skeleton loading on first page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)