### PR TITLE
feat: explainer callouts + rename Solo Queue to Watch Alone

### DIFF
--- a/src/components/home/Homepage.tsx
+++ b/src/components/home/Homepage.tsx
@@ -490,6 +490,11 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
         {/* Combined view */}
         {isCombinedView && (
           <>
+            <Typography level="body-sm" sx={{ textAlign: 'center', color: 'neutral.400', mb: 2 }}>
+              Movies ranked by combining both your This or That picks. The more you each compare,
+              the better the ranking.
+            </Typography>
+
             {combinedLoading && (
               <Box sx={{ textAlign: 'center', py: 4 }}>
                 <CircularProgress size="sm" />
@@ -499,130 +504,169 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
               <>
                 {combinedData.combinedList.rankings.length === 0 ? (
                   <Box sx={{ textAlign: 'center', py: 6 }}>
-                    <Typography level="body-md" sx={{ color: 'text.secondary' }}>
+                    <Typography level="body-md" sx={{ color: 'text.secondary', mb: 2 }}>
                       No rankings to combine yet. Both users need to do some "This or That"
                       comparisons first!
                     </Typography>
+                    {onShowThisOrThat && (
+                      <Button variant="soft" color="primary" size="sm" onClick={onShowThisOrThat}>
+                        Start comparing
+                      </Button>
+                    )}
                   </Box>
                 ) : (
-                  <Sheet
-                    variant="outlined"
-                    sx={{
-                      borderRadius: 'md',
-                      overflow: 'clip',
-                      borderColor: 'var(--mn-border-vis)',
-                    }}
-                  >
-                    <Box sx={{ overflowX: 'auto' }}>
-                      <table
-                        style={{
-                          width: '100%',
-                          minWidth: 360,
-                          borderCollapse: 'collapse',
-                          tableLayout: 'auto',
-                        }}
-                      >
-                        <thead>
-                          <tr
-                            style={{
-                              background: 'var(--mn-bg-elevated)',
-                              borderBottom: '1px solid var(--mn-border-vis)',
-                            }}
-                          >
-                            <th style={combinedThStyle}>#</th>
-                            <th style={{ ...combinedThStyle, textAlign: 'left' }}>Title</th>
-                            <th style={combinedThStyle}>You</th>
-                            <th style={combinedThStyle}>
-                              {combinedData.combinedList.connection.user.display_name ||
-                                combinedData.combinedList.connection.user.username}
-                            </th>
-                            <th style={combinedThStyle}>Combined</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {combinedData.combinedList.rankings.map((r: any, idx: number) => (
-                            <tr key={r.movie.id}>
-                              <td style={{ ...combinedTdStyle, textAlign: 'center', width: 48 }}>
-                                <Typography
-                                  level="body-xs"
-                                  sx={{
-                                    fontWeight: 700,
-                                    color: idx < 3 ? 'primary.400' : 'text.tertiary',
-                                  }}
-                                >
-                                  {idx + 1}
-                                </Typography>
-                              </td>
-                              <td style={combinedTdStyle}>
-                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                                  <Typography level="body-sm" sx={{ fontWeight: 600 }}>
-                                    {r.movie.title}
-                                  </Typography>
-                                  {!r.bothRated && (
-                                    <Tooltip
-                                      title="Only one of you has ranked this movie in This or That"
-                                      arrow
-                                    >
-                                      <Chip size="sm" variant="soft" color="neutral">
-                                        Needs ranking
-                                      </Chip>
-                                    </Tooltip>
-                                  )}
-                                </Box>
-                              </td>
-                              <td style={{ ...combinedTdStyle, textAlign: 'center' }}>
-                                {r.userAElo != null ? (
-                                  <Chip
-                                    size="sm"
-                                    variant="soft"
-                                    color={r.userAElo >= 1000 ? 'success' : 'warning'}
-                                  >
-                                    {Math.round(r.userAElo)}
-                                  </Chip>
-                                ) : (
-                                  <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
-                                    --
-                                  </Typography>
-                                )}
-                              </td>
-                              <td style={{ ...combinedTdStyle, textAlign: 'center' }}>
-                                {r.userBElo != null ? (
-                                  <Chip
-                                    size="sm"
-                                    variant="soft"
-                                    color={r.userBElo >= 1000 ? 'success' : 'warning'}
-                                  >
-                                    {Math.round(r.userBElo)}
-                                  </Chip>
-                                ) : (
-                                  <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
-                                    --
-                                  </Typography>
-                                )}
-                              </td>
-                              <td style={{ ...combinedTdStyle, textAlign: 'center' }}>
-                                <Chip size="sm" variant="solid" color="primary">
-                                  {Math.round(r.combinedElo)}
-                                </Chip>
-                              </td>
+                  <>
+                    <Sheet
+                      variant="outlined"
+                      sx={{
+                        borderRadius: 'md',
+                        overflow: 'clip',
+                        borderColor: 'var(--mn-border-vis)',
+                      }}
+                    >
+                      <Box sx={{ overflowX: 'auto' }}>
+                        <table
+                          style={{
+                            width: '100%',
+                            minWidth: 360,
+                            borderCollapse: 'collapse',
+                            tableLayout: 'auto',
+                          }}
+                        >
+                          <thead>
+                            <tr
+                              style={{
+                                background: 'var(--mn-bg-elevated)',
+                                borderBottom: '1px solid var(--mn-border-vis)',
+                              }}
+                            >
+                              <th style={combinedThStyle}>#</th>
+                              <th style={{ ...combinedThStyle, textAlign: 'left' }}>Title</th>
+                              <th style={combinedThStyle}>You</th>
+                              <th style={combinedThStyle}>
+                                {combinedData.combinedList.connection.user.display_name ||
+                                  combinedData.combinedList.connection.user.username}
+                              </th>
+                              <th style={combinedThStyle}>Combined</th>
                             </tr>
-                          ))}
-                        </tbody>
-                      </table>
-                    </Box>
-                  </Sheet>
+                          </thead>
+                          <tbody>
+                            {combinedData.combinedList.rankings.map((r: any, idx: number) => (
+                              <tr key={r.movie.id}>
+                                <td style={{ ...combinedTdStyle, textAlign: 'center', width: 48 }}>
+                                  <Typography
+                                    level="body-xs"
+                                    sx={{
+                                      fontWeight: 700,
+                                      color: idx < 3 ? 'primary.400' : 'text.tertiary',
+                                    }}
+                                  >
+                                    {idx + 1}
+                                  </Typography>
+                                </td>
+                                <td style={combinedTdStyle}>
+                                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    <Typography level="body-sm" sx={{ fontWeight: 600 }}>
+                                      {r.movie.title}
+                                    </Typography>
+                                    {!r.bothRated && (
+                                      <Tooltip
+                                        title="Only one of you has ranked this movie in This or That"
+                                        arrow
+                                      >
+                                        <Chip size="sm" variant="soft" color="neutral">
+                                          Needs ranking
+                                        </Chip>
+                                      </Tooltip>
+                                    )}
+                                  </Box>
+                                </td>
+                                <td style={{ ...combinedTdStyle, textAlign: 'center' }}>
+                                  {r.userAElo != null ? (
+                                    <Chip
+                                      size="sm"
+                                      variant="soft"
+                                      color={r.userAElo >= 1000 ? 'success' : 'warning'}
+                                    >
+                                      {Math.round(r.userAElo)}
+                                    </Chip>
+                                  ) : (
+                                    <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+                                      --
+                                    </Typography>
+                                  )}
+                                </td>
+                                <td style={{ ...combinedTdStyle, textAlign: 'center' }}>
+                                  {r.userBElo != null ? (
+                                    <Chip
+                                      size="sm"
+                                      variant="soft"
+                                      color={r.userBElo >= 1000 ? 'success' : 'warning'}
+                                    >
+                                      {Math.round(r.userBElo)}
+                                    </Chip>
+                                  ) : (
+                                    <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+                                      --
+                                    </Typography>
+                                  )}
+                                </td>
+                                <td style={{ ...combinedTdStyle, textAlign: 'center' }}>
+                                  <Chip size="sm" variant="solid" color="primary">
+                                    {Math.round(r.combinedElo)}
+                                  </Chip>
+                                </td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </Box>
+                    </Sheet>
+
+                    {/* Sparse data CTA */}
+                    {(() => {
+                      const rankings = combinedData.combinedList.rankings;
+                      const needsRanking = rankings.filter((r: any) => !r.bothRated).length;
+                      return needsRanking > rankings.length / 2 ? (
+                        <Sheet
+                          variant="soft"
+                          color="warning"
+                          sx={{
+                            mt: 2,
+                            p: 2,
+                            borderRadius: 'md',
+                            textAlign: 'center',
+                          }}
+                        >
+                          <Typography level="body-sm" sx={{ fontWeight: 600, mb: 1 }}>
+                            Rankings work best when you've both compared more movies
+                          </Typography>
+                          {onShowThisOrThat && (
+                            <Button
+                              variant="soft"
+                              color="primary"
+                              size="sm"
+                              onClick={onShowThisOrThat}
+                            >
+                              Go to This or That
+                            </Button>
+                          )}
+                        </Sheet>
+                      ) : null;
+                    })()}
+                  </>
                 )}
               </>
             )}
           </>
         )}
 
-        {/* Solo Queue view */}
+        {/* Watch Alone view */}
         {isSoloView && (
           <>
             <Box sx={{ textAlign: 'center', mb: 3 }}>
               <Typography level="body-sm" sx={{ color: 'text.tertiary' }}>
-                Your connections passed on these — watch them on your own!
+                Movies your connections passed on — these are all yours to watch solo!
               </Typography>
             </Box>
 

--- a/src/components/home/ThisOrThat.tsx
+++ b/src/components/home/ThisOrThat.tsx
@@ -177,8 +177,9 @@ const ThisOrThat: React.FC = () => {
           >
             This or That
           </Typography>
-          <Typography level="body-xs" sx={{ color: 'text.secondary', mb: { xs: 1, sm: 1.5 } }}>
-            Pick which movie you'd rather watch
+          <Typography level="body-sm" sx={{ color: 'neutral.400', mb: { xs: 1, sm: 1.5 } }}>
+            Pick which movie you'd rather watch. Your choices build a personal ranking that combines
+            with your connections' picks.
           </Typography>
         </Box>
 
@@ -324,6 +325,14 @@ const ThisOrThat: React.FC = () => {
 
         {tab === 'rankings' && (
           <>
+            <Typography
+              level="body-sm"
+              sx={{ textAlign: 'center', color: 'neutral.400', mb: { xs: 1.5, sm: 2 } }}
+            >
+              Your personal ranking based on your This or That picks. Connect with friends to
+              combine rankings.
+            </Typography>
+
             {rankingsLoading && (
               <Box sx={{ textAlign: 'center', py: 4 }}>
                 <Typography level="body-sm" sx={{ color: 'text.secondary' }}>

--- a/src/components/home/ViewSelector.tsx
+++ b/src/components/home/ViewSelector.tsx
@@ -60,7 +60,7 @@ const ViewSelector: React.FC<ViewSelectorProps> = ({
             '&:hover': { color: 'primary.300' },
           }}
         >
-          Solo Queue
+          Watch Alone
         </Button>
       )}
       <Button


### PR DESCRIPTION
## Summary
- Add persistent explainer subtitles to This or That (Compare & My Rankings tabs) and Combined view so new users understand how features connect
- Add sparse-data CTA banner in Combined view when >50% of movies show "Needs ranking," with a link to This or That
- Add "Start comparing" button to the Combined view empty state
- Rename "Solo Queue" tab to "Watch Alone" with friendlier description text

## Test plan
- [ ] Verify This or That Compare tab shows subtitle about building personal rankings
- [ ] Verify My Rankings tab shows subtitle about connecting with friends
- [ ] Verify Combined view (e.g. "Keenan + Me") shows subtitle about combined picks
- [ ] Verify sparse-data CTA banner appears when >50% of combined movies need ranking
- [ ] Verify empty combined state shows "Start comparing" button that navigates to This or That
- [ ] Verify "Solo Queue" tab now reads "Watch Alone" with updated description
- [ ] All frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)