### PR TITLE
feat: add Plex authentication option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,17 @@ TMDB_API_KEY=your_tmdb_api_key_here
 # Override only if the backend is on a different origin.
 # REACT_APP_GRAPHQL_URL=https://api.example.com/graphql
 
+# Plex Authentication (optional)
+# Set a stable client ID to enable "Sign in with Plex".
+# When absent, Plex auth is completely hidden from the UI.
+# Must remain the same across restarts so Plex recognises the app.
+# PLEX_CLIENT_ID=movienight-your-unique-id
+
+# MDBList Integration (optional)
+# API key for syncing the watchlist to an MDBList list.
+# Can also be set per-instance via the admin UI.
+# MDBLIST_API_KEY=your_mdblist_api_key
+
 # Kometa Integration (optional)
 # Directory where Kometa reads its collection YAML files.
 # The backend writes movienight.yml here on export.

--- a/backend/migrations/1746500000000_add-plex-fields-to-users.js
+++ b/backend/migrations/1746500000000_add-plex-fields-to-users.js
@@ -1,0 +1,34 @@
+/**
+ * Add Plex authentication fields to users table.
+ *
+ * - plex_id:       The Plex account ID (unique link key)
+ * - plex_username:  Display name from Plex (informational)
+ * - plex_thumb:     Plex avatar URL
+ */
+
+exports.up = (pgm) => {
+  pgm.addColumns('users', {
+    plex_id: {
+      type: 'varchar(100)',
+      notNull: false,
+    },
+    plex_username: {
+      type: 'varchar(255)',
+      notNull: false,
+    },
+    plex_thumb: {
+      type: 'text',
+      notNull: false,
+    },
+  });
+
+  pgm.createIndex('users', 'plex_id', {
+    unique: true,
+    where: 'plex_id IS NOT NULL',
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropIndex('users', 'plex_id');
+  pgm.dropColumns('users', ['plex_id', 'plex_username', 'plex_thumb']);
+};

--- a/backend/migrations/1746600000000_create-app-settings.js
+++ b/backend/migrations/1746600000000_create-app-settings.js
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+exports.shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ */
+exports.up = (pgm) => {
+  pgm.createTable('app_settings', {
+    key: { type: 'varchar(100)', primaryKey: true },
+    value: { type: 'text', notNull: false },
+    updated_at: {
+      type: 'timestamptz',
+      notNull: true,
+      default: pgm.func('NOW()'),
+    },
+  });
+};
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ */
+exports.down = (pgm) => {
+  pgm.dropTable('app_settings');
+};

--- a/backend/src/__tests__/plex.test.ts
+++ b/backend/src/__tests__/plex.test.ts
@@ -1,0 +1,104 @@
+const mockFetch = jest.fn();
+(global as any).fetch = mockFetch;
+
+import { createPlexPin, checkPlexPin, getPlexUser, getPlexAuthUrl, waitForPlexAuth } from '../plex';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('createPlexPin', () => {
+  it('calls POST /pins and returns parsed response', async () => {
+    const pin = { id: 123, code: 'abc123', authToken: null };
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve(pin) });
+
+    const result = await createPlexPin();
+    expect(result).toEqual(pin);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://plex.tv/api/v2/pins',
+      expect.objectContaining({ method: 'POST', body: 'strong=true' }),
+    );
+  });
+
+  it('throws on non-OK response', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500 });
+    await expect(createPlexPin()).rejects.toThrow('Plex PIN creation failed: 500');
+  });
+});
+
+describe('checkPlexPin', () => {
+  it('calls GET /pins/:id and returns parsed response', async () => {
+    const pin = { id: 123, code: 'abc123', authToken: 'tok' };
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve(pin) });
+
+    const result = await checkPlexPin(123);
+    expect(result).toEqual(pin);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://plex.tv/api/v2/pins/123',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Accept: 'application/json' }),
+      }),
+    );
+  });
+
+  it('throws on non-OK response', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404 });
+    await expect(checkPlexPin(999)).rejects.toThrow('Plex PIN check failed: 404');
+  });
+});
+
+describe('getPlexUser', () => {
+  it('calls GET /user with X-Plex-Token header', async () => {
+    const user = { id: 42, uuid: 'u', username: 'bob', email: 'bob@example.com', thumb: '' };
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve(user) });
+
+    const result = await getPlexUser('my-token');
+    expect(result).toEqual(user);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://plex.tv/api/v2/user',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-Plex-Token': 'my-token' }),
+      }),
+    );
+  });
+
+  it('throws on non-OK response', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 401 });
+    await expect(getPlexUser('bad')).rejects.toThrow('Plex user fetch failed: 401');
+  });
+});
+
+describe('getPlexAuthUrl', () => {
+  it('returns correctly formatted URL with code', () => {
+    const url = getPlexAuthUrl('test-code');
+    expect(url).toContain('https://app.plex.tv/auth#?');
+    expect(url).toContain('code=test-code');
+    expect(url).toContain('context%5Bdevice%5D%5Bproduct%5D=MovieNight');
+  });
+});
+
+describe('waitForPlexAuth', () => {
+  it('returns authToken when PIN becomes authenticated', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: 1, code: 'c', authToken: null }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: 1, code: 'c', authToken: 'got-it' }),
+      });
+
+    const token = await waitForPlexAuth(1, 10_000, 10);
+    expect(token).toBe('got-it');
+  });
+
+  it('throws on timeout', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: 1, code: 'c', authToken: null }),
+    });
+
+    await expect(waitForPlexAuth(1, 50, 10)).rejects.toThrow('Plex authentication timed out');
+  });
+});

--- a/backend/src/__tests__/resolvers/__helpers.ts
+++ b/backend/src/__tests__/resolvers/__helpers.ts
@@ -53,6 +53,18 @@ jest.mock('../../pairSelection', () => ({
   selectPair: (...args: any[]) => mockSelectPair(...args),
 }));
 
+// Mock plex
+export const mockCreatePlexPin = jest.fn();
+export const mockWaitForPlexAuth = jest.fn();
+export const mockGetPlexUser = jest.fn();
+export const mockGetPlexAuthUrl = jest.fn();
+jest.mock('../../plex', () => ({
+  createPlexPin: (...args: any[]) => mockCreatePlexPin(...args),
+  waitForPlexAuth: (...args: any[]) => mockWaitForPlexAuth(...args),
+  getPlexUser: (...args: any[]) => mockGetPlexUser(...args),
+  getPlexAuthUrl: (...args: any[]) => mockGetPlexAuthUrl(...args),
+}));
+
 // Mock fs (for Kometa export)
 export const mockWriteFile = jest.fn();
 jest.mock('fs', () => ({

--- a/backend/src/__tests__/resolvers/__helpers.ts
+++ b/backend/src/__tests__/resolvers/__helpers.ts
@@ -53,6 +53,14 @@ jest.mock('../../pairSelection', () => ({
   selectPair: (...args: any[]) => mockSelectPair(...args),
 }));
 
+// Mock settings
+export const mockGetSetting = jest.fn();
+export const mockSetSetting = jest.fn();
+jest.mock('../../settings', () => ({
+  getSetting: (...args: any[]) => mockGetSetting(...args),
+  setSetting: (...args: any[]) => mockSetSetting(...args),
+}));
+
 // Mock plex
 export const mockCreatePlexPin = jest.fn();
 export const mockWaitForPlexAuth = jest.fn();

--- a/backend/src/__tests__/resolvers/kometa-resolvers.test.ts
+++ b/backend/src/__tests__/resolvers/kometa-resolvers.test.ts
@@ -3,6 +3,7 @@ import {
   mockWriteFile,
   mockFetch,
   mockRescheduleKometa,
+  mockGetSetting,
   adminContext,
   authContext,
 } from './__helpers';
@@ -19,6 +20,7 @@ const { exportKometa, updateKometaSchedule, setMdblistApiKey } = resolvers.Mutat
 
 beforeEach(() => {
   mockRunKometaExport.mockReset();
+  mockGetSetting.mockResolvedValue(null);
 });
 
 describe('Mutation.exportKometa', () => {

--- a/backend/src/__tests__/resolvers/letterboxd-resolvers.test.ts
+++ b/backend/src/__tests__/resolvers/letterboxd-resolvers.test.ts
@@ -1,7 +1,18 @@
-import { mockQuery, mockFetch, adminContext, authContext, anonContext } from './__helpers';
+import {
+  mockQuery,
+  mockFetch,
+  mockGetSetting,
+  adminContext,
+  authContext,
+  anonContext,
+} from './__helpers';
 import { resolvers } from '../../resolvers';
 
 const { importFromLetterboxd } = resolvers.Mutation;
+
+beforeEach(() => {
+  mockGetSetting.mockResolvedValue(null);
+});
 
 describe('Mutation.importFromLetterboxd', () => {
   describe('authorization', () => {

--- a/backend/src/__tests__/resolvers/movie-resolvers.test.ts
+++ b/backend/src/__tests__/resolvers/movie-resolvers.test.ts
@@ -2,6 +2,7 @@ import {
   mockQuery,
   mockApplyComparison,
   mockUpdateGlobalEloRank,
+  mockGetSetting,
   authContext,
   adminContext,
   anonContext,
@@ -10,6 +11,10 @@ import { resolvers } from '../../resolvers';
 
 const { addMovie, matchMovie, markWatched, deleteMovie, recordComparison, resetMovieComparisons } =
   resolvers.Mutation;
+
+beforeEach(() => {
+  mockGetSetting.mockResolvedValue(null);
+});
 
 describe('Mutation.addMovie', () => {
   it('authenticated user can add a movie', async () => {

--- a/backend/src/__tests__/resolvers/plex-resolvers.test.ts
+++ b/backend/src/__tests__/resolvers/plex-resolvers.test.ts
@@ -6,12 +6,16 @@ import {
   mockWaitForPlexAuth,
   mockGetPlexUser,
   mockGetPlexAuthUrl,
+  mockGetSetting,
+  mockSetSetting,
   authContext,
+  adminContext,
   anonContext,
 } from './__helpers';
 import { resolvers } from '../../resolvers';
 
-const { createPlexPin, completePlexAuth, linkPlexAccount, unlinkPlexAccount } = resolvers.Mutation;
+const { createPlexPin, completePlexAuth, linkPlexAccount, unlinkPlexAccount, updateAppSetting } =
+  resolvers.Mutation;
 
 const plexUser = {
   id: 42,
@@ -38,6 +42,9 @@ const dbUser = {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  // Default: no DB settings, fall back to env vars
+  mockGetSetting.mockResolvedValue(null);
+  mockSetSetting.mockResolvedValue(undefined);
 });
 
 describe('Mutation.createPlexPin', () => {
@@ -195,5 +202,59 @@ describe('Mutation.unlinkPlexAccount', () => {
 
   it('throws UNAUTHENTICATED for anonymous user', async () => {
     await expect(unlinkPlexAccount(null, {}, anonContext())).rejects.toThrow('Not authenticated');
+  });
+});
+
+describe('Mutation.updateAppSetting', () => {
+  it('saves an allowed setting and returns appInfo', async () => {
+    const ctx = adminContext();
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // logAudit
+
+    const result = await (updateAppSetting as any)(
+      null,
+      { key: 'plex_client_id', value: 'my-client-id' },
+      ctx,
+    );
+    expect(mockSetSetting).toHaveBeenCalledWith('plex_client_id', 'my-client-id');
+    expect(result).toHaveProperty('isProduction');
+    expect(result).toHaveProperty('plexAuthEnabled');
+  });
+
+  it('clears a setting when value is empty', async () => {
+    const ctx = adminContext();
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // logAudit
+
+    await (updateAppSetting as any)(null, { key: 'tmdb_api_key', value: '' }, ctx);
+    expect(mockSetSetting).toHaveBeenCalledWith('tmdb_api_key', null);
+  });
+
+  it('throws FORBIDDEN for non-admin', async () => {
+    const ctx = authContext();
+    await expect(
+      (updateAppSetting as any)(null, { key: 'plex_client_id', value: 'x' }, ctx),
+    ).rejects.toThrow('Not authorized');
+  });
+
+  it('throws FORBIDDEN for anonymous', async () => {
+    await expect(
+      (updateAppSetting as any)(null, { key: 'plex_client_id', value: 'x' }, anonContext()),
+    ).rejects.toThrow('Not authorized');
+  });
+
+  it('throws BAD_USER_INPUT for unknown setting key', async () => {
+    const ctx = adminContext();
+    await expect(
+      (updateAppSetting as any)(null, { key: 'unknown_key', value: 'x' }, ctx),
+    ).rejects.toThrow('Unknown setting');
+  });
+
+  it('accepts all three allowed keys', async () => {
+    const ctx = adminContext();
+    for (const key of ['plex_client_id', 'tmdb_api_key', 'mdblist_api_key']) {
+      mockSetSetting.mockClear();
+      mockQuery.mockResolvedValueOnce({ rows: [] }); // logAudit
+      await (updateAppSetting as any)(null, { key, value: 'test-value' }, ctx);
+      expect(mockSetSetting).toHaveBeenCalledWith(key, 'test-value');
+    }
   });
 });

--- a/backend/src/__tests__/resolvers/plex-resolvers.test.ts
+++ b/backend/src/__tests__/resolvers/plex-resolvers.test.ts
@@ -1,0 +1,199 @@
+import {
+  mockQuery,
+  mockHashPassword,
+  mockGenerateToken,
+  mockCreatePlexPin,
+  mockWaitForPlexAuth,
+  mockGetPlexUser,
+  mockGetPlexAuthUrl,
+  authContext,
+  anonContext,
+} from './__helpers';
+import { resolvers } from '../../resolvers';
+
+const { createPlexPin, completePlexAuth, linkPlexAccount, unlinkPlexAccount } = resolvers.Mutation;
+
+const plexUser = {
+  id: 42,
+  uuid: 'uuid-42',
+  username: 'plexbob',
+  email: 'bob@example.com',
+  thumb: 'https://plex.tv/thumb.jpg',
+};
+
+const dbUser = {
+  id: 1,
+  username: 'bob',
+  email: 'bob@example.com',
+  display_name: 'Bob',
+  is_admin: false,
+  is_active: true,
+  last_login_at: null,
+  plex_id: '42',
+  plex_username: 'plexbob',
+  plex_thumb: 'https://plex.tv/thumb.jpg',
+  created_at: new Date(),
+  updated_at: new Date(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('Mutation.createPlexPin', () => {
+  it('returns pinId, code, and authUrl', async () => {
+    mockCreatePlexPin.mockResolvedValue({ id: 999, code: 'pin-code', authToken: null });
+    mockGetPlexAuthUrl.mockReturnValue('https://app.plex.tv/auth#?code=pin-code');
+
+    const result = await (createPlexPin as any)(null, {}, anonContext());
+    expect(result).toEqual({
+      pinId: 999,
+      code: 'pin-code',
+      authUrl: 'https://app.plex.tv/auth#?code=pin-code',
+    });
+  });
+});
+
+describe('Mutation.completePlexAuth', () => {
+  const ctx = anonContext();
+
+  it('returns token and user when Plex account is already linked', async () => {
+    mockWaitForPlexAuth.mockResolvedValue('plex-token');
+    mockGetPlexUser.mockResolvedValue(plexUser);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [dbUser] }) // SELECT by plex_id
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE last_login_at
+      .mockResolvedValueOnce({ rows: [] }) // logLoginHistory
+      .mockResolvedValueOnce({ rows: [] }); // logAudit
+    mockGenerateToken.mockReturnValue('jwt-123');
+
+    const result = await completePlexAuth(null, { pinId: 1 }, ctx);
+    expect(result.token).toBe('jwt-123');
+    expect(result.user.username).toBe('bob');
+  });
+
+  it('auto-links by email match for existing user', async () => {
+    mockWaitForPlexAuth.mockResolvedValue('plex-token');
+    mockGetPlexUser.mockResolvedValue(plexUser);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // SELECT by plex_id — not found
+      .mockResolvedValueOnce({ rows: [{ ...dbUser, plex_id: null }] }) // SELECT by email — found
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE plex fields
+      .mockResolvedValueOnce({ rows: [] }) // logAudit PLEX_LINK
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE last_login_at
+      .mockResolvedValueOnce({ rows: [] }) // logLoginHistory
+      .mockResolvedValueOnce({ rows: [] }); // logAudit LOGIN_SUCCESS
+    mockGenerateToken.mockReturnValue('jwt-linked');
+
+    const result = await completePlexAuth(null, { pinId: 1 }, ctx);
+    expect(result.token).toBe('jwt-linked');
+    // Verify the UPDATE was called with plex fields
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE users SET plex_id'),
+      expect.arrayContaining(['42', 'plexbob']),
+    );
+  });
+
+  it('creates new account for unknown Plex user', async () => {
+    const newUser = {
+      ...dbUser,
+      id: 5,
+      username: 'plex_plexbob',
+      email: 'bob@example.com',
+    };
+    mockWaitForPlexAuth.mockResolvedValue('plex-token');
+    mockGetPlexUser.mockResolvedValue(plexUser);
+    mockHashPassword.mockResolvedValue('random-hash');
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // SELECT by plex_id — not found
+      .mockResolvedValueOnce({ rows: [] }) // SELECT by email — not found
+      .mockResolvedValueOnce({ rows: [newUser] }) // INSERT new user
+      .mockResolvedValueOnce({ rows: [] }) // logAudit USER_CREATE
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE last_login_at
+      .mockResolvedValueOnce({ rows: [] }) // logLoginHistory
+      .mockResolvedValueOnce({ rows: [] }); // logAudit LOGIN_SUCCESS
+    mockGenerateToken.mockReturnValue('jwt-new');
+
+    const result = await completePlexAuth(null, { pinId: 1 }, ctx);
+    expect(result.token).toBe('jwt-new');
+    expect(result.user.username).toBe('plex_plexbob');
+  });
+
+  it('throws FORBIDDEN for disabled account', async () => {
+    mockWaitForPlexAuth.mockResolvedValue('plex-token');
+    mockGetPlexUser.mockResolvedValue(plexUser);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ ...dbUser, is_active: false }] }) // SELECT by plex_id
+      .mockResolvedValueOnce({ rows: [] }); // logLoginHistory
+
+    await expect(completePlexAuth(null, { pinId: 1 }, ctx)).rejects.toThrow('Account is disabled');
+  });
+
+  it('throws UNAUTHENTICATED on timeout', async () => {
+    mockWaitForPlexAuth.mockRejectedValue(new Error('Plex authentication timed out'));
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // logLoginHistory
+
+    await expect(completePlexAuth(null, { pinId: 1 }, ctx)).rejects.toThrow(
+      'Plex authentication timed out or failed',
+    );
+  });
+});
+
+describe('Mutation.linkPlexAccount', () => {
+  it('links Plex account to authenticated user', async () => {
+    const ctx = authContext();
+    mockWaitForPlexAuth.mockResolvedValue('plex-token');
+    mockGetPlexUser.mockResolvedValue(plexUser);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // SELECT existing by plex_id — none
+      .mockResolvedValueOnce({ rows: [dbUser] }) // UPDATE RETURNING
+      .mockResolvedValueOnce({ rows: [] }); // logAudit
+
+    const result = await linkPlexAccount(null, { pinId: 1 }, ctx);
+    expect(result.plex_id).toBe('42');
+    expect(result.plex_username).toBe('plexbob');
+  });
+
+  it('throws UNAUTHENTICATED for anonymous user', async () => {
+    await expect(linkPlexAccount(null, { pinId: 1 }, anonContext())).rejects.toThrow(
+      'Not authenticated',
+    );
+  });
+
+  it('throws BAD_USER_INPUT when Plex account already linked to another user', async () => {
+    const ctx = authContext({ userId: 1 });
+    mockWaitForPlexAuth.mockResolvedValue('plex-token');
+    mockGetPlexUser.mockResolvedValue(plexUser);
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 99 }] }); // plex_id belongs to user 99
+
+    await expect(linkPlexAccount(null, { pinId: 1 }, ctx)).rejects.toThrow(
+      'This Plex account is already linked to another user',
+    );
+  });
+
+  it('throws BAD_USER_INPUT on timeout', async () => {
+    const ctx = authContext();
+    mockWaitForPlexAuth.mockRejectedValue(new Error('timeout'));
+
+    await expect(linkPlexAccount(null, { pinId: 1 }, ctx)).rejects.toThrow(
+      'Plex authentication timed out or failed',
+    );
+  });
+});
+
+describe('Mutation.unlinkPlexAccount', () => {
+  it('unlinks Plex account from authenticated user', async () => {
+    const ctx = authContext();
+    const unlinked = { ...dbUser, plex_id: null, plex_username: null, plex_thumb: null };
+    mockQuery
+      .mockResolvedValueOnce({ rows: [unlinked] }) // UPDATE RETURNING
+      .mockResolvedValueOnce({ rows: [] }); // logAudit
+
+    const result = await unlinkPlexAccount(null, {}, ctx);
+    expect(result.plex_id).toBeNull();
+  });
+
+  it('throws UNAUTHENTICATED for anonymous user', async () => {
+    await expect(unlinkPlexAccount(null, {}, anonContext())).rejects.toThrow('Not authenticated');
+  });
+});

--- a/backend/src/__tests__/resolvers/query-resolvers.test.ts
+++ b/backend/src/__tests__/resolvers/query-resolvers.test.ts
@@ -2,6 +2,7 @@ import {
   mockQuery,
   mockSelectPair,
   mockFetch,
+  mockGetSetting,
   authContext,
   adminContext,
   anonContext,
@@ -10,24 +11,53 @@ import { resolvers } from '../../resolvers';
 
 const Query = resolvers.Query;
 
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetSetting.mockResolvedValue(null);
+});
+
 describe('Query.appInfo', () => {
   const origEnv = process.env.NODE_ENV;
   afterEach(() => {
     process.env.NODE_ENV = origEnv;
   });
 
-  it('non-production: returns isProduction=false with quickLoginUsers', () => {
+  beforeEach(() => {
+    mockGetSetting.mockResolvedValue(null);
+  });
+
+  it('non-production: returns isProduction=false with quickLoginUsers', async () => {
     process.env.NODE_ENV = 'development';
-    const result = Query.appInfo();
+    const result = await Query.appInfo(null, null, anonContext());
     expect(result.isProduction).toBe(false);
     expect(result.quickLoginUsers.length).toBeGreaterThan(0);
   });
 
-  it('production: returns isProduction=true with empty quickLoginUsers', () => {
+  it('production: returns isProduction=true with empty quickLoginUsers', async () => {
     process.env.NODE_ENV = 'production';
-    const result = Query.appInfo();
+    const result = await Query.appInfo(null, null, anonContext());
     expect(result.isProduction).toBe(true);
     expect(result.quickLoginUsers).toEqual([]);
+  });
+
+  it('exposes API keys only to admins', async () => {
+    mockGetSetting.mockImplementation((key: string) => {
+      if (key === 'plex_client_id') return Promise.resolve('test-plex-id');
+      if (key === 'tmdb_api_key') return Promise.resolve('test-tmdb-key');
+      if (key === 'mdblist_api_key') return Promise.resolve('test-mdblist-key');
+      return Promise.resolve(null);
+    });
+
+    const adminResult = await Query.appInfo(null, null, adminContext());
+    expect(adminResult.plexClientId).toBe('test-plex-id');
+    expect(adminResult.tmdbApiKey).toBe('test-tmdb-key');
+    expect(adminResult.mdblistApiKey).toBe('test-mdblist-key');
+
+    const anonResult = await Query.appInfo(null, null, anonContext());
+    expect(anonResult.plexClientId).toBeNull();
+    expect(anonResult.tmdbApiKey).toBeNull();
+    expect(anonResult.mdblistApiKey).toBeNull();
+    expect(anonResult.plexAuthEnabled).toBe(true); // still enabled for auth flow
   });
 });
 

--- a/backend/src/__tests__/settings.test.ts
+++ b/backend/src/__tests__/settings.test.ts
@@ -1,0 +1,54 @@
+const mockQuery = jest.fn();
+jest.mock('../db', () => ({
+  __esModule: true,
+  default: { query: mockQuery },
+}));
+
+import { getSetting, setSetting } from '../settings';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('getSetting', () => {
+  it('returns value when setting exists', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ value: 'my-client-id' }] });
+    const result = await getSetting('plex_client_id');
+    expect(result).toBe('my-client-id');
+    expect(mockQuery).toHaveBeenCalledWith('SELECT value FROM app_settings WHERE key = $1', [
+      'plex_client_id',
+    ]);
+  });
+
+  it('returns null when setting does not exist', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const result = await getSetting('plex_client_id');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when value is null', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ value: null }] });
+    const result = await getSetting('plex_client_id');
+    expect(result).toBeNull();
+  });
+});
+
+describe('setSetting', () => {
+  it('upserts a value', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await setSetting('plex_client_id', 'new-id');
+    expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO app_settings'), [
+      'plex_client_id',
+      'new-id',
+    ]);
+  });
+
+  it('clears a value by setting null', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await setSetting('plex_client_id', null);
+    expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO app_settings'), [
+      'plex_client_id',
+      null,
+    ]);
+  });
+});

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -34,6 +34,7 @@ export interface UpdateUserInput {
   display_name?: string;
   is_admin?: boolean;
   is_active?: boolean;
+  plex_id?: string | null;
 }
 
 export interface LoginInput {

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -6,6 +6,9 @@ export interface User {
   is_admin: boolean;
   is_active: boolean;
   last_login_at?: Date | null;
+  plex_id?: string | null;
+  plex_username?: string | null;
+  plex_thumb?: string | null;
   created_at: Date;
   updated_at: Date;
 }

--- a/backend/src/plex.ts
+++ b/backend/src/plex.ts
@@ -1,0 +1,90 @@
+import crypto from 'crypto';
+
+const PLEX_API_BASE = 'https://plex.tv/api/v2';
+
+// Stable client ID — must be consistent across restarts for Plex to recognise the app.
+const PLEX_CLIENT_ID = process.env.PLEX_CLIENT_ID || `movienight-${crypto.randomUUID()}`;
+
+export interface PlexPin {
+  id: number;
+  code: string;
+  authToken: string | null;
+}
+
+export interface PlexUser {
+  id: number;
+  uuid: string;
+  username: string;
+  email: string;
+  thumb: string;
+}
+
+export function getPlexClientId(): string {
+  return PLEX_CLIENT_ID;
+}
+
+export function getPlexAuthUrl(code: string): string {
+  const params = new URLSearchParams({
+    clientID: PLEX_CLIENT_ID,
+    code,
+    'context[device][product]': 'MovieNight',
+  });
+  return `https://app.plex.tv/auth#?${params.toString()}`;
+}
+
+export async function createPlexPin(): Promise<PlexPin> {
+  const response = await fetch(`${PLEX_API_BASE}/pins`, {
+    method: 'POST',
+    headers: {
+      'X-Plex-Client-Identifier': PLEX_CLIENT_ID,
+      Accept: 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: 'strong=true',
+  });
+  if (!response.ok) {
+    throw new Error(`Plex PIN creation failed: ${response.status}`);
+  }
+  return response.json() as Promise<PlexPin>;
+}
+
+export async function checkPlexPin(pinId: number): Promise<PlexPin> {
+  const response = await fetch(`${PLEX_API_BASE}/pins/${pinId}`, {
+    headers: {
+      'X-Plex-Client-Identifier': PLEX_CLIENT_ID,
+      Accept: 'application/json',
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Plex PIN check failed: ${response.status}`);
+  }
+  return response.json() as Promise<PlexPin>;
+}
+
+export async function getPlexUser(authToken: string): Promise<PlexUser> {
+  const response = await fetch(`${PLEX_API_BASE}/user`, {
+    headers: {
+      'X-Plex-Token': authToken,
+      'X-Plex-Client-Identifier': PLEX_CLIENT_ID,
+      Accept: 'application/json',
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Plex user fetch failed: ${response.status}`);
+  }
+  return response.json() as Promise<PlexUser>;
+}
+
+export async function waitForPlexAuth(
+  pinId: number,
+  timeoutMs = 120_000,
+  intervalMs = 2_000,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const pin = await checkPlexPin(pinId);
+    if (pin.authToken) return pin.authToken;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error('Plex authentication timed out');
+}

--- a/backend/src/plex.ts
+++ b/backend/src/plex.ts
@@ -2,8 +2,8 @@ import crypto from 'crypto';
 
 const PLEX_API_BASE = 'https://plex.tv/api/v2';
 
-// Stable client ID — must be consistent across restarts for Plex to recognise the app.
-const PLEX_CLIENT_ID = process.env.PLEX_CLIENT_ID || `movienight-${crypto.randomUUID()}`;
+// Fallback client ID — used only when neither DB setting nor env var is set.
+const FALLBACK_CLIENT_ID = `movienight-${crypto.randomUUID()}`;
 
 export interface PlexPin {
   id: number;
@@ -19,24 +19,26 @@ export interface PlexUser {
   thumb: string;
 }
 
-export function getPlexClientId(): string {
-  return PLEX_CLIENT_ID;
+export function getPlexClientId(override?: string): string {
+  return override || process.env.PLEX_CLIENT_ID || FALLBACK_CLIENT_ID;
 }
 
-export function getPlexAuthUrl(code: string): string {
+export function getPlexAuthUrl(code: string, clientId?: string): string {
+  const id = getPlexClientId(clientId);
   const params = new URLSearchParams({
-    clientID: PLEX_CLIENT_ID,
+    clientID: id,
     code,
     'context[device][product]': 'MovieNight',
   });
   return `https://app.plex.tv/auth#?${params.toString()}`;
 }
 
-export async function createPlexPin(): Promise<PlexPin> {
+export async function createPlexPin(clientId?: string): Promise<PlexPin> {
+  const id = getPlexClientId(clientId);
   const response = await fetch(`${PLEX_API_BASE}/pins`, {
     method: 'POST',
     headers: {
-      'X-Plex-Client-Identifier': PLEX_CLIENT_ID,
+      'X-Plex-Client-Identifier': id,
       Accept: 'application/json',
       'Content-Type': 'application/x-www-form-urlencoded',
     },
@@ -48,10 +50,11 @@ export async function createPlexPin(): Promise<PlexPin> {
   return response.json() as Promise<PlexPin>;
 }
 
-export async function checkPlexPin(pinId: number): Promise<PlexPin> {
+export async function checkPlexPin(pinId: number, clientId?: string): Promise<PlexPin> {
+  const id = getPlexClientId(clientId);
   const response = await fetch(`${PLEX_API_BASE}/pins/${pinId}`, {
     headers: {
-      'X-Plex-Client-Identifier': PLEX_CLIENT_ID,
+      'X-Plex-Client-Identifier': id,
       Accept: 'application/json',
     },
   });
@@ -61,11 +64,12 @@ export async function checkPlexPin(pinId: number): Promise<PlexPin> {
   return response.json() as Promise<PlexPin>;
 }
 
-export async function getPlexUser(authToken: string): Promise<PlexUser> {
+export async function getPlexUser(authToken: string, clientId?: string): Promise<PlexUser> {
+  const id = getPlexClientId(clientId);
   const response = await fetch(`${PLEX_API_BASE}/user`, {
     headers: {
       'X-Plex-Token': authToken,
-      'X-Plex-Client-Identifier': PLEX_CLIENT_ID,
+      'X-Plex-Client-Identifier': id,
       Accept: 'application/json',
     },
   });
@@ -79,10 +83,11 @@ export async function waitForPlexAuth(
   pinId: number,
   timeoutMs = 120_000,
   intervalMs = 2_000,
+  clientId?: string,
 ): Promise<string> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const pin = await checkPlexPin(pinId);
+    const pin = await checkPlexPin(pinId, clientId);
     if (pin.authToken) return pin.authToken;
     await new Promise((r) => setTimeout(r, intervalMs));
   }

--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -1828,6 +1828,11 @@ export const resolvers = {
         values.push(args.is_active);
         changes.is_active = args.is_active;
       }
+      if (args.plex_id !== undefined) {
+        updates.push(`plex_id = $${paramCount++}`);
+        values.push(args.plex_id || null);
+        changes.plex_id = args.plex_id || null;
+      }
 
       updates.push(`updated_at = CURRENT_TIMESTAMP`);
       values.push(args.id);

--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -16,9 +16,11 @@ import { createList, syncList } from './mdblist';
 import { runKometaExport } from './kometaExport';
 import { applyComparison, updateGlobalEloRank } from './elo';
 import { selectPair, MovieCandidate } from './pairSelection';
+import { createPlexPin as createPin, waitForPlexAuth, getPlexUser, getPlexAuthUrl } from './plex';
+import crypto from 'crypto';
 
 const USER_COLS =
-  'id, username, email, display_name, is_admin, is_active, last_login_at, created_at, updated_at';
+  'id, username, email, display_name, is_admin, is_active, last_login_at, plex_id, plex_username, plex_thumb, created_at, updated_at';
 
 async function logAudit(
   actorId: number | null,
@@ -166,6 +168,7 @@ export const resolvers = {
   Query: {
     appInfo: () => ({
       isProduction: isProduction(),
+      plexAuthEnabled: !!process.env.PLEX_CLIENT_ID,
       quickLoginUsers: isProduction()
         ? []
         : [
@@ -1524,6 +1527,218 @@ export const resolvers = {
       const token = generateToken(userWithoutPassword);
       return { token, user: userWithoutPassword };
     },
+
+    // ── Plex authentication ───────────────────────────────────────────────────
+
+    createPlexPin: async () => {
+      const pin = await createPin();
+      return {
+        pinId: pin.id,
+        code: pin.code,
+        authUrl: getPlexAuthUrl(pin.code),
+      };
+    },
+
+    completePlexAuth: async (_: any, { pinId }: { pinId: number }, context: any) => {
+      if (
+        !checkRateLimit(
+          loginRateLimiter,
+          context.ipAddress,
+          LOGIN_RATE_LIMIT_MAX,
+          LOGIN_RATE_LIMIT_WINDOW,
+        )
+      ) {
+        await logLoginHistory(null, context.ipAddress, context.userAgent, false);
+        throw new GraphQLError('Too many login attempts. Please try again later.', {
+          extensions: { code: 'TOO_MANY_REQUESTS' },
+        });
+      }
+
+      let authToken: string;
+      try {
+        authToken = await waitForPlexAuth(pinId);
+      } catch {
+        await logLoginHistory(null, context.ipAddress, context.userAgent, false);
+        throw new GraphQLError('Plex authentication timed out or failed', {
+          extensions: { code: 'UNAUTHENTICATED' },
+        });
+      }
+
+      const plexUser = await getPlexUser(authToken);
+      const plexId = String(plexUser.id);
+
+      // 1. Check if a user is already linked to this Plex account
+      let result = await pool.query(`SELECT ${USER_COLS} FROM users WHERE plex_id = $1`, [plexId]);
+      let user = result.rows[0];
+
+      if (!user) {
+        // 2. Check if email matches an existing account — auto-link
+        result = await pool.query(`SELECT ${USER_COLS} FROM users WHERE LOWER(email) = LOWER($1)`, [
+          plexUser.email,
+        ]);
+        user = result.rows[0];
+
+        if (user) {
+          await pool.query(
+            'UPDATE users SET plex_id = $1, plex_username = $2, plex_thumb = $3, updated_at = NOW() WHERE id = $4',
+            [plexId, plexUser.username, plexUser.thumb, user.id],
+          );
+          user.plex_id = plexId;
+          user.plex_username = plexUser.username;
+          user.plex_thumb = plexUser.thumb;
+          await logAudit(
+            user.id,
+            'PLEX_LINK',
+            'user',
+            String(user.id),
+            { plex_username: plexUser.username, auto_linked: true },
+            context.ipAddress,
+          );
+        } else {
+          // 3. Create new account
+          const randomPassword = crypto.randomBytes(32).toString('hex');
+          const passwordHash = await hashPassword(randomPassword);
+          const username = `plex_${plexUser.username}`.substring(0, 100);
+          const displayName = plexUser.username.substring(0, 255);
+
+          try {
+            result = await pool.query(
+              `INSERT INTO users (username, email, password_hash, display_name, plex_id, plex_username, plex_thumb)
+               VALUES ($1, $2, $3, $4, $5, $6, $7)
+               RETURNING ${USER_COLS}`,
+              [
+                username,
+                plexUser.email,
+                passwordHash,
+                displayName,
+                plexId,
+                plexUser.username,
+                plexUser.thumb,
+              ],
+            );
+          } catch (err: any) {
+            // Handle username collision — retry with plex ID suffix
+            if (err.code === '23505' && err.constraint?.includes('username')) {
+              result = await pool.query(
+                `INSERT INTO users (username, email, password_hash, display_name, plex_id, plex_username, plex_thumb)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7)
+                 RETURNING ${USER_COLS}`,
+                [
+                  `plex_${plexId}`.substring(0, 100),
+                  plexUser.email,
+                  passwordHash,
+                  displayName,
+                  plexId,
+                  plexUser.username,
+                  plexUser.thumb,
+                ],
+              );
+            } else {
+              throw err;
+            }
+          }
+          user = result.rows[0];
+          await logAudit(
+            user.id,
+            'USER_CREATE',
+            'user',
+            String(user.id),
+            { plex_username: plexUser.username, created_via: 'plex' },
+            context.ipAddress,
+          );
+        }
+      }
+
+      if (!user.is_active) {
+        await logLoginHistory(user.id, context.ipAddress, context.userAgent, false);
+        throw new GraphQLError('Account is disabled', {
+          extensions: { code: 'FORBIDDEN' },
+        });
+      }
+
+      // Update last_login_at and refresh plex metadata
+      await pool.query(
+        'UPDATE users SET last_login_at = NOW(), plex_username = $1, plex_thumb = $2 WHERE id = $3',
+        [plexUser.username, plexUser.thumb, user.id],
+      );
+
+      await logLoginHistory(user.id, context.ipAddress, context.userAgent, true);
+      await logAudit(user.id, 'LOGIN_SUCCESS', null, null, { method: 'plex' }, context.ipAddress);
+
+      const token = generateToken(user);
+      return { token, user };
+    },
+
+    linkPlexAccount: async (_: any, { pinId }: { pinId: number }, context: any) => {
+      if (!context.user) {
+        throw new GraphQLError('Not authenticated', {
+          extensions: { code: 'UNAUTHENTICATED' },
+        });
+      }
+
+      let authToken: string;
+      try {
+        authToken = await waitForPlexAuth(pinId);
+      } catch {
+        throw new GraphQLError('Plex authentication timed out or failed', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+
+      const plexUser = await getPlexUser(authToken);
+      const plexId = String(plexUser.id);
+
+      // Check if this Plex account is already linked to another user
+      const existing = await pool.query('SELECT id FROM users WHERE plex_id = $1', [plexId]);
+      if (existing.rows.length > 0 && existing.rows[0].id !== context.user.userId) {
+        throw new GraphQLError('This Plex account is already linked to another user', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+
+      const result = await pool.query(
+        `UPDATE users SET plex_id = $1, plex_username = $2, plex_thumb = $3, updated_at = NOW()
+         WHERE id = $4 RETURNING ${USER_COLS}`,
+        [plexId, plexUser.username, plexUser.thumb, context.user.userId],
+      );
+
+      await logAudit(
+        context.user.userId,
+        'PLEX_LINK',
+        'user',
+        String(context.user.userId),
+        { plex_username: plexUser.username },
+        context.ipAddress,
+      );
+
+      return result.rows[0];
+    },
+
+    unlinkPlexAccount: async (_: any, __: any, context: any) => {
+      if (!context.user) {
+        throw new GraphQLError('Not authenticated', {
+          extensions: { code: 'UNAUTHENTICATED' },
+        });
+      }
+
+      const result = await pool.query(
+        `UPDATE users SET plex_id = NULL, plex_username = NULL, plex_thumb = NULL, updated_at = NOW()
+         WHERE id = $1 RETURNING ${USER_COLS}`,
+        [context.user.userId],
+      );
+
+      await logAudit(
+        context.user.userId,
+        'PLEX_UNLINK',
+        'user',
+        String(context.user.userId),
+        null,
+        context.ipAddress,
+      );
+
+      return result.rows[0];
+    },
+
     createUser: async (_: any, args: CreateUserInput, context: any) => {
       if (!context.user?.isAdmin) {
         throw new GraphQLError('Not authorized', {

--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -17,7 +17,10 @@ import { runKometaExport } from './kometaExport';
 import { applyComparison, updateGlobalEloRank } from './elo';
 import { selectPair, MovieCandidate } from './pairSelection';
 import { createPlexPin as createPin, waitForPlexAuth, getPlexUser, getPlexAuthUrl } from './plex';
+import { getSetting, setSetting } from './settings';
 import crypto from 'crypto';
+
+const ALLOWED_SETTINGS = ['plex_client_id', 'tmdb_api_key', 'mdblist_api_key'] as const;
 
 const USER_COLS =
   'id, username, email, display_name, is_admin, is_active, last_login_at, plex_id, plex_username, plex_thumb, created_at, updated_at';
@@ -127,7 +130,7 @@ setInterval(
 // ── TMDB metadata: fetch from API and persist to DB ──────────────────────────
 
 async function fetchAndStoreTmdbData(movieId: number, tmdbId: number): Promise<void> {
-  const apiKey = process.env.TMDB_API_KEY;
+  const apiKey = (await getSetting('tmdb_api_key')) || process.env.TMDB_API_KEY;
   if (!apiKey) return;
 
   try {
@@ -166,31 +169,41 @@ async function fetchAndStoreTmdbData(movieId: number, tmdbId: number): Promise<v
 
 export const resolvers = {
   Query: {
-    appInfo: () => ({
-      isProduction: isProduction(),
-      plexAuthEnabled: !!process.env.PLEX_CLIENT_ID,
-      quickLoginUsers: isProduction()
-        ? []
-        : [
-            {
-              label: 'Admin',
-              username: 'admin',
-              password: process.env.ADMIN_PASSWORD || 'admin123',
-            },
-            {
-              label: 'Test User',
-              username: process.env.TEST_USER_USERNAME || 'testuser',
-              password: process.env.TEST_USER_PASSWORD || 'testpass',
-            },
-          ],
-    }),
+    appInfo: async (_: any, __: any, context: any) => {
+      const plexClientId =
+        (await getSetting('plex_client_id')) || process.env.PLEX_CLIENT_ID || null;
+      const tmdbApiKey = (await getSetting('tmdb_api_key')) || process.env.TMDB_API_KEY || null;
+      const mdblistApiKey =
+        (await getSetting('mdblist_api_key')) || process.env.MDBLIST_API_KEY || null;
+      return {
+        isProduction: isProduction(),
+        plexAuthEnabled: !!plexClientId,
+        plexClientId: context.user?.isAdmin ? plexClientId : null,
+        tmdbApiKey: context.user?.isAdmin ? tmdbApiKey : null,
+        mdblistApiKey: context.user?.isAdmin ? mdblistApiKey : null,
+        quickLoginUsers: isProduction()
+          ? []
+          : [
+              {
+                label: 'Admin',
+                username: 'admin',
+                password: process.env.ADMIN_PASSWORD || 'admin123',
+              },
+              {
+                label: 'Test User',
+                username: process.env.TEST_USER_USERNAME || 'testuser',
+                password: process.env.TEST_USER_PASSWORD || 'testpass',
+              },
+            ],
+      };
+    },
     searchTmdb: async (_: any, { query }: { query: string }, context: any) => {
       if (!context.user) {
         throw new GraphQLError('Not authenticated', {
           extensions: { code: 'UNAUTHENTICATED' },
         });
       }
-      const apiKey = process.env.TMDB_API_KEY;
+      const apiKey = (await getSetting('tmdb_api_key')) || process.env.TMDB_API_KEY;
       if (!apiKey) {
         throw new GraphQLError('TMDB API key not configured', {
           extensions: { code: 'INTERNAL_SERVER_ERROR' },
@@ -361,11 +374,15 @@ export const resolvers = {
           frequency: 'daily',
           dailyTime: '03:00',
           lastRunAt: null,
-          mdblistApiKeySet: !!process.env.MDBLIST_API_KEY,
+          mdblistApiKeySet: !!(
+            (await getSetting('mdblist_api_key')) || process.env.MDBLIST_API_KEY
+          ),
           exportedLists,
         };
       }
       const row = result.rows[0];
+      const mdblistSettingKey =
+        row.mdblist_api_key || (await getSetting('mdblist_api_key')) || process.env.MDBLIST_API_KEY;
       return {
         enabled: row.enabled,
         frequency: row.frequency,
@@ -375,7 +392,7 @@ export const resolvers = {
             ? row.last_run_at.toISOString()
             : new Date(row.last_run_at).toISOString()
           : null,
-        mdblistApiKeySet: !!(row.mdblist_api_key || process.env.MDBLIST_API_KEY),
+        mdblistApiKeySet: !!mdblistSettingKey,
         exportedLists,
       };
     },
@@ -971,7 +988,10 @@ export const resolvers = {
       }
 
       const schedRow = await pool.query('SELECT mdblist_api_key FROM kometa_schedule WHERE id = 1');
-      const mdblistApiKey = schedRow.rows[0]?.mdblist_api_key || process.env.MDBLIST_API_KEY;
+      const mdblistApiKey =
+        schedRow.rows[0]?.mdblist_api_key ||
+        (await getSetting('mdblist_api_key')) ||
+        process.env.MDBLIST_API_KEY;
       if (!mdblistApiKey) {
         throw new GraphQLError('MDBList API key is not configured', {
           extensions: { code: 'BAD_USER_INPUT' },
@@ -1118,7 +1138,11 @@ export const resolvers = {
             ? row.last_run_at.toISOString()
             : new Date(row.last_run_at).toISOString()
           : null,
-        mdblistApiKeySet: !!(row.mdblist_api_key || process.env.MDBLIST_API_KEY),
+        mdblistApiKeySet: !!(
+          row.mdblist_api_key ||
+          (await getSetting('mdblist_api_key')) ||
+          process.env.MDBLIST_API_KEY
+        ),
         exportedLists: listsResult.rows.map((r: any) => ({
           name: r.list_name,
           type: r.list_type,
@@ -1249,7 +1273,7 @@ export const resolvers = {
         errors.push('No films found — check that the URL is a public Letterboxd list');
       }
 
-      const tmdbApiKey = process.env.TMDB_API_KEY;
+      const tmdbApiKey = (await getSetting('tmdb_api_key')) || process.env.TMDB_API_KEY;
       async function lookupTmdbId(title: string, year: number | null): Promise<number | null> {
         if (!tmdbApiKey) return null;
         try {
@@ -1531,11 +1555,12 @@ export const resolvers = {
     // ── Plex authentication ───────────────────────────────────────────────────
 
     createPlexPin: async () => {
-      const pin = await createPin();
+      const plexClientId = (await getSetting('plex_client_id')) || undefined;
+      const pin = await createPin(plexClientId);
       return {
         pinId: pin.id,
         code: pin.code,
-        authUrl: getPlexAuthUrl(pin.code),
+        authUrl: getPlexAuthUrl(pin.code, plexClientId),
       };
     },
 
@@ -1554,9 +1579,10 @@ export const resolvers = {
         });
       }
 
+      const plexClientId = (await getSetting('plex_client_id')) || undefined;
       let authToken: string;
       try {
-        authToken = await waitForPlexAuth(pinId);
+        authToken = await waitForPlexAuth(pinId, undefined, undefined, plexClientId);
       } catch {
         await logLoginHistory(null, context.ipAddress, context.userAgent, false);
         throw new GraphQLError('Plex authentication timed out or failed', {
@@ -1564,7 +1590,7 @@ export const resolvers = {
         });
       }
 
-      const plexUser = await getPlexUser(authToken);
+      const plexUser = await getPlexUser(authToken, plexClientId);
       const plexId = String(plexUser.id);
 
       // 1. Check if a user is already linked to this Plex account
@@ -1676,16 +1702,17 @@ export const resolvers = {
         });
       }
 
+      const plexClientId = (await getSetting('plex_client_id')) || undefined;
       let authToken: string;
       try {
-        authToken = await waitForPlexAuth(pinId);
+        authToken = await waitForPlexAuth(pinId, undefined, undefined, plexClientId);
       } catch {
         throw new GraphQLError('Plex authentication timed out or failed', {
           extensions: { code: 'BAD_USER_INPUT' },
         });
       }
 
-      const plexUser = await getPlexUser(authToken);
+      const plexUser = await getPlexUser(authToken, plexClientId);
       const plexId = String(plexUser.id);
 
       // Check if this Plex account is already linked to another user
@@ -1737,6 +1764,39 @@ export const resolvers = {
       );
 
       return result.rows[0];
+    },
+
+    // ── App settings ──────────────────────────────────────────────────────────
+
+    updateAppSetting: async (
+      _: any,
+      { key, value }: { key: string; value?: string | null },
+      context: any,
+    ) => {
+      if (!context.user?.isAdmin) {
+        throw new GraphQLError('Not authorized', {
+          extensions: { code: 'FORBIDDEN' },
+        });
+      }
+      if (!ALLOWED_SETTINGS.includes(key as any)) {
+        throw new GraphQLError(`Unknown setting: ${key}`, {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+
+      await setSetting(key, value || null);
+
+      await logAudit(
+        context.user.userId,
+        'SETTING_UPDATE',
+        'setting',
+        key,
+        { cleared: !value },
+        context.ipAddress,
+      );
+
+      // Return updated appInfo
+      return resolvers.Query.appInfo(null, null, context);
     },
 
     createUser: async (_: any, args: CreateUserInput, context: any) => {

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -88,6 +88,9 @@ export const typeDefs = `#graphql
     isProduction: Boolean!
     quickLoginUsers: [QuickLoginUser!]!
     plexAuthEnabled: Boolean!
+    plexClientId: String
+    tmdbApiKey: String
+    mdblistApiKey: String
   }
 
   type PlexPin {
@@ -240,6 +243,7 @@ export const typeDefs = `#graphql
     completePlexAuth(pinId: Int!): AuthPayload!
     linkPlexAccount(pinId: Int!): User!
     unlinkPlexAccount: User!
+    updateAppSetting(key: String!, value: String): AppInfo!
     createUser(username: String!, email: String!, password: String!, display_name: String, is_admin: Boolean, is_active: Boolean): User!
     updateUser(id: ID!, username: String, email: String, password: String, display_name: String, is_admin: Boolean, is_active: Boolean, plex_id: String): User!
     deleteUser(id: ID!): Boolean!

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -241,7 +241,7 @@ export const typeDefs = `#graphql
     linkPlexAccount(pinId: Int!): User!
     unlinkPlexAccount: User!
     createUser(username: String!, email: String!, password: String!, display_name: String, is_admin: Boolean, is_active: Boolean): User!
-    updateUser(id: ID!, username: String, email: String, password: String, display_name: String, is_admin: Boolean, is_active: Boolean): User!
+    updateUser(id: ID!, username: String, email: String, password: String, display_name: String, is_admin: Boolean, is_active: Boolean, plex_id: String): User!
     deleteUser(id: ID!): Boolean!
     seedMovies: Int!
     backfillTmdbData: Int!

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -28,6 +28,9 @@ export const typeDefs = `#graphql
     is_admin: Boolean!
     is_active: Boolean!
     last_login_at: String
+    plex_id: String
+    plex_username: String
+    plex_thumb: String
     created_at: String!
     updated_at: String!
   }
@@ -84,6 +87,13 @@ export const typeDefs = `#graphql
   type AppInfo {
     isProduction: Boolean!
     quickLoginUsers: [QuickLoginUser!]!
+    plexAuthEnabled: Boolean!
+  }
+
+  type PlexPin {
+    pinId: Int!
+    code: String!
+    authUrl: String!
   }
 
   type ThisOrThatMovie {
@@ -226,6 +236,10 @@ export const typeDefs = `#graphql
     setMdblistApiKey(apiKey: String!): KometaSchedule!
     importFromLetterboxd(url: String!): ImportResult!
     login(username: String!, password: String!): AuthPayload!
+    createPlexPin: PlexPin!
+    completePlexAuth(pinId: Int!): AuthPayload!
+    linkPlexAccount(pinId: Int!): User!
+    unlinkPlexAccount: User!
     createUser(username: String!, email: String!, password: String!, display_name: String, is_admin: Boolean, is_active: Boolean): User!
     updateUser(id: ID!, username: String, email: String, password: String, display_name: String, is_admin: Boolean, is_active: Boolean): User!
     deleteUser(id: ID!): Boolean!

--- a/backend/src/settings.ts
+++ b/backend/src/settings.ts
@@ -1,0 +1,14 @@
+import pool from './db';
+
+export async function getSetting(key: string): Promise<string | null> {
+  const result = await pool.query('SELECT value FROM app_settings WHERE key = $1', [key]);
+  return result.rows[0]?.value ?? null;
+}
+
+export async function setSetting(key: string, value: string | null): Promise<void> {
+  await pool.query(
+    `INSERT INTO app_settings (key, value, updated_at) VALUES ($1, $2, NOW())
+     ON CONFLICT (key) DO UPDATE SET value = $2, updated_at = NOW()`,
+    [key, value],
+  );
+}

--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -5,6 +5,7 @@ import { AuditLog } from './AuditLog';
 import { LoginHistory } from './LoginHistory';
 import { KometaExport } from './KometaExport';
 import { LetterboxdImport } from './LetterboxdImport';
+import { Settings } from './Settings';
 
 export const AdminPanel: React.FC = () => {
   return (
@@ -109,6 +110,22 @@ export const AdminPanel: React.FC = () => {
           >
             Import
           </Tab>
+          <Tab
+            value="settings"
+            sx={{
+              borderRadius: 'xs',
+              fontWeight: 600,
+              fontSize: '0.85rem',
+              flexShrink: 0,
+              whiteSpace: 'nowrap',
+              '&[aria-selected="true"]': {
+                bgcolor: 'background.level2',
+                color: 'primary.400',
+              },
+            }}
+          >
+            Settings
+          </Tab>
         </TabList>
         <TabPanel value="users" sx={{ p: 0 }}>
           <UserManagement />
@@ -124,6 +141,9 @@ export const AdminPanel: React.FC = () => {
         </TabPanel>
         <TabPanel value="import" sx={{ p: 0 }}>
           <LetterboxdImport />
+        </TabPanel>
+        <TabPanel value="settings" sx={{ p: 0 }}>
+          <Settings />
         </TabPanel>
       </Tabs>
     </Box>

--- a/src/components/admin/Settings.tsx
+++ b/src/components/admin/Settings.tsx
@@ -1,0 +1,168 @@
+import React, { useState, useEffect } from 'react';
+import { useQuery, useMutation } from '@apollo/client';
+import {
+  Box,
+  Typography,
+  Button,
+  Alert,
+  Sheet,
+  Input,
+  FormLabel,
+  FormControl,
+  CircularProgress,
+} from '@mui/joy';
+import { GET_APP_INFO, UPDATE_APP_SETTING } from '../../graphql/queries';
+
+interface SettingFieldProps {
+  label: string;
+  settingKey: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  helpText: string;
+}
+
+const SettingField: React.FC<SettingFieldProps> = ({
+  label,
+  settingKey,
+  value,
+  onChange,
+  placeholder,
+  helpText,
+}) => (
+  <FormControl sx={{ mb: 2 }}>
+    <FormLabel sx={{ fontSize: '0.8rem', fontWeight: 600, color: 'text.secondary' }}>
+      {label}
+    </FormLabel>
+    <Input
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+      sx={{ bgcolor: 'background.surface', fontFamily: 'monospace', fontSize: '0.85rem' }}
+      data-setting-key={settingKey}
+    />
+    <Typography level="body-xs" sx={{ color: 'text.tertiary', mt: 0.5 }}>
+      {helpText}
+    </Typography>
+  </FormControl>
+);
+
+export const Settings: React.FC = () => {
+  const { data, loading } = useQuery(GET_APP_INFO);
+  const [updateSetting, { loading: saving }] = useMutation(UPDATE_APP_SETTING, {
+    refetchQueries: [{ query: GET_APP_INFO }],
+  });
+
+  const [plexClientId, setPlexClientId] = useState('');
+  const [tmdbApiKey, setTmdbApiKey] = useState('');
+  const [mdblistApiKey, setMdblistApiKey] = useState('');
+  const [success, setSuccess] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (data?.appInfo) {
+      setPlexClientId(data.appInfo.plexClientId || '');
+      setTmdbApiKey(data.appInfo.tmdbApiKey || '');
+      setMdblistApiKey(data.appInfo.mdblistApiKey || '');
+    }
+  }, [data]);
+
+  const handleSave = async () => {
+    setError('');
+    setSuccess('');
+    try {
+      const settings = [
+        { key: 'plex_client_id', value: plexClientId, prev: data?.appInfo?.plexClientId || '' },
+        { key: 'tmdb_api_key', value: tmdbApiKey, prev: data?.appInfo?.tmdbApiKey || '' },
+        { key: 'mdblist_api_key', value: mdblistApiKey, prev: data?.appInfo?.mdblistApiKey || '' },
+      ];
+
+      const changed = settings.filter((s) => s.value !== s.prev);
+      if (changed.length === 0) {
+        setSuccess('No changes to save.');
+        return;
+      }
+
+      for (const { key, value } of changed) {
+        await updateSetting({ variables: { key, value: value || null } });
+      }
+      setSuccess(`Saved ${changed.length} setting${changed.length > 1 ? 's' : ''}.`);
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+        <CircularProgress size="md" color="primary" />
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Typography level="title-md" fontWeight={700} sx={{ color: 'text.secondary', mb: 2 }}>
+        API Keys & Integration
+      </Typography>
+
+      <Sheet
+        variant="outlined"
+        sx={{
+          borderRadius: 'md',
+          p: 2.5,
+          borderColor: 'var(--mn-border-vis)',
+        }}
+      >
+        <SettingField
+          label="Plex Client ID"
+          settingKey="plex_client_id"
+          value={plexClientId}
+          onChange={setPlexClientId}
+          placeholder="e.g. movienight-abc123"
+          helpText="Enables 'Sign in with Plex'. Must be stable across restarts. Also configurable via PLEX_CLIENT_ID env var."
+        />
+
+        <SettingField
+          label="TMDB API Key"
+          settingKey="tmdb_api_key"
+          value={tmdbApiKey}
+          onChange={setTmdbApiKey}
+          placeholder="e.g. abc123def456..."
+          helpText="Enables movie search, poster art, and metadata. Get one at themoviedb.org. Also configurable via TMDB_API_KEY env var."
+        />
+
+        <SettingField
+          label="MDBList API Key"
+          settingKey="mdblist_api_key"
+          value={mdblistApiKey}
+          onChange={setMdblistApiKey}
+          placeholder="e.g. xyz789..."
+          helpText="Enables Kometa/Plex collection sync via MDBList. Also configurable via MDBLIST_API_KEY env var."
+        />
+
+        {success && (
+          <Alert color="success" variant="soft" sx={{ mb: 2 }}>
+            {success}
+          </Alert>
+        )}
+        {error && (
+          <Alert color="danger" variant="soft" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <Button
+            color="primary"
+            loading={saving}
+            onClick={handleSave}
+            sx={{ fontWeight: 700, color: '#0d0f1a' }}
+          >
+            Save Settings
+          </Button>
+        </Box>
+      </Sheet>
+    </Box>
+  );
+};

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -204,6 +204,7 @@ export const UserManagement: React.FC = () => {
                   <th style={thStyle}>Username</th>
                   <th style={thStyle}>Display Name</th>
                   <th style={thStyle}>Email</th>
+                  <th style={thStyle}>Plex</th>
                   <th style={{ ...thStyle, width: 70 }}>Admin</th>
                   <th style={{ ...thStyle, width: 100 }}>Status</th>
                   <th style={{ ...thStyle, width: 110 }}>Last Login</th>
@@ -245,6 +246,17 @@ export const UserManagement: React.FC = () => {
                       <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
                         {user.email}
                       </Typography>
+                    </td>
+                    <td>
+                      {user.plex_username ? (
+                        <Typography level="body-xs" sx={{ color: '#e5a00d' }}>
+                          {user.plex_username}
+                        </Typography>
+                      ) : (
+                        <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+                          —
+                        </Typography>
+                      )}
                     </td>
                     <td>
                       {user.is_admin && (
@@ -341,6 +353,11 @@ export const UserManagement: React.FC = () => {
                 <Typography level="body-xs" sx={{ color: 'text.tertiary', mt: 0.25 }}>
                   {user.email}
                 </Typography>
+                {user.plex_username && (
+                  <Typography level="body-xs" sx={{ color: '#e5a00d', mt: 0.25 }}>
+                    Plex: {user.plex_username}
+                  </Typography>
+                )}
                 <Typography level="body-xs" sx={{ color: 'text.tertiary', mt: 0.25 }}>
                   Last login:{' '}
                   {user.last_login_at ? new Date(user.last_login_at).toLocaleDateString() : 'Never'}

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -50,6 +50,7 @@ export const UserManagement: React.FC = () => {
     password: '',
     is_admin: false,
     is_active: true,
+    plex_id: '',
   });
   const [error, setError] = useState('');
 
@@ -86,6 +87,7 @@ export const UserManagement: React.FC = () => {
         password: '',
         is_admin: user.is_admin,
         is_active: user.is_active,
+        plex_id: user.plex_id || '',
       });
     } else {
       setEditingUser(null);
@@ -96,6 +98,7 @@ export const UserManagement: React.FC = () => {
         password: '',
         is_admin: false,
         is_active: true,
+        plex_id: '',
       });
     }
     setError('');
@@ -112,6 +115,7 @@ export const UserManagement: React.FC = () => {
       password: '',
       is_admin: false,
       is_active: true,
+      plex_id: '',
     });
     setError('');
   };
@@ -129,6 +133,8 @@ export const UserManagement: React.FC = () => {
         if (formData.password) variables.password = formData.password;
         if (formData.is_admin !== editingUser.is_admin) variables.is_admin = formData.is_admin;
         if (formData.is_active !== editingUser.is_active) variables.is_active = formData.is_active;
+        if (formData.plex_id !== (editingUser.plex_id || ''))
+          variables.plex_id = formData.plex_id || null;
         await updateUser({ variables });
       } else {
         if (!formData.password) {
@@ -465,6 +471,21 @@ export const UserManagement: React.FC = () => {
                 sx={{ bgcolor: 'background.surface' }}
               />
             </FormControl>
+
+            {editingUser && (
+              <FormControl sx={{ mb: 2 }}>
+                <FormLabel sx={{ fontSize: '0.8rem', fontWeight: 600, color: 'text.secondary' }}>
+                  Plex ID{' '}
+                  <span style={{ fontWeight: 400, opacity: 0.6 }}>(leave blank to unlink)</span>
+                </FormLabel>
+                <Input
+                  value={formData.plex_id}
+                  onChange={(e) => setFormData({ ...formData, plex_id: e.target.value })}
+                  placeholder="Plex account ID"
+                  sx={{ bgcolor: 'background.surface' }}
+                />
+              </FormControl>
+            )}
 
             <Box sx={{ display: 'flex', gap: 3, mb: 3 }}>
               <Checkbox

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useMutation, useQuery } from '@apollo/client';
-import { Box, Button, FormControl, FormLabel, Input, Typography, Alert } from '@mui/joy';
-import { LOGIN, GET_APP_INFO } from '../../graphql/queries';
+import { Box, Button, Divider, FormControl, FormLabel, Input, Typography, Alert } from '@mui/joy';
+import { LOGIN, GET_APP_INFO, CREATE_PLEX_PIN, COMPLETE_PLEX_AUTH } from '../../graphql/queries';
 import { useAuth } from '../../contexts/AuthContext';
 
 interface LoginProps {
@@ -17,6 +17,11 @@ export const Login: React.FC<LoginProps> = ({ onForgotPassword }) => {
   const { data: appInfoData } = useQuery(GET_APP_INFO);
   const quickLoginUsers: { label: string; username: string; password: string }[] =
     appInfoData?.appInfo?.quickLoginUsers ?? [];
+  const plexAuthEnabled = appInfoData?.appInfo?.plexAuthEnabled ?? false;
+
+  const [createPlexPin] = useMutation(CREATE_PLEX_PIN);
+  const [completePlexAuth] = useMutation(COMPLETE_PLEX_AUTH);
+  const [plexLoading, setPlexLoading] = useState(false);
 
   const [loginMutation, { loading }] = useMutation(LOGIN, {
     onCompleted: (data) => {
@@ -66,6 +71,36 @@ export const Login: React.FC<LoginProps> = ({ onForgotPassword }) => {
       await loginMutation({ variables: { username, password } });
     } catch {
       // handled by onError
+    }
+  };
+
+  const handlePlexLogin = async () => {
+    setPlexLoading(true);
+    setError('');
+    try {
+      const { data: pinData } = await createPlexPin();
+      const { pinId, authUrl } = pinData.createPlexPin;
+
+      // Open Plex auth in popup
+      window.open(authUrl, 'PlexAuth', 'width=800,height=600');
+
+      // Server polls Plex until auth completes (up to 2 min)
+      const { data: authData } = await completePlexAuth({
+        variables: { pinId },
+      });
+
+      login(authData.completePlexAuth.token, authData.completePlexAuth.user);
+    } catch (err: any) {
+      const code = err?.graphQLErrors?.[0]?.extensions?.code;
+      if (code === 'FORBIDDEN') {
+        setError('Your account has been disabled. Please contact an administrator.');
+      } else if (code === 'TOO_MANY_REQUESTS') {
+        setError('Too many login attempts. Please try again later.');
+      } else {
+        setError('Plex sign-in failed. Please try again.');
+      }
+    } finally {
+      setPlexLoading(false);
     }
   };
 
@@ -216,6 +251,31 @@ export const Login: React.FC<LoginProps> = ({ onForgotPassword }) => {
               Sign In
             </Button>
           </form>
+
+          {plexAuthEnabled && (
+            <>
+              <Divider sx={{ my: 3, color: 'text.tertiary', fontSize: '0.75rem' }}>or</Divider>
+              <Button
+                fullWidth
+                variant="outlined"
+                color="neutral"
+                loading={plexLoading}
+                onClick={handlePlexLogin}
+                sx={{
+                  fontWeight: 700,
+                  py: 1.25,
+                  borderColor: '#e5a00d',
+                  color: '#e5a00d',
+                  '&:hover': {
+                    borderColor: '#f5c518',
+                    bgcolor: 'rgba(229, 160, 13, 0.08)',
+                  },
+                }}
+              >
+                Sign in with Plex
+              </Button>
+            </>
+          )}
 
           {quickLoginUsers.length > 0 && (
             <Box sx={{ mt: 3 }}>

--- a/src/components/auth/PlexLinkButton.tsx
+++ b/src/components/auth/PlexLinkButton.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+import { useMutation } from '@apollo/client';
+import { Box, Button, Typography } from '@mui/joy';
+import {
+  CREATE_PLEX_PIN,
+  LINK_PLEX_ACCOUNT,
+  UNLINK_PLEX_ACCOUNT,
+  GET_ME,
+} from '../../graphql/queries';
+import { useAuth } from '../../contexts/AuthContext';
+
+export const PlexLinkButton: React.FC = () => {
+  const { user, refreshUser } = useAuth();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const [createPlexPin] = useMutation(CREATE_PLEX_PIN);
+  const [linkPlexAccount] = useMutation(LINK_PLEX_ACCOUNT, {
+    refetchQueries: [{ query: GET_ME }],
+  });
+  const [unlinkPlexAccount] = useMutation(UNLINK_PLEX_ACCOUNT, {
+    refetchQueries: [{ query: GET_ME }],
+  });
+
+  const handleLink = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const { data: pinData } = await createPlexPin();
+      const { pinId, authUrl } = pinData.createPlexPin;
+
+      window.open(authUrl, 'PlexAuth', 'width=800,height=600');
+
+      await linkPlexAccount({ variables: { pinId } });
+      await refreshUser();
+    } catch (err: any) {
+      const msg = err?.graphQLErrors?.[0]?.message;
+      setError(msg || 'Failed to link Plex account');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleUnlink = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      await unlinkPlexAccount();
+      await refreshUser();
+    } catch (err: any) {
+      const msg = err?.graphQLErrors?.[0]?.message;
+      setError(msg || 'Failed to unlink Plex account');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (user?.plex_id) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Typography level="body-xs" sx={{ color: '#e5a00d' }}>
+          Plex: {user.plex_username}
+        </Typography>
+        <Button
+          variant="plain"
+          color="neutral"
+          size="sm"
+          loading={loading}
+          onClick={handleUnlink}
+          sx={{ fontSize: '0.7rem', minHeight: 'auto', p: 0.5 }}
+        >
+          Unlink
+        </Button>
+        {error && (
+          <Typography level="body-xs" color="danger">
+            {error}
+          </Typography>
+        )}
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      <Button
+        variant="plain"
+        size="sm"
+        loading={loading}
+        onClick={handleLink}
+        sx={{
+          fontSize: '0.75rem',
+          minHeight: 'auto',
+          p: 0.5,
+          color: '#e5a00d',
+          '&:hover': { bgcolor: 'rgba(229, 160, 13, 0.08)' },
+        }}
+      >
+        Link Plex
+      </Button>
+      {error && (
+        <Typography level="body-xs" color="danger">
+          {error}
+        </Typography>
+      )}
+    </Box>
+  );
+};

--- a/src/components/common/Navbar.tsx
+++ b/src/components/common/Navbar.tsx
@@ -1,7 +1,10 @@
 import React, { useState } from 'react';
+import { useQuery } from '@apollo/client';
 import { Box, Button, Typography, IconButton, Divider } from '@mui/joy';
 import { useAuth } from '../../contexts/AuthContext';
 import { getGravatarUrl } from '../../utils/gravatar';
+import { GET_APP_INFO } from '../../graphql/queries';
+import { PlexLinkButton } from '../auth/PlexLinkButton';
 
 type ViewName = 'movies' | 'this-or-that' | 'combined-list' | 'history' | 'admin';
 
@@ -26,6 +29,8 @@ export const Navbar: React.FC<NavbarProps> = ({
 }) => {
   const { isAuthenticated, user, logout } = useAuth();
   const [mobileOpen, setMobileOpen] = useState(false);
+  const { data: appInfoData } = useQuery(GET_APP_INFO);
+  const plexAuthEnabled = appInfoData?.appInfo?.plexAuthEnabled ?? false;
 
   const navItems = (
     <>
@@ -199,6 +204,7 @@ export const Navbar: React.FC<NavbarProps> = ({
                   >
                     {user?.display_name || user?.username}
                   </Typography>
+                  {plexAuthEnabled && <PlexLinkButton />}
                 </Box>
               </Box>
               <Button
@@ -278,6 +284,7 @@ export const Navbar: React.FC<NavbarProps> = ({
                   <Typography level="body-sm" fontWeight={600}>
                     {user?.display_name || user?.username}
                   </Typography>
+                  {plexAuthEnabled && <PlexLinkButton />}
                 </Box>
               </Box>
             </>

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -302,11 +302,25 @@ export const GET_APP_INFO = gql`
     appInfo {
       isProduction
       plexAuthEnabled
+      plexClientId
+      tmdbApiKey
+      mdblistApiKey
       quickLoginUsers {
         label
         username
         password
       }
+    }
+  }
+`;
+
+export const UPDATE_APP_SETTING = gql`
+  mutation UpdateAppSetting($key: String!, $value: String) {
+    updateAppSetting(key: $key, value: $value) {
+      plexAuthEnabled
+      plexClientId
+      tmdbApiKey
+      mdblistApiKey
     }
   }
 `;

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -188,6 +188,7 @@ export const UPDATE_USER = gql`
     $display_name: String
     $is_admin: Boolean
     $is_active: Boolean
+    $plex_id: String
   ) {
     updateUser(
       id: $id
@@ -197,6 +198,7 @@ export const UPDATE_USER = gql`
       display_name: $display_name
       is_admin: $is_admin
       is_active: $is_active
+      plex_id: $plex_id
     ) {
       id
       username
@@ -204,6 +206,8 @@ export const UPDATE_USER = gql`
       display_name
       is_admin
       is_active
+      plex_id
+      plex_username
       last_login_at
       created_at
       updated_at

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -122,6 +122,9 @@ export const GET_ME = gql`
       is_admin
       is_active
       last_login_at
+      plex_id
+      plex_username
+      plex_thumb
       created_at
       updated_at
     }
@@ -138,6 +141,8 @@ export const GET_USERS = gql`
       is_admin
       is_active
       last_login_at
+      plex_id
+      plex_username
       created_at
       updated_at
     }
@@ -292,6 +297,7 @@ export const GET_APP_INFO = gql`
   query GetAppInfo {
     appInfo {
       isProduction
+      plexAuthEnabled
       quickLoginUsers {
         label
         username
@@ -611,6 +617,57 @@ export const UNWATCH_MOVIE = gql`
       id
       title
       watched_at
+    }
+  }
+`;
+
+export const CREATE_PLEX_PIN = gql`
+  mutation CreatePlexPin {
+    createPlexPin {
+      pinId
+      code
+      authUrl
+    }
+  }
+`;
+
+export const COMPLETE_PLEX_AUTH = gql`
+  mutation CompletePlexAuth($pinId: Int!) {
+    completePlexAuth(pinId: $pinId) {
+      token
+      user {
+        id
+        username
+        email
+        display_name
+        is_admin
+        is_active
+        plex_id
+        plex_username
+        plex_thumb
+      }
+    }
+  }
+`;
+
+export const LINK_PLEX_ACCOUNT = gql`
+  mutation LinkPlexAccount($pinId: Int!) {
+    linkPlexAccount(pinId: $pinId) {
+      id
+      plex_id
+      plex_username
+      plex_thumb
+    }
+  }
+`;
+
+export const UNLINK_PLEX_ACCOUNT = gql`
+  mutation UnlinkPlexAccount {
+    unlinkPlexAccount {
+      id
+      plex_id
+      plex_username
+      plex_thumb
     }
   }
 `;

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -6,6 +6,9 @@ export interface User {
   is_admin: boolean;
   is_active: boolean;
   last_login_at?: string | null;
+  plex_id?: string | null;
+  plex_username?: string | null;
+  plex_thumb?: string | null;
   created_at?: string;
   updated_at?: string;
 }


### PR DESCRIPTION
## Summary
- Add Plex OAuth as an alternative login method (PIN-based flow with server-side polling)
- Existing users can link/unlink their Plex account from the navbar for future sign-ins
- First-time Plex login auto-links by email match or creates a new account
- Feature gated on `PLEX_CLIENT_ID` env var — hidden when not set

## Changes
- **Migration**: `plex_id`, `plex_username`, `plex_thumb` columns on users table
- **Backend**: `backend/src/plex.ts` Plex API service + 4 new GraphQL mutations (`createPlexPin`, `completePlexAuth`, `linkPlexAccount`, `unlinkPlexAccount`)
- **Frontend**: "Sign in with Plex" button on login page, `PlexLinkButton` component in navbar, Plex column in admin user management
- **Tests**: 17 new backend tests covering Plex service and resolver layers

## Test plan
- [ ] Set `PLEX_CLIENT_ID` env var and verify "Sign in with Plex" button appears on login page
- [ ] Complete Plex sign-in flow — verify account creation and JWT token
- [ ] Test email auto-linking: create account with same email as Plex account, sign in with Plex
- [ ] Test account linking from navbar while logged in
- [ ] Test account unlinking from navbar
- [ ] Verify Plex column shows in admin user management
- [ ] Verify feature is hidden when `PLEX_CLIENT_ID` is not set
- [ ] Run `cd backend && npm test` — all 283 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)