### PR TITLE
feat: allow login with email or username

### DIFF
--- a/backend/src/__tests__/resolvers/auth-resolvers.test.ts
+++ b/backend/src/__tests__/resolvers/auth-resolvers.test.ts
@@ -45,6 +45,32 @@ describe('Mutation.login', () => {
     expect(result.user).not.toHaveProperty('password_hash');
   });
 
+  it('returns token and user when logging in with email', async () => {
+    const dbUser = {
+      id: 1,
+      username: 'alice',
+      email: 'alice@example.com',
+      display_name: 'Alice',
+      password_hash: 'hashed',
+      is_admin: false,
+      is_active: true,
+      last_login_at: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    };
+    mockQuery
+      .mockResolvedValueOnce({ rows: [dbUser] }) // SELECT user by email
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE last_login_at
+      .mockResolvedValueOnce({ rows: [] }) // logLoginHistory
+      .mockResolvedValueOnce({ rows: [] }); // logAudit
+    mockComparePassword.mockResolvedValue(true);
+    mockGenerateToken.mockReturnValue('jwt-token');
+
+    const result = await login(null, { username: 'alice@example.com', password: 'pass' }, ctx);
+    expect(result.token).toBe('jwt-token');
+    expect(result.user.username).toBe('alice');
+  });
+
   it('throws UNAUTHENTICATED for invalid username', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [] }) // no user found

--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -1483,7 +1483,10 @@ export const resolvers = {
         });
       }
 
-      const result = await pool.query('SELECT * FROM users WHERE username = $1', [username]);
+      const result = await pool.query(
+        'SELECT * FROM users WHERE username = $1 OR LOWER(email) = LOWER($1)',
+        [username],
+      );
       const user = result.rows[0];
 
       if (!user) {

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -34,7 +34,7 @@ export const Login: React.FC<LoginProps> = ({ onForgotPassword }) => {
       } else if (err.graphQLErrors?.length) {
         const code = err.graphQLErrors[0]?.extensions?.code;
         if (code === 'UNAUTHENTICATED') {
-          setError('Incorrect username or password.');
+          setError('Incorrect username/email or password.');
         } else if (code === 'FORBIDDEN') {
           setError('Your account has been disabled. Please contact an administrator.');
         } else {
@@ -59,7 +59,7 @@ export const Login: React.FC<LoginProps> = ({ onForgotPassword }) => {
     e.preventDefault();
     setError('');
     if (!username || !password) {
-      setError('Please enter both username and password');
+      setError('Please enter your username or email and password');
       return;
     }
     try {
@@ -152,13 +152,13 @@ export const Login: React.FC<LoginProps> = ({ onForgotPassword }) => {
           <form onSubmit={handleSubmit}>
             <FormControl sx={{ mb: 2 }}>
               <FormLabel sx={{ color: 'text.secondary', fontSize: '0.8rem', fontWeight: 600 }}>
-                Username
+                Username or Email
               </FormLabel>
               <Input
                 type="text"
                 value={username}
                 onChange={(e) => setUsername(e.target.value)}
-                placeholder="Enter your username"
+                placeholder="Enter your username or email"
                 autoFocus
                 required
                 sx={{


### PR DESCRIPTION
## Summary
- Accept either a username or email address in the single login field
- Backend login query now matches on `username` OR case-insensitive `email`
- Frontend labels, placeholders, and error messages updated to reflect both options
- Added test for email-based login

## Test plan
- [ ] Log in with a username — works as before
- [ ] Log in with an email address (case-insensitive) — resolves to correct user
- [ ] Invalid email/username still returns "Invalid credentials"
- [ ] Backend tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)