### PR TITLE
feat: mobile-friendly admin panel

### DIFF
--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -23,6 +23,10 @@ export const AdminPanel: React.FC = () => {
             gap: 0.5,
             mb: 3,
             '--Tab-indicatorThickness': '0px',
+            overflowX: 'auto',
+            flexWrap: 'nowrap',
+            '&::-webkit-scrollbar': { display: 'none' },
+            scrollbarWidth: 'none',
           }}
         >
           <Tab
@@ -31,6 +35,8 @@ export const AdminPanel: React.FC = () => {
               borderRadius: 'xs',
               fontWeight: 600,
               fontSize: '0.85rem',
+              flexShrink: 0,
+              whiteSpace: 'nowrap',
               '&[aria-selected="true"]': {
                 bgcolor: 'background.level2',
                 color: 'primary.400',
@@ -45,6 +51,8 @@ export const AdminPanel: React.FC = () => {
               borderRadius: 'xs',
               fontWeight: 600,
               fontSize: '0.85rem',
+              flexShrink: 0,
+              whiteSpace: 'nowrap',
               '&[aria-selected="true"]': {
                 bgcolor: 'background.level2',
                 color: 'primary.400',
@@ -59,6 +67,8 @@ export const AdminPanel: React.FC = () => {
               borderRadius: 'xs',
               fontWeight: 600,
               fontSize: '0.85rem',
+              flexShrink: 0,
+              whiteSpace: 'nowrap',
               '&[aria-selected="true"]': {
                 bgcolor: 'background.level2',
                 color: 'primary.400',
@@ -73,6 +83,8 @@ export const AdminPanel: React.FC = () => {
               borderRadius: 'xs',
               fontWeight: 600,
               fontSize: '0.85rem',
+              flexShrink: 0,
+              whiteSpace: 'nowrap',
               '&[aria-selected="true"]': {
                 bgcolor: 'background.level2',
                 color: 'primary.400',
@@ -87,6 +99,8 @@ export const AdminPanel: React.FC = () => {
               borderRadius: 'xs',
               fontWeight: 600,
               fontSize: '0.85rem',
+              flexShrink: 0,
+              whiteSpace: 'nowrap',
               '&[aria-selected="true"]': {
                 bgcolor: 'background.level2',
                 color: 'primary.400',

--- a/src/components/admin/AuditLog.tsx
+++ b/src/components/admin/AuditLog.tsx
@@ -55,96 +55,153 @@ export const AuditLog: React.FC = () => {
       <Typography level="title-md" fontWeight={700} sx={{ color: 'text.secondary', mb: 2 }}>
         {data?.auditLogs?.length ?? 0} entries
       </Typography>
-      <Sheet
-        variant="outlined"
-        sx={{ borderRadius: 'md', overflow: 'clip', borderColor: 'var(--mn-border-vis)' }}
-      >
-        <Box sx={{ overflowX: 'auto' }}>
-          <Table
-            stickyHeader
-            sx={{
-              '--TableCell-headBackground': 'var(--mn-bg-elevated)',
-              '--TableRow-hoverBackground': 'var(--mn-bg-hover)',
-              '--TableCell-paddingY': '10px',
-              '--TableCell-paddingX': '16px',
-              minWidth: 680,
-            }}
-          >
-            <thead>
-              <tr>
-                <th style={{ ...thStyle, width: 145 }}>Time</th>
-                <th style={{ ...thStyle, width: 110 }}>Actor</th>
-                <th style={{ ...thStyle, width: 155 }}>Action</th>
-                <th style={{ ...thStyle, width: 120 }}>Target</th>
-                <th style={thStyle}>Details</th>
-                <th style={{ ...thStyle, width: 115 }}>IP</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data?.auditLogs.map((log: AuditLogEntry) => (
-                <tr key={log.id}>
-                  <td>
-                    <Typography
-                      level="body-xs"
-                      sx={{ color: 'text.secondary', fontVariantNumeric: 'tabular-nums' }}
-                    >
-                      {new Date(log.created_at).toLocaleString()}
-                    </Typography>
-                  </td>
-                  <td>
-                    <Typography
-                      level="body-sm"
-                      fontWeight={log.actor_username ? 600 : 400}
-                      sx={{ color: log.actor_username ? 'text.primary' : 'text.tertiary' }}
-                    >
-                      {log.actor_username || '—'}
-                    </Typography>
-                  </td>
-                  <td>
-                    <Chip size="sm" color={actionColor(log.action)} variant="soft">
-                      {log.action}
-                    </Chip>
-                  </td>
-                  <td>
-                    {log.target_type && log.target_id ? (
-                      <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
-                        {log.target_type}:{log.target_id}
-                      </Typography>
-                    ) : (
-                      <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
-                        —
-                      </Typography>
-                    )}
-                  </td>
-                  <td>
-                    <Typography
-                      level="body-xs"
-                      sx={{
-                        color: 'text.secondary',
-                        maxWidth: 260,
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                      }}
-                      title={log.metadata || ''}
-                    >
-                      {log.metadata || '—'}
-                    </Typography>
-                  </td>
-                  <td>
-                    <Typography
-                      level="body-xs"
-                      sx={{ color: 'text.secondary', fontFamily: 'monospace' }}
-                    >
-                      {log.ip_address || '—'}
-                    </Typography>
-                  </td>
+      {/* Desktop table */}
+      <Box sx={{ display: { xs: 'none', sm: 'block' } }}>
+        <Sheet
+          variant="outlined"
+          sx={{ borderRadius: 'md', overflow: 'clip', borderColor: 'var(--mn-border-vis)' }}
+        >
+          <Box sx={{ overflowX: 'auto' }}>
+            <Table
+              stickyHeader
+              sx={{
+                '--TableCell-headBackground': 'var(--mn-bg-elevated)',
+                '--TableRow-hoverBackground': 'var(--mn-bg-hover)',
+                '--TableCell-paddingY': '10px',
+                '--TableCell-paddingX': '16px',
+                minWidth: 680,
+              }}
+            >
+              <thead>
+                <tr>
+                  <th style={{ ...thStyle, width: 145 }}>Time</th>
+                  <th style={{ ...thStyle, width: 110 }}>Actor</th>
+                  <th style={{ ...thStyle, width: 155 }}>Action</th>
+                  <th style={{ ...thStyle, width: 120 }}>Target</th>
+                  <th style={thStyle}>Details</th>
+                  <th style={{ ...thStyle, width: 115 }}>IP</th>
                 </tr>
-              ))}
-            </tbody>
-          </Table>
-        </Box>
-      </Sheet>
+              </thead>
+              <tbody>
+                {data?.auditLogs.map((log: AuditLogEntry) => (
+                  <tr key={log.id}>
+                    <td>
+                      <Typography
+                        level="body-xs"
+                        sx={{ color: 'text.secondary', fontVariantNumeric: 'tabular-nums' }}
+                      >
+                        {new Date(log.created_at).toLocaleString()}
+                      </Typography>
+                    </td>
+                    <td>
+                      <Typography
+                        level="body-sm"
+                        fontWeight={log.actor_username ? 600 : 400}
+                        sx={{ color: log.actor_username ? 'text.primary' : 'text.tertiary' }}
+                      >
+                        {log.actor_username || '—'}
+                      </Typography>
+                    </td>
+                    <td>
+                      <Chip size="sm" color={actionColor(log.action)} variant="soft">
+                        {log.action}
+                      </Chip>
+                    </td>
+                    <td>
+                      {log.target_type && log.target_id ? (
+                        <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
+                          {log.target_type}:{log.target_id}
+                        </Typography>
+                      ) : (
+                        <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+                          —
+                        </Typography>
+                      )}
+                    </td>
+                    <td>
+                      <Typography
+                        level="body-xs"
+                        sx={{
+                          color: 'text.secondary',
+                          maxWidth: 260,
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                        title={log.metadata || ''}
+                      >
+                        {log.metadata || '—'}
+                      </Typography>
+                    </td>
+                    <td>
+                      <Typography
+                        level="body-xs"
+                        sx={{ color: 'text.secondary', fontFamily: 'monospace' }}
+                      >
+                        {log.ip_address || '—'}
+                      </Typography>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </Box>
+        </Sheet>
+      </Box>
+
+      {/* Mobile cards */}
+      <Box sx={{ display: { xs: 'block', sm: 'none' } }}>
+        {data?.auditLogs.map((log: AuditLogEntry) => (
+          <Sheet
+            key={log.id}
+            variant="outlined"
+            sx={{ borderRadius: 'md', mb: 1, p: 1.5, borderColor: 'var(--mn-border-vis)' }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexWrap: 'wrap' }}>
+              <Chip size="sm" color={actionColor(log.action)} variant="soft">
+                {log.action}
+              </Chip>
+              <Typography level="body-sm" fontWeight={600}>
+                {log.actor_username || '—'}
+              </Typography>
+            </Box>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mt: 0.5 }}>
+              {log.target_type && log.target_id ? (
+                <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
+                  {log.target_type}:{log.target_id}
+                </Typography>
+              ) : null}
+              <Typography level="body-xs" sx={{ color: 'text.tertiary', ml: 'auto' }}>
+                {new Date(log.created_at).toLocaleString()}
+              </Typography>
+            </Box>
+            {log.metadata && (
+              <Typography
+                level="body-xs"
+                sx={{
+                  color: 'text.secondary',
+                  mt: 0.5,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  display: '-webkit-box',
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: 'vertical',
+                }}
+              >
+                {log.metadata}
+              </Typography>
+            )}
+            {log.ip_address && (
+              <Typography
+                level="body-xs"
+                sx={{ color: 'text.tertiary', fontFamily: 'monospace', mt: 0.25 }}
+              >
+                {log.ip_address}
+              </Typography>
+            )}
+          </Sheet>
+        ))}
+      </Box>
     </Box>
   );
 };

--- a/src/components/admin/LoginHistory.tsx
+++ b/src/components/admin/LoginHistory.tsx
@@ -45,84 +45,138 @@ export const LoginHistory: React.FC = () => {
       <Typography level="title-md" fontWeight={700} sx={{ color: 'text.secondary', mb: 2 }}>
         {data?.loginHistory?.length ?? 0} entries
       </Typography>
-      <Sheet
-        variant="outlined"
-        sx={{ borderRadius: 'md', overflow: 'clip', borderColor: 'var(--mn-border-vis)' }}
-      >
-        <Box sx={{ overflowX: 'auto' }}>
-          <Table
-            stickyHeader
-            sx={{
-              '--TableCell-headBackground': 'var(--mn-bg-elevated)',
-              '--TableRow-hoverBackground': 'var(--mn-bg-hover)',
-              '--TableCell-paddingY': '10px',
-              '--TableCell-paddingX': '16px',
-              minWidth: 560,
-            }}
-          >
-            <thead>
-              <tr>
-                <th style={{ ...thStyle, width: 145 }}>Time</th>
-                <th style={{ ...thStyle, width: 120 }}>User</th>
-                <th style={{ ...thStyle, width: 90 }}>Result</th>
-                <th style={{ ...thStyle, width: 120 }}>IP Address</th>
-                <th style={thStyle}>User Agent</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data?.loginHistory.map((entry: LoginHistoryEntry) => (
-                <tr key={entry.id}>
-                  <td>
-                    <Typography
-                      level="body-xs"
-                      sx={{ color: 'text.secondary', fontVariantNumeric: 'tabular-nums' }}
-                    >
-                      {new Date(entry.created_at).toLocaleString()}
-                    </Typography>
-                  </td>
-                  <td>
-                    <Typography
-                      level="body-sm"
-                      fontWeight={entry.username ? 600 : 400}
-                      sx={{ color: entry.username ? 'text.primary' : 'text.tertiary' }}
-                    >
-                      {entry.username || 'unknown'}
-                    </Typography>
-                  </td>
-                  <td>
-                    <Chip size="sm" color={entry.succeeded ? 'success' : 'danger'} variant="soft">
-                      {entry.succeeded ? 'Success' : 'Failed'}
-                    </Chip>
-                  </td>
-                  <td>
-                    <Typography
-                      level="body-xs"
-                      sx={{ color: 'text.secondary', fontFamily: 'monospace' }}
-                    >
-                      {entry.ip_address || '—'}
-                    </Typography>
-                  </td>
-                  <td>
-                    <Typography
-                      level="body-xs"
-                      sx={{
-                        color: 'text.secondary',
-                        maxWidth: 300,
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                      }}
-                      title={entry.user_agent || ''}
-                    >
-                      {entry.user_agent || '—'}
-                    </Typography>
-                  </td>
+      {/* Desktop table */}
+      <Box sx={{ display: { xs: 'none', sm: 'block' } }}>
+        <Sheet
+          variant="outlined"
+          sx={{ borderRadius: 'md', overflow: 'clip', borderColor: 'var(--mn-border-vis)' }}
+        >
+          <Box sx={{ overflowX: 'auto' }}>
+            <Table
+              stickyHeader
+              sx={{
+                '--TableCell-headBackground': 'var(--mn-bg-elevated)',
+                '--TableRow-hoverBackground': 'var(--mn-bg-hover)',
+                '--TableCell-paddingY': '10px',
+                '--TableCell-paddingX': '16px',
+                minWidth: 560,
+              }}
+            >
+              <thead>
+                <tr>
+                  <th style={{ ...thStyle, width: 145 }}>Time</th>
+                  <th style={{ ...thStyle, width: 120 }}>User</th>
+                  <th style={{ ...thStyle, width: 90 }}>Result</th>
+                  <th style={{ ...thStyle, width: 120 }}>IP Address</th>
+                  <th style={thStyle}>User Agent</th>
                 </tr>
-              ))}
-            </tbody>
-          </Table>
-        </Box>
-      </Sheet>
+              </thead>
+              <tbody>
+                {data?.loginHistory.map((entry: LoginHistoryEntry) => (
+                  <tr key={entry.id}>
+                    <td>
+                      <Typography
+                        level="body-xs"
+                        sx={{ color: 'text.secondary', fontVariantNumeric: 'tabular-nums' }}
+                      >
+                        {new Date(entry.created_at).toLocaleString()}
+                      </Typography>
+                    </td>
+                    <td>
+                      <Typography
+                        level="body-sm"
+                        fontWeight={entry.username ? 600 : 400}
+                        sx={{ color: entry.username ? 'text.primary' : 'text.tertiary' }}
+                      >
+                        {entry.username || 'unknown'}
+                      </Typography>
+                    </td>
+                    <td>
+                      <Chip size="sm" color={entry.succeeded ? 'success' : 'danger'} variant="soft">
+                        {entry.succeeded ? 'Success' : 'Failed'}
+                      </Chip>
+                    </td>
+                    <td>
+                      <Typography
+                        level="body-xs"
+                        sx={{ color: 'text.secondary', fontFamily: 'monospace' }}
+                      >
+                        {entry.ip_address || '—'}
+                      </Typography>
+                    </td>
+                    <td>
+                      <Typography
+                        level="body-xs"
+                        sx={{
+                          color: 'text.secondary',
+                          maxWidth: 300,
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                        title={entry.user_agent || ''}
+                      >
+                        {entry.user_agent || '—'}
+                      </Typography>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </Box>
+        </Sheet>
+      </Box>
+
+      {/* Mobile cards */}
+      <Box sx={{ display: { xs: 'block', sm: 'none' } }}>
+        {data?.loginHistory.map((entry: LoginHistoryEntry) => (
+          <Sheet
+            key={entry.id}
+            variant="outlined"
+            sx={{ borderRadius: 'md', mb: 1, p: 1.5, borderColor: 'var(--mn-border-vis)' }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+              <Typography
+                level="body-sm"
+                fontWeight={entry.username ? 600 : 400}
+                sx={{ color: entry.username ? 'text.primary' : 'text.tertiary' }}
+              >
+                {entry.username || 'unknown'}
+              </Typography>
+              <Chip size="sm" color={entry.succeeded ? 'success' : 'danger'} variant="soft">
+                {entry.succeeded ? 'Success' : 'Failed'}
+              </Chip>
+              <Typography level="body-xs" sx={{ color: 'text.tertiary', ml: 'auto' }}>
+                {new Date(entry.created_at).toLocaleString()}
+              </Typography>
+            </Box>
+            <Box sx={{ mt: 0.5 }}>
+              {entry.ip_address && (
+                <Typography
+                  level="body-xs"
+                  sx={{ color: 'text.secondary', fontFamily: 'monospace' }}
+                >
+                  {entry.ip_address}
+                </Typography>
+              )}
+              {entry.user_agent && (
+                <Typography
+                  level="body-xs"
+                  sx={{
+                    color: 'text.tertiary',
+                    mt: 0.25,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {entry.user_agent}
+                </Typography>
+              )}
+            </Box>
+          </Sheet>
+        ))}
+      </Box>
     </Box>
   );
 };

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -181,123 +181,211 @@ export const UserManagement: React.FC = () => {
         </Button>
       </Box>
 
-      <Sheet
-        variant="outlined"
-        sx={{ borderRadius: 'md', overflow: 'clip', borderColor: 'var(--mn-border-vis)' }}
-      >
-        <Box sx={{ overflowX: 'auto' }}>
-          <Table
-            stickyHeader
-            sx={{
-              '--TableCell-headBackground': 'var(--mn-bg-elevated)',
-              '--TableRow-hoverBackground': 'var(--mn-bg-hover)',
-              '--TableCell-paddingY': '12px',
-              '--TableCell-paddingX': '16px',
-              minWidth: 720,
-            }}
-          >
-            <thead>
-              <tr>
-                <th style={{ ...thStyle, width: 44 }} />
-                <th style={thStyle}>Username</th>
-                <th style={thStyle}>Display Name</th>
-                <th style={thStyle}>Email</th>
-                <th style={{ ...thStyle, width: 70 }}>Admin</th>
-                <th style={{ ...thStyle, width: 100 }}>Status</th>
-                <th style={{ ...thStyle, width: 110 }}>Last Login</th>
-                <th style={{ ...thStyle, width: 100 }}>Created</th>
-                <th style={{ ...thStyle, width: 110, textAlign: 'right' }}>Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data?.users.map((user: User) => (
-                <tr key={user.id}>
-                  <td style={{ paddingLeft: 16 }}>
-                    <img
-                      src={getGravatarUrl(user.email, 28)}
-                      alt=""
-                      style={{
-                        width: 28,
-                        height: 28,
-                        borderRadius: '50%',
-                        display: 'block',
-                        border: '2px solid rgba(245,197,24,0.2)',
-                      }}
-                    />
-                  </td>
-                  <td>
-                    <Typography level="body-sm" fontWeight={600}>
-                      {user.username}
-                    </Typography>
-                  </td>
-                  <td>
-                    {user.display_name ? (
-                      <Typography level="body-sm">{user.display_name}</Typography>
-                    ) : (
-                      <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
-                        —
-                      </Typography>
-                    )}
-                  </td>
-                  <td>
-                    <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
-                      {user.email}
-                    </Typography>
-                  </td>
-                  <td>
-                    {user.is_admin && (
-                      <Chip size="sm" color="warning" variant="soft">
-                        Admin
-                      </Chip>
-                    )}
-                  </td>
-                  <td>
-                    <Chip size="sm" color={user.is_active ? 'success' : 'neutral'} variant="soft">
-                      {user.is_active ? 'Active' : 'Suspended'}
-                    </Chip>
-                  </td>
-                  <td>
-                    <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
-                      {user.last_login_at ? new Date(user.last_login_at).toLocaleDateString() : '—'}
-                    </Typography>
-                  </td>
-                  <td>
-                    <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
-                      {new Date(user.created_at!).toLocaleDateString()}
-                    </Typography>
-                  </td>
-                  <td>
-                    <Box sx={{ display: 'flex', gap: 0.5, justifyContent: 'flex-end', pr: 1 }}>
-                      <Button
-                        size="sm"
-                        variant="soft"
-                        color="neutral"
-                        onClick={() => handleOpen(user)}
-                      >
-                        Edit
-                      </Button>
-                      <IconButton
-                        size="sm"
-                        variant="plain"
-                        color="danger"
-                        onClick={() => handleDelete(user.id)}
-                        sx={{ opacity: 0.5, '&:hover': { opacity: 1 } }}
-                      >
-                        ✕
-                      </IconButton>
-                    </Box>
-                  </td>
+      {/* Desktop table */}
+      <Box sx={{ display: { xs: 'none', sm: 'block' } }}>
+        <Sheet
+          variant="outlined"
+          sx={{ borderRadius: 'md', overflow: 'clip', borderColor: 'var(--mn-border-vis)' }}
+        >
+          <Box sx={{ overflowX: 'auto' }}>
+            <Table
+              stickyHeader
+              sx={{
+                '--TableCell-headBackground': 'var(--mn-bg-elevated)',
+                '--TableRow-hoverBackground': 'var(--mn-bg-hover)',
+                '--TableCell-paddingY': '12px',
+                '--TableCell-paddingX': '16px',
+                minWidth: 720,
+              }}
+            >
+              <thead>
+                <tr>
+                  <th style={{ ...thStyle, width: 44 }} />
+                  <th style={thStyle}>Username</th>
+                  <th style={thStyle}>Display Name</th>
+                  <th style={thStyle}>Email</th>
+                  <th style={{ ...thStyle, width: 70 }}>Admin</th>
+                  <th style={{ ...thStyle, width: 100 }}>Status</th>
+                  <th style={{ ...thStyle, width: 110 }}>Last Login</th>
+                  <th style={{ ...thStyle, width: 100 }}>Created</th>
+                  <th style={{ ...thStyle, width: 110, textAlign: 'right' }}>Actions</th>
                 </tr>
-              ))}
-            </tbody>
-          </Table>
-        </Box>
-      </Sheet>
+              </thead>
+              <tbody>
+                {data?.users.map((user: User) => (
+                  <tr key={user.id}>
+                    <td style={{ paddingLeft: 16 }}>
+                      <img
+                        src={getGravatarUrl(user.email, 28)}
+                        alt=""
+                        style={{
+                          width: 28,
+                          height: 28,
+                          borderRadius: '50%',
+                          display: 'block',
+                          border: '2px solid rgba(245,197,24,0.2)',
+                        }}
+                      />
+                    </td>
+                    <td>
+                      <Typography level="body-sm" fontWeight={600}>
+                        {user.username}
+                      </Typography>
+                    </td>
+                    <td>
+                      {user.display_name ? (
+                        <Typography level="body-sm">{user.display_name}</Typography>
+                      ) : (
+                        <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+                          —
+                        </Typography>
+                      )}
+                    </td>
+                    <td>
+                      <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
+                        {user.email}
+                      </Typography>
+                    </td>
+                    <td>
+                      {user.is_admin && (
+                        <Chip size="sm" color="warning" variant="soft">
+                          Admin
+                        </Chip>
+                      )}
+                    </td>
+                    <td>
+                      <Chip size="sm" color={user.is_active ? 'success' : 'neutral'} variant="soft">
+                        {user.is_active ? 'Active' : 'Suspended'}
+                      </Chip>
+                    </td>
+                    <td>
+                      <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
+                        {user.last_login_at
+                          ? new Date(user.last_login_at).toLocaleDateString()
+                          : '—'}
+                      </Typography>
+                    </td>
+                    <td>
+                      <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
+                        {new Date(user.created_at!).toLocaleDateString()}
+                      </Typography>
+                    </td>
+                    <td>
+                      <Box sx={{ display: 'flex', gap: 0.5, justifyContent: 'flex-end', pr: 1 }}>
+                        <Button
+                          size="sm"
+                          variant="soft"
+                          color="neutral"
+                          onClick={() => handleOpen(user)}
+                        >
+                          Edit
+                        </Button>
+                        <IconButton
+                          size="sm"
+                          variant="plain"
+                          color="danger"
+                          onClick={() => handleDelete(user.id)}
+                          sx={{ opacity: 0.5, '&:hover': { opacity: 1 } }}
+                        >
+                          ✕
+                        </IconButton>
+                      </Box>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </Box>
+        </Sheet>
+      </Box>
+
+      {/* Mobile cards */}
+      <Box sx={{ display: { xs: 'block', sm: 'none' } }}>
+        {data?.users.map((user: User) => (
+          <Sheet
+            key={user.id}
+            variant="outlined"
+            sx={{ borderRadius: 'md', mb: 1, p: 1.5, borderColor: 'var(--mn-border-vis)' }}
+          >
+            <Box sx={{ display: 'flex', gap: 1.5 }}>
+              <img
+                src={getGravatarUrl(user.email, 32)}
+                alt=""
+                style={{
+                  width: 32,
+                  height: 32,
+                  borderRadius: '50%',
+                  flexShrink: 0,
+                  border: '2px solid rgba(245,197,24,0.2)',
+                }}
+              />
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap' }}>
+                  <Typography level="body-sm" fontWeight={600}>
+                    {user.username}
+                  </Typography>
+                  {user.is_admin && (
+                    <Chip size="sm" color="warning" variant="soft">
+                      Admin
+                    </Chip>
+                  )}
+                  <Chip size="sm" color={user.is_active ? 'success' : 'neutral'} variant="soft">
+                    {user.is_active ? 'Active' : 'Suspended'}
+                  </Chip>
+                </Box>
+                {user.display_name && user.display_name !== user.username && (
+                  <Typography level="body-xs" sx={{ color: 'text.secondary', mt: 0.25 }}>
+                    {user.display_name}
+                  </Typography>
+                )}
+                <Typography level="body-xs" sx={{ color: 'text.tertiary', mt: 0.25 }}>
+                  {user.email}
+                </Typography>
+                <Typography level="body-xs" sx={{ color: 'text.tertiary', mt: 0.25 }}>
+                  Last login:{' '}
+                  {user.last_login_at ? new Date(user.last_login_at).toLocaleDateString() : 'Never'}
+                  {' · '}Created: {new Date(user.created_at!).toLocaleDateString()}
+                </Typography>
+              </Box>
+            </Box>
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'flex-end',
+                gap: 0.5,
+                mt: 1,
+                pt: 0.5,
+                borderTop: '1px solid',
+                borderColor: 'var(--mn-border)',
+              }}
+            >
+              <Button
+                size="sm"
+                variant="soft"
+                color="neutral"
+                onClick={() => handleOpen(user)}
+                sx={{ minHeight: 44 }}
+              >
+                Edit
+              </Button>
+              <IconButton
+                size="sm"
+                variant="soft"
+                color="danger"
+                onClick={() => handleDelete(user.id)}
+                sx={{ minWidth: 44, minHeight: 44 }}
+              >
+                ✕
+              </IconButton>
+            </Box>
+          </Sheet>
+        ))}
+      </Box>
 
       <Modal open={open} onClose={handleClose}>
         <ModalDialog
           sx={{
-            minWidth: 420,
+            width: { xs: '92vw', sm: 420 },
             maxWidth: '95vw',
             bgcolor: 'background.level1',
             borderColor: 'var(--mn-border-vis)',


### PR DESCRIPTION
## Summary
- Admin tables (Users, Audit Log, Login History) show card layouts on mobile (<600px) instead of horizontal-scrolling tables
- Tab bar scrolls horizontally with hidden scrollbar so all 5 tabs remain accessible on narrow screens
- User edit/create modal uses responsive width (`92vw` on mobile, `420px` on desktop)
- Touch targets on user card actions sized to 44px minimum

## Test plan
- [ ] Resize browser to <600px or use DevTools mobile viewport
- [ ] Verify all 5 admin tabs are reachable via horizontal scroll
- [ ] Users tab: cards show avatar, name, badges, dates, Edit/Delete actions
- [ ] Audit Log tab: cards show color-coded action chips, actor, timestamp, metadata
- [ ] Login History tab: cards show user, result chip, IP, user agent
- [ ] Desktop (>600px): tables render exactly as before (no visual regression)
- [ ] User edit/create modal fits on phone screen without overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)