### PR TITLE
feat: onboarding guide with persistent help icon

### DIFF
--- a/src/components/common/Navbar.tsx
+++ b/src/components/common/Navbar.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Box, Button, Typography, IconButton, Divider } from '@mui/joy';
 import { useAuth } from '../../contexts/AuthContext';
 import { getGravatarUrl } from '../../utils/gravatar';
+import { OnboardingModal } from './OnboardingGuide';
 
 type ViewName = 'movies' | 'this-or-that' | 'combined-list' | 'history' | 'admin';
 
@@ -26,6 +27,7 @@ export const Navbar: React.FC<NavbarProps> = ({
 }) => {
   const { isAuthenticated, user, logout } = useAuth();
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [helpOpen, setHelpOpen] = useState(false);
 
   const navItems = (
     <>
@@ -201,6 +203,21 @@ export const Navbar: React.FC<NavbarProps> = ({
                   </Typography>
                 </Box>
               </Box>
+              <IconButton
+                variant="plain"
+                color="neutral"
+                size="sm"
+                aria-label="How MovieNight works"
+                onClick={() => setHelpOpen(true)}
+                sx={{
+                  fontWeight: 800,
+                  fontSize: '1rem',
+                  color: 'text.secondary',
+                  '&:hover': { color: 'primary.300' },
+                }}
+              >
+                ?
+              </IconButton>
               <Button
                 variant="outlined"
                 color="neutral"
@@ -239,6 +256,8 @@ export const Navbar: React.FC<NavbarProps> = ({
           </IconButton>
         </Box>
       </Box>
+
+      <OnboardingModal open={helpOpen} onClose={() => setHelpOpen(false)} />
 
       {/* Mobile drawer */}
       {mobileOpen && (

--- a/src/components/common/OnboardingGuide.tsx
+++ b/src/components/common/OnboardingGuide.tsx
@@ -1,0 +1,196 @@
+import React from 'react';
+import {
+  Box,
+  Button,
+  Divider,
+  IconButton,
+  Modal,
+  ModalClose,
+  ModalDialog,
+  Sheet,
+  Typography,
+} from '@mui/joy';
+
+export const ONBOARDING_DISMISSED_KEY = 'onboarding_dismissed';
+
+interface Step {
+  emoji: string;
+  title: string;
+  description: string;
+}
+
+const STEPS: Step[] = [
+  {
+    emoji: '🎬',
+    title: 'Suggest',
+    description: 'Add movies you want to watch.',
+  },
+  {
+    emoji: '🤝',
+    title: 'Connect',
+    description: "Link up with friends. They'll see your picks and you'll see theirs.",
+  },
+  {
+    emoji: '⚖️',
+    title: 'Rank',
+    description: 'Compare movies in This or That to build your preference list.',
+  },
+  {
+    emoji: '🍿',
+    title: 'Watch',
+    description: 'The top-ranked movie you both agree on wins.',
+  },
+];
+
+const StepList: React.FC = () => (
+  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+    {STEPS.map((s, i) => (
+      <Box key={s.title} sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5 }}>
+        <Box
+          sx={{
+            fontSize: '1.5rem',
+            lineHeight: 1.2,
+            flexShrink: 0,
+            width: 28,
+            textAlign: 'center',
+          }}
+          aria-hidden
+        >
+          {s.emoji}
+        </Box>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography level="title-sm" sx={{ fontWeight: 700 }}>
+            {i + 1}. {s.title}
+          </Typography>
+          <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
+            {s.description}
+          </Typography>
+        </Box>
+      </Box>
+    ))}
+  </Box>
+);
+
+const ExtraTips: React.FC = () => (
+  <Box>
+    <Typography
+      level="body-xs"
+      sx={{
+        textTransform: 'uppercase',
+        letterSpacing: '0.08em',
+        fontWeight: 700,
+        color: 'text.tertiary',
+        mb: 1,
+      }}
+    >
+      A few extras
+    </Typography>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+      <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
+        <Typography component="span" sx={{ fontWeight: 700 }}>
+          Watch Alone
+        </Typography>{' '}
+        — movies your connections passed on, all yours to enjoy solo.
+      </Typography>
+      <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
+        <Typography component="span" sx={{ fontWeight: 700 }}>
+          History
+        </Typography>{' '}
+        — everything you've already watched.
+      </Typography>
+      <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
+        Tap the{' '}
+        <Typography component="span" sx={{ fontWeight: 700 }}>
+          ?
+        </Typography>{' '}
+        in the header any time to revisit this.
+      </Typography>
+    </Box>
+  </Box>
+);
+
+interface OnboardingCardProps {
+  onDismiss: () => void;
+}
+
+export const OnboardingCard: React.FC<OnboardingCardProps> = ({ onDismiss }) => (
+  <Sheet
+    variant="outlined"
+    sx={{
+      mb: 3,
+      p: { xs: 2, sm: 2.5 },
+      borderRadius: 'md',
+      bgcolor: 'primary.softBg',
+      borderColor: 'primary.outlinedBorder',
+      position: 'relative',
+    }}
+  >
+    <IconButton
+      variant="plain"
+      color="neutral"
+      size="sm"
+      aria-label="Dismiss welcome card"
+      onClick={onDismiss}
+      sx={{
+        position: 'absolute',
+        top: 6,
+        right: 6,
+        opacity: 0.5,
+        '&:hover': { opacity: 1 },
+      }}
+    >
+      ✕
+    </IconButton>
+    <Typography
+      level="title-md"
+      sx={{ fontWeight: 800, mb: 0.5, color: 'primary.softColor', pr: 4 }}
+    >
+      Welcome to MovieNight
+    </Typography>
+    <Typography level="body-sm" sx={{ color: 'text.secondary', mb: 2 }}>
+      Here's how it works:
+    </Typography>
+    <StepList />
+    <Box sx={{ mt: 2.5, display: 'flex', justifyContent: 'flex-end' }}>
+      <Button
+        variant="solid"
+        color="primary"
+        size="sm"
+        onClick={onDismiss}
+        sx={{ fontWeight: 700, color: '#0d0f1a' }}
+      >
+        Got it
+      </Button>
+    </Box>
+  </Sheet>
+);
+
+interface OnboardingModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export const OnboardingModal: React.FC<OnboardingModalProps> = ({ open, onClose }) => (
+  <Modal open={open} onClose={onClose}>
+    <ModalDialog
+      sx={{
+        maxWidth: 460,
+        width: '100%',
+        p: 3,
+        bgcolor: 'background.level1',
+        borderColor: 'var(--mn-border-vis)',
+      }}
+    >
+      <ModalClose />
+      <Typography level="title-lg" sx={{ fontWeight: 800, mb: 0.5 }}>
+        How MovieNight works
+      </Typography>
+      <Typography level="body-sm" sx={{ color: 'text.secondary', mb: 2 }}>
+        The four-step loop:
+      </Typography>
+      <StepList />
+      <Divider sx={{ my: 2.5 }} />
+      <ExtraTips />
+    </ModalDialog>
+  </Modal>
+);

--- a/src/components/home/Homepage.tsx
+++ b/src/components/home/Homepage.tsx
@@ -35,6 +35,7 @@ import ViewSelector from './ViewSelector';
 import ConnectionBanners from './ConnectionBanners';
 import ThisOrThatBanner from './ThisOrThatBanner';
 import ConfirmDialog from '../common/ConfirmDialog';
+import { OnboardingCard, ONBOARDING_DISMISSED_KEY } from '../common/OnboardingGuide';
 import { Movie } from '../../models/Movies';
 import { useAuth } from '../../contexts/AuthContext';
 import { useToast } from '../../contexts/ToastContext';
@@ -57,6 +58,15 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
   const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
   const [askSeenMovieId, setAskSeenMovieId] = useState<string | null>(null);
   const [recentlyAddedIds, setRecentlyAddedIds] = useState<string[]>([]);
+  const [onboardingDismissed, setOnboardingDismissed] = useState(
+    () =>
+      typeof window !== 'undefined' && localStorage.getItem(ONBOARDING_DISMISSED_KEY) === 'true',
+  );
+
+  const handleDismissOnboarding = useCallback(() => {
+    localStorage.setItem(ONBOARDING_DISMISSED_KEY, 'true');
+    setOnboardingDismissed(true);
+  }, []);
 
   const handleMovieAdded = useCallback((id: string) => {
     setRecentlyAddedIds((prev) => [id, ...prev]);
@@ -147,6 +157,15 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
 
   // Check if the current user has any personal Elo data
   const hasEloData = isAuthenticated && allMovies.some((m) => m.elo_rank != null);
+
+  // First-login onboarding: show until dismissed, and only when the user looks new
+  // (no suggestions of their own and no ranking activity yet)
+  const userHasSuggestedMovie =
+    isAuthenticated && user
+      ? allMovies.some((m) => String(m.requested_by) === String(user.id))
+      : false;
+  const showOnboardingCard =
+    isAuthenticated && !onboardingDismissed && !userHasSuggestedMovie && !hasEloData;
 
   // "My Suggestions" view: only movies the current user suggested
   const isMySuggestionsView = !isCombinedView && !isSoloView;
@@ -305,6 +324,9 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
             onSetSeenTag={handleSetSeenTag}
           />
         )}
+
+        {/* First-login onboarding card */}
+        {showOnboardingCard && <OnboardingCard onDismiss={handleDismissOnboarding} />}
 
         {/* Add movie form */}
         {isAuthenticated && <AddMovieForm onMovieAdded={handleMovieAdded} />}


### PR DESCRIPTION
## Summary
- New `OnboardingGuide.tsx` exporting a dismissible welcome `OnboardingCard` and a reopenable `OnboardingModal`, both showing the Suggest → Connect → Rank → Watch loop with emoji step icons.
- Navbar gains a `?` `IconButton` (authenticated only, both mobile & desktop) that opens the modal — modal version adds extras for Watch Alone, History, and a hint about the help button.
- Homepage shows the card between `ConnectionBanners` and `AddMovieForm` when the user is authenticated, hasn't dismissed it (localStorage `onboarding_dismissed`), has suggested zero movies, and has no Elo data.

## Test plan
- [x] Prettier check clean on all three modified/new files
- [x] `tsc --noEmit` passes
- [x] Frontend test suite (23 tests) passes
- [ ] Manual: log in as a fresh user → card appears above the movie list; clicking ✕ or "Got it" hides it and survives reload
- [ ] Manual: existing user (with suggestions or Elo data) does NOT see the card on first load
- [ ] Manual: `?` icon in header opens the modal at any time, including after dismissal
- [ ] Manual: modal closes via `ModalClose`, escape, or backdrop click; mobile layout looks right

🤖 Generated with [Claude Code](https://claude.com/claude-code)