### PR TITLE
fix: stop posters blanking when responding in connection inbox

### DIFF
--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -462,7 +462,7 @@ export const resolvers = {
 
       const result = await pool.query(
         `SELECT m.id, m.title, m.requested_by, m.date_submitted, m.rank, m.tmdb_id, m.watched_at,
-                m.elo_rank,
+                m.elo_rank, m.poster_path,
                 u.username AS user_username, u.display_name AS user_display_name,
                 ume.elo_rating, ume.comparison_count
          FROM user_movie_elo ume
@@ -568,7 +568,7 @@ export const resolvers = {
 
       const result = await pool.query(
         `SELECT m.id, m.title, m.requested_by, m.date_submitted, m.rank, m.tmdb_id, m.watched_at,
-                m.elo_rank,
+                m.elo_rank, m.poster_path,
                 u.username AS user_username, u.display_name AS user_display_name,
                 ume_a.elo_rating AS user_a_elo,
                 ume_b.elo_rating AS user_b_elo,
@@ -618,7 +618,7 @@ export const resolvers = {
 
       const result = await pool.query(
         `SELECT DISTINCT m.id, m.title, m.requested_by, m.date_submitted, m.rank, m.tmdb_id,
-                m.watched_at, m.elo_rank,
+                m.watched_at, m.elo_rank, m.poster_path,
                 u.id AS adder_id, u.username AS adder_username, u.display_name AS adder_display_name
          FROM movies m
          JOIN users u ON m.requested_by = u.id

--- a/src/components/common/Poster.tsx
+++ b/src/components/common/Poster.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Box } from '@mui/joy';
+
+export type PosterSize = 'xs' | 'sm' | 'md' | 'lg';
+
+const SIZE_PX: Record<PosterSize, { w: number; h: number; r: number }> = {
+  xs: { w: 28, h: 42, r: 3 }, // table rows
+  sm: { w: 40, h: 60, r: 4 }, // movie cards
+  md: { w: 52, h: 78, r: 4 }, // inbox modal
+  lg: { w: 92, h: 138, r: 6 }, // larger thumbnails
+};
+
+interface PosterProps {
+  url?: string | null;
+  alt?: string;
+  size?: PosterSize;
+}
+
+const Poster: React.FC<PosterProps> = ({ url, alt = '', size = 'sm' }) => {
+  const { w, h, r } = SIZE_PX[size];
+
+  if (!url) {
+    return (
+      <Box
+        sx={{
+          width: w,
+          height: h,
+          bgcolor: 'background.level2',
+          borderRadius: `${r}px`,
+          flexShrink: 0,
+        }}
+      />
+    );
+  }
+
+  return (
+    <img
+      src={url}
+      alt={alt}
+      loading="lazy"
+      decoding="async"
+      width={w}
+      height={h}
+      style={{
+        width: w,
+        height: h,
+        objectFit: 'cover',
+        borderRadius: r,
+        flexShrink: 0,
+        backgroundColor: 'var(--joy-palette-background-level2)',
+      }}
+    />
+  );
+};
+
+export default Poster;

--- a/src/components/home/ConnectionInboxModal.tsx
+++ b/src/components/home/ConnectionInboxModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Modal, ModalDialog, ModalClose, Box, Button, Typography, Sheet, Chip } from '@mui/joy';
 import { useToast } from '../../contexts/ToastContext';
+import Poster from '../common/Poster';
 
 const formatRelativeDate = (iso: string): string => {
   const then = new Date(iso).getTime();
@@ -137,29 +138,7 @@ const ConnectionInboxModal: React.FC<ConnectionInboxModalProps> = ({
                       {/* Movie info */}
                       <Box sx={{ display: 'flex', gap: 1.25, minWidth: 0 }}>
                         {/* Poster */}
-                        {item.movie.poster_url ? (
-                          <img
-                            src={item.movie.poster_url}
-                            alt=""
-                            style={{
-                              width: 52,
-                              height: 78,
-                              objectFit: 'cover',
-                              borderRadius: 4,
-                              flexShrink: 0,
-                            }}
-                          />
-                        ) : (
-                          <Box
-                            sx={{
-                              width: 52,
-                              height: 78,
-                              bgcolor: 'background.level2',
-                              borderRadius: '4px',
-                              flexShrink: 0,
-                            }}
-                          />
-                        )}
+                        <Poster url={item.movie.poster_url} size="md" />
 
                         {/* Title + meta */}
                         <Box sx={{ flex: 1, minWidth: 0 }}>

--- a/src/components/home/Homepage.tsx
+++ b/src/components/home/Homepage.tsx
@@ -36,6 +36,7 @@ import ConnectionBanners from './ConnectionBanners';
 import ConnectionInboxModal from './ConnectionInboxModal';
 import ThisOrThatBanner from './ThisOrThatBanner';
 import ConfirmDialog from '../common/ConfirmDialog';
+import Poster from '../common/Poster';
 import { OnboardingCard, ONBOARDING_DISMISSED_KEY } from '../common/OnboardingGuide';
 import { Movie } from '../../models/Movies';
 import { useAuth } from '../../contexts/AuthContext';
@@ -387,29 +388,7 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
                 >
                   <Box sx={{ display: 'flex', gap: 1.5, alignItems: 'center' }}>
                     {/* Poster */}
-                    {movie.poster_url ? (
-                      <img
-                        src={movie.poster_url}
-                        alt=""
-                        style={{
-                          width: 40,
-                          height: 60,
-                          objectFit: 'cover',
-                          borderRadius: 4,
-                          flexShrink: 0,
-                        }}
-                      />
-                    ) : (
-                      <Box
-                        sx={{
-                          width: 40,
-                          height: 60,
-                          bgcolor: 'background.level2',
-                          borderRadius: '4px',
-                          flexShrink: 0,
-                        }}
-                      />
-                    )}
+                    <Poster url={movie.poster_url} size="sm" />
 
                     {/* Details */}
                     <Box sx={{ flex: 1, minWidth: 0 }}>

--- a/src/components/home/MovieCard.tsx
+++ b/src/components/home/MovieCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Box, Typography, Chip, IconButton, Tooltip, Sheet } from '@mui/joy';
 import { Movie } from '../../models/Movies';
+import Poster from '../common/Poster';
 
 interface MovieCardProps {
   movie: Movie;
@@ -56,29 +57,7 @@ const MovieCard: React.FC<MovieCardProps> = ({
           </Typography>
         )}
         {/* Poster */}
-        {movie.poster_url ? (
-          <img
-            src={movie.poster_url}
-            alt=""
-            style={{
-              width: 40,
-              height: 60,
-              objectFit: 'cover',
-              borderRadius: 4,
-              flexShrink: 0,
-            }}
-          />
-        ) : (
-          <Box
-            sx={{
-              width: 40,
-              height: 60,
-              bgcolor: 'background.level2',
-              borderRadius: '4px',
-              flexShrink: 0,
-            }}
-          />
-        )}
+        <Poster url={movie.poster_url} size="sm" />
 
         {/* Details */}
         <Box sx={{ flex: 1, minWidth: 0 }}>

--- a/src/components/home/MovieRow.tsx
+++ b/src/components/home/MovieRow.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Box, Typography, Chip, IconButton, Tooltip } from '@mui/joy';
 import { Movie } from '../../models/Movies';
+import Poster from '../common/Poster';
 
 export interface MovieRowProps {
   movie: Movie;
@@ -31,29 +32,7 @@ const MovieRow: React.FC<MovieRowProps> = ({
       {/* Title */}
       <td style={{ verticalAlign: 'middle', padding: '8px 16px' }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          {movie.poster_url ? (
-            <img
-              src={movie.poster_url}
-              alt=""
-              style={{
-                width: 28,
-                height: 42,
-                objectFit: 'cover',
-                borderRadius: 3,
-                flexShrink: 0,
-              }}
-            />
-          ) : (
-            <Box
-              sx={{
-                width: 28,
-                height: 42,
-                bgcolor: 'background.level2',
-                borderRadius: '3px',
-                flexShrink: 0,
-              }}
-            />
-          )}
+          <Poster url={movie.poster_url} size="xs" />
           <Typography level="body-sm" sx={{ fontWeight: 600, color: 'text.primary' }}>
             {movie.title}
           </Typography>

--- a/src/components/home/WatchHistory.tsx
+++ b/src/components/home/WatchHistory.tsx
@@ -15,6 +15,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import { useToast } from '../../contexts/ToastContext';
 import { useConfirm } from '../../hooks/useConfirm';
 import ConfirmDialog from '../common/ConfirmDialog';
+import Poster from '../common/Poster';
 import WatchHistoryCard from './WatchHistoryCard';
 
 const PAGE_SIZE = 25;
@@ -152,29 +153,7 @@ const WatchHistory: React.FC = () => {
                           <tr key={movie.id}>
                             <td style={{ verticalAlign: 'middle', padding: '8px 16px' }}>
                               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                                {movie.poster_url ? (
-                                  <img
-                                    src={movie.poster_url}
-                                    alt=""
-                                    style={{
-                                      width: 28,
-                                      height: 42,
-                                      objectFit: 'cover',
-                                      borderRadius: 3,
-                                      flexShrink: 0,
-                                    }}
-                                  />
-                                ) : (
-                                  <Box
-                                    sx={{
-                                      width: 28,
-                                      height: 42,
-                                      bgcolor: 'background.level2',
-                                      borderRadius: '3px',
-                                      flexShrink: 0,
-                                    }}
-                                  />
-                                )}
+                                <Poster url={movie.poster_url} size="xs" />
                                 <Typography
                                   level="body-sm"
                                   sx={{ fontWeight: 600, color: 'text.primary' }}

--- a/src/components/home/WatchHistoryCard.tsx
+++ b/src/components/home/WatchHistoryCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box, Typography, Chip, IconButton, Tooltip, Sheet } from '@mui/joy';
+import Poster from '../common/Poster';
 
 interface WatchHistoryCardProps {
   movie: any;
@@ -19,29 +20,7 @@ const WatchHistoryCard: React.FC<WatchHistoryCardProps> = ({ movie, canUnwatch, 
   >
     <Box sx={{ display: 'flex', gap: 1.5 }}>
       {/* Poster */}
-      {movie.poster_url ? (
-        <img
-          src={movie.poster_url}
-          alt=""
-          style={{
-            width: 40,
-            height: 60,
-            objectFit: 'cover',
-            borderRadius: 4,
-            flexShrink: 0,
-          }}
-        />
-      ) : (
-        <Box
-          sx={{
-            width: 40,
-            height: 60,
-            bgcolor: 'background.level2',
-            borderRadius: '4px',
-            flexShrink: 0,
-          }}
-        />
-      )}
+      <Poster url={movie.poster_url} size="sm" />
 
       {/* Details */}
       <Box sx={{ flex: 1, minWidth: 0 }}>


### PR DESCRIPTION
## Summary
- Three resolvers (`newMoviesFromConnections`, `combinedList`, `myRankings`) selected Movie rows but omitted `m.poster_path`, so the `poster_url` field resolver returned `null`. Because Apollo normalizes by `Movie:id`, the inbox's refetch after `setMovieInterest` overwrote valid poster URLs with `null` everywhere, blanking posters across the app until the 5s `GET_MOVIES` poll healed the cache.
- Adds `m.poster_path` to those three SELECTs.
- Unifies poster rendering behind a new `src/components/common/Poster.tsx` with `loading="lazy"`, `decoding="async"`, fixed `width`/`height` attributes, and a gray fallback. Replaces six ad-hoc `<img>` blocks (MovieCard, MovieRow, WatchHistoryCard, WatchHistory, Homepage recently-added section, ConnectionInboxModal).

## Test plan
- [x] Backend `npm test` (272 passed)
- [x] Frontend `npm test -- --watchAll=false` (23 passed)
- [x] `tsc --noEmit` clean for frontend and backend
- [x] `prettier --check` clean
- [ ] Manual: open the connection inbox, click "Add to queue" / "Add as rewatch" / "Pass" — remaining posters stay on screen, no flicker, no 5s reload.
- [ ] Manual: posters render at consistent sizes across MovieCard, MovieRow, WatchHistory, Homepage recently-added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)