### PR TITLE
UX quality pass: accessibility, styling, terminology, severity cues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,36 @@ src/components/
 - **Frontend state** — auth state lives in `AuthContext`; movie/user data comes from Apollo cache.
 - **Env vars** — frontend uses `REACT_APP_*`; backend uses bare names.
 
+## UI style guide
+
+### Terminology
+
+| Action                         | Verb / button text             | Notes                                              |
+| ------------------------------ | ------------------------------ | -------------------------------------------------- |
+| Mark a queued movie watched    | **Done** (confirm: `Done`)     | Confirmation: "Mark as done?" / moves to history.  |
+| Requeue a watched movie        | **Watch again**                | Confirmation: "Watch again?" / moves to queue end. |
+| Tag a movie as previously seen | **Seen it** / "I've seen this" | Per-user `seen` tag.                               |
+| Remove from queue (admin)      | **Remove**                     | Destructive — uses danger confirmation.            |
+
+Avoid `Requeue`, `Mark watched`, `Mark complete` as user-facing copy.
+
+### Confirmation severity (`useConfirm` / `ConfirmDialog`)
+
+| Severity | `confirmColor` | When to use                                                                                                           |
+| -------- | -------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Danger   | `'danger'`     | Permanent destructive actions: delete movie/user, remove connection, seed (deletes existing data), reset comparisons. |
+| Warning  | `'warning'`    | Recoverable but disruptive actions.                                                                                   |
+| Neutral  | `'primary'`    | Reversible state changes (e.g. requeue from history).                                                                 |
+| Success  | `'success'`    | Affirmative completion (e.g. mark a movie as done).                                                                   |
+
+Danger and warning confirmations render a leading icon for severity reinforcement.
+
+### Styling
+
+- Prefer MUI `sx` + theme tokens for Joy components.
+- Use CSS variables (`--mn-*` from `index.css`) only for raw HTML elements (`<table>`, `<th>`, `<td>`, `<a>`) and global styles.
+- Keep table cell/header styles in module-level `React.CSSProperties` constants — avoid per-element inline literals.
+
 ## Database schema (current)
 
 | Table             | Notable columns                                                                                                                                       |

--- a/src/App.css
+++ b/src/App.css
@@ -2,37 +2,6 @@
   text-align: center;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
 .App-link {
   color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
 }

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -190,6 +190,7 @@ export const UserManagement: React.FC = () => {
           <Box sx={{ overflowX: 'auto' }}>
             <Table
               stickyHeader
+              aria-label="User accounts"
               sx={{
                 '--TableCell-headBackground': 'var(--mn-bg-elevated)',
                 '--TableRow-hoverBackground': 'var(--mn-bg-hover)',
@@ -200,15 +201,31 @@ export const UserManagement: React.FC = () => {
             >
               <thead>
                 <tr>
-                  <th style={{ ...thStyle, width: 44 }} />
-                  <th style={thStyle}>Username</th>
-                  <th style={thStyle}>Display Name</th>
-                  <th style={thStyle}>Email</th>
-                  <th style={{ ...thStyle, width: 70 }}>Admin</th>
-                  <th style={{ ...thStyle, width: 100 }}>Status</th>
-                  <th style={{ ...thStyle, width: 110 }}>Last Login</th>
-                  <th style={{ ...thStyle, width: 100 }}>Created</th>
-                  <th style={{ ...thStyle, width: 110, textAlign: 'right' }}>Actions</th>
+                  <th scope="col" aria-label="Avatar" style={{ ...thStyle, width: 44 }} />
+                  <th scope="col" style={thStyle}>
+                    Username
+                  </th>
+                  <th scope="col" style={thStyle}>
+                    Display Name
+                  </th>
+                  <th scope="col" style={thStyle}>
+                    Email
+                  </th>
+                  <th scope="col" style={{ ...thStyle, width: 70 }}>
+                    Admin
+                  </th>
+                  <th scope="col" style={{ ...thStyle, width: 100 }}>
+                    Status
+                  </th>
+                  <th scope="col" style={{ ...thStyle, width: 110 }}>
+                    Last Login
+                  </th>
+                  <th scope="col" style={{ ...thStyle, width: 100 }}>
+                    Created
+                  </th>
+                  <th scope="col" style={{ ...thStyle, width: 110, textAlign: 'right' }}>
+                    Actions
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -285,9 +302,10 @@ export const UserManagement: React.FC = () => {
                           variant="plain"
                           color="danger"
                           onClick={() => handleDelete(user.id)}
+                          aria-label={`Delete user ${user.username}`}
                           sx={{ opacity: 0.5, '&:hover': { opacity: 1 } }}
                         >
-                          ✕
+                          <span aria-hidden="true">✕</span>
                         </IconButton>
                       </Box>
                     </td>
@@ -373,9 +391,10 @@ export const UserManagement: React.FC = () => {
                 variant="soft"
                 color="danger"
                 onClick={() => handleDelete(user.id)}
+                aria-label={`Delete user ${user.username}`}
                 sx={{ minWidth: 44, minHeight: 44 }}
               >
-                ✕
+                <span aria-hidden="true">✕</span>
               </IconButton>
             </Box>
           </Sheet>

--- a/src/components/common/ConfirmDialog.tsx
+++ b/src/components/common/ConfirmDialog.tsx
@@ -1,17 +1,40 @@
 import React from 'react';
 import { Modal, ModalDialog, Typography, Button, Box, Divider } from '@mui/joy';
 
+export type ConfirmColor = 'danger' | 'primary' | 'warning' | 'success';
+
 export interface ConfirmDialogProps {
   open: boolean;
   title: string;
   message: string;
   confirmText?: string;
   cancelText?: string;
-  confirmColor?: 'danger' | 'primary' | 'warning' | 'success';
+  confirmColor?: ConfirmColor;
   loading?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
 }
+
+const ICONS: Record<ConfirmColor, string> = {
+  danger: '⚠',
+  warning: '⚠',
+  success: '✓',
+  primary: 'ⓘ',
+};
+
+const ICON_BG: Record<ConfirmColor, string> = {
+  danger: 'rgba(224, 64, 64, 0.15)',
+  warning: 'rgba(245, 166, 35, 0.15)',
+  success: 'rgba(76, 175, 130, 0.15)',
+  primary: 'rgba(245, 197, 24, 0.15)',
+};
+
+const ICON_COLOR: Record<ConfirmColor, string> = {
+  danger: '#ef9a9a',
+  warning: '#fbc45a',
+  success: '#80cfa9',
+  primary: '#ffd133',
+};
 
 const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
   open,
@@ -23,43 +46,79 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
   loading = false,
   onConfirm,
   onCancel,
-}) => (
-  <Modal open={open} onClose={onCancel}>
-    <ModalDialog
-      sx={{
-        maxWidth: 400,
-        width: '100%',
-        p: 3,
-        bgcolor: 'background.level1',
-        borderColor: 'var(--mn-border-vis)',
-      }}
-    >
-      <Typography level="title-md" sx={{ fontWeight: 700, mb: 0.5 }}>
-        {title}
-      </Typography>
-      <Typography level="body-sm" sx={{ color: 'text.secondary', mb: 2 }}>
-        {message}
-      </Typography>
-      <Divider sx={{ mb: 2 }} />
-      <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
-        <Button variant="plain" color="neutral" onClick={onCancel} disabled={loading}>
-          {cancelText}
-        </Button>
-        <Button
-          variant="solid"
-          color={confirmColor}
-          onClick={onConfirm}
-          loading={loading}
-          sx={{
-            fontWeight: 700,
-            ...(confirmColor === 'primary' ? { color: '#0d0f1a' } : {}),
-          }}
+}) => {
+  const isDestructive = confirmColor === 'danger' || confirmColor === 'warning';
+  return (
+    <Modal open={open} onClose={onCancel}>
+      <ModalDialog
+        role="alertdialog"
+        aria-labelledby="confirm-dialog-title"
+        aria-describedby="confirm-dialog-message"
+        sx={{
+          maxWidth: 400,
+          width: '100%',
+          p: 3,
+          bgcolor: 'background.level1',
+          borderColor: 'var(--mn-border-vis)',
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5, mb: 0.5 }}>
+          {isDestructive && (
+            <Box
+              aria-hidden="true"
+              sx={{
+                width: 32,
+                height: 32,
+                borderRadius: '50%',
+                bgcolor: ICON_BG[confirmColor],
+                color: ICON_COLOR[confirmColor],
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: '1rem',
+                fontWeight: 700,
+                flexShrink: 0,
+              }}
+            >
+              {ICONS[confirmColor]}
+            </Box>
+          )}
+          <Typography
+            id="confirm-dialog-title"
+            level="title-md"
+            sx={{ fontWeight: 700, pt: isDestructive ? 0.5 : 0 }}
+          >
+            {title}
+          </Typography>
+        </Box>
+        <Typography
+          id="confirm-dialog-message"
+          level="body-sm"
+          sx={{ color: 'text.secondary', mb: 2, ml: isDestructive ? 5.5 : 0 }}
         >
-          {confirmText}
-        </Button>
-      </Box>
-    </ModalDialog>
-  </Modal>
-);
+          {message}
+        </Typography>
+        <Divider sx={{ mb: 2 }} />
+        <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
+          <Button variant="plain" color="neutral" onClick={onCancel} disabled={loading}>
+            {cancelText}
+          </Button>
+          <Button
+            variant="solid"
+            color={confirmColor}
+            onClick={onConfirm}
+            loading={loading}
+            sx={{
+              fontWeight: 700,
+              ...(confirmColor === 'primary' ? { color: '#0d0f1a' } : {}),
+            }}
+          >
+            {confirmText}
+          </Button>
+        </Box>
+      </ModalDialog>
+    </Modal>
+  );
+};
 
 export default ConfirmDialog;

--- a/src/components/common/OnboardingGuide.tsx
+++ b/src/components/common/OnboardingGuide.tsx
@@ -233,7 +233,7 @@ export const OnboardingModal: React.FC<OnboardingModalProps> = ({
         borderColor: 'var(--mn-border-vis)',
       }}
     >
-      <ModalClose />
+      <ModalClose aria-label="Close onboarding guide" />
       <Typography level="title-lg" sx={{ fontWeight: 800, mb: 0.5 }}>
         How MovieNight works
       </Typography>

--- a/src/components/home/ConnectionInboxModal.tsx
+++ b/src/components/home/ConnectionInboxModal.tsx
@@ -63,12 +63,15 @@ const ConnectionInboxModal: React.FC<ConnectionInboxModalProps> = ({
 
   return (
     <Modal open={open} onClose={onClose}>
-      <ModalDialog sx={{ maxWidth: 600, width: '100%', p: { xs: 2, sm: 3 } }}>
-        <ModalClose />
+      <ModalDialog
+        aria-labelledby="connection-inbox-title"
+        sx={{ maxWidth: 600, width: '100%', p: { xs: 2, sm: 3 } }}
+      >
+        <ModalClose aria-label="Close connection inbox" />
 
         <Box sx={{ mb: 2, pr: 4 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
-            <Typography level="title-md" sx={{ fontWeight: 700 }}>
+            <Typography id="connection-inbox-title" level="title-md" sx={{ fontWeight: 700 }}>
               Suggestions from your connections
             </Typography>
             {remaining > 0 && (

--- a/src/components/home/Homepage.tsx
+++ b/src/components/home/Homepage.tsx
@@ -228,7 +228,7 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
       title: 'Seed movies?',
       message: 'This will DELETE all existing movies and seed 30 new ones.',
       confirmText: 'Seed',
-      confirmColor: 'warning',
+      confirmColor: 'danger',
     });
     if (!ok) return;
     try {
@@ -602,6 +602,7 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
                       >
                         <Box sx={{ overflowX: 'auto' }}>
                           <table
+                            aria-label="Combined movie rankings"
                             style={{
                               width: '100%',
                               minWidth: 360,
@@ -616,7 +617,9 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
                                   borderBottom: '1px solid var(--mn-border-vis)',
                                 }}
                               >
-                                <th style={combinedThStyle}>#</th>
+                                <th style={combinedThStyle} scope="col">
+                                  #
+                                </th>
                                 <th style={{ ...combinedThStyle, textAlign: 'left' }}>
                                   <Box
                                     sx={{
@@ -812,6 +815,7 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
               >
                 <Box sx={{ overflowX: 'auto' }}>
                   <table
+                    aria-label="Solo movies"
                     style={{
                       width: '100%',
                       minWidth: 540,
@@ -906,6 +910,7 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
                 >
                   <Box sx={{ overflowX: 'auto' }}>
                     <table
+                      aria-label={isMySuggestionsView ? 'My suggested movies' : 'Movie queue'}
                       style={{
                         width: '100%',
                         minWidth: 540,
@@ -921,20 +926,30 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
                           }}
                         >
                           {['Title', 'Suggested by', 'Added'].map((label) => (
-                            <th key={label} style={thStyle}>
+                            <th key={label} scope="col" style={thStyle}>
                               {label}
                             </th>
                           ))}
-                          <th style={{ ...thStyle, textAlign: 'center', padding: '10px 8px' }}>
+                          <th
+                            scope="col"
+                            style={{ ...thStyle, textAlign: 'center', padding: '10px 8px' }}
+                          >
                             TMDB
                           </th>
                           {isAuthenticated && (
-                            <th style={{ ...thStyle, textAlign: 'center', padding: '10px 4px' }}>
+                            <th
+                              scope="col"
+                              style={{ ...thStyle, textAlign: 'center', padding: '10px 4px' }}
+                            >
                               Seen
                             </th>
                           )}
                           {isAuthenticated && (
-                            <th style={{ ...thStyle, textAlign: 'right', padding: '10px 12px' }} />
+                            <th
+                              scope="col"
+                              aria-label="Actions"
+                              style={{ ...thStyle, textAlign: 'right', padding: '10px 12px' }}
+                            />
                           )}
                         </tr>
                       </thead>

--- a/src/components/home/MovieCard.tsx
+++ b/src/components/home/MovieCard.tsx
@@ -74,6 +74,7 @@ const MovieCard: React.FC<MovieCardProps> = ({
                 href={`https://www.themoviedb.org/movie/${movie.tmdb_id}`}
                 target="_blank"
                 rel="noopener noreferrer"
+                aria-label={`View ${movie.title} on TMDB (opens in new tab)`}
                 style={{
                   color: 'var(--joy-palette-primary-500)',
                   fontSize: '0.7rem',
@@ -129,18 +130,22 @@ const MovieCard: React.FC<MovieCardProps> = ({
             >
               <IconButton
                 size="sm"
-                variant="plain"
+                variant={isSeen ? 'soft' : 'plain'}
                 color={isSeen ? 'warning' : 'neutral'}
                 onClick={() => onToggleSeen(movie.id, isSeen)}
+                aria-label={
+                  isSeen ? `Remove "Seen it" from ${movie.title}` : `Mark ${movie.title} as seen`
+                }
+                aria-pressed={isSeen}
                 sx={{
-                  opacity: isSeen ? 0.9 : 0.35,
+                  opacity: isSeen ? 0.95 : 0.5,
                   '&:hover': { opacity: 1 },
                   fontSize: '0.85rem',
                   minWidth: 36,
                   minHeight: 36,
                 }}
               >
-                {isSeen ? '👁' : '👁‍🗨'}
+                <span aria-hidden="true">{isSeen ? '👁' : '👁‍🗨'}</span>
                 {seenCount > 0 && (
                   <Typography
                     component="span"
@@ -159,9 +164,10 @@ const MovieCard: React.FC<MovieCardProps> = ({
               color="success"
               variant="soft"
               onClick={() => onMarkWatched(movie.id, movie.title)}
+              aria-label={`Mark "${movie.title}" as done`}
               sx={{ minWidth: 36, minHeight: 36 }}
             >
-              ✓
+              <span aria-hidden="true">✓</span>
             </IconButton>
           )}
           {isAdmin && (
@@ -170,9 +176,10 @@ const MovieCard: React.FC<MovieCardProps> = ({
               color="danger"
               variant="soft"
               onClick={() => onDelete(movie.id, movie.title)}
+              aria-label={`Remove "${movie.title}"`}
               sx={{ minWidth: 36, minHeight: 36 }}
             >
-              ✕
+              <span aria-hidden="true">✕</span>
             </IconButton>
           )}
         </Box>

--- a/src/components/home/MovieRow.tsx
+++ b/src/components/home/MovieRow.tsx
@@ -14,6 +14,45 @@ export interface MovieRowProps {
   isRecentlyAdded?: boolean;
 }
 
+const cellStyle: React.CSSProperties = {
+  verticalAlign: 'middle',
+  padding: '8px 16px',
+};
+
+const cellStyleNarrow: React.CSSProperties = {
+  verticalAlign: 'middle',
+  padding: '12px 16px',
+};
+
+const cellStyleNoWrap: React.CSSProperties = {
+  ...cellStyleNarrow,
+  whiteSpace: 'nowrap',
+};
+
+const cellStyleCenter: React.CSSProperties = {
+  verticalAlign: 'middle',
+  padding: '12px 8px',
+  textAlign: 'center',
+};
+
+const cellStyleSeen: React.CSSProperties = {
+  verticalAlign: 'middle',
+  padding: '0 4px',
+  textAlign: 'center',
+};
+
+const cellStyleActions: React.CSSProperties = {
+  verticalAlign: 'middle',
+  padding: '0 12px',
+  textAlign: 'right',
+  whiteSpace: 'nowrap',
+};
+
+const recentlyAddedRowStyle: React.CSSProperties = {
+  background: 'rgba(var(--joy-palette-primary-mainChannel) / 0.06)',
+  boxShadow: 'inset 3px 0 0 var(--joy-palette-primary-400)',
+};
+
 const MovieRow: React.FC<MovieRowProps> = ({
   movie,
   isAdmin,
@@ -28,20 +67,18 @@ const MovieRow: React.FC<MovieRowProps> = ({
   const seenByUsers = (movie.userTags ?? []).filter((t) => t.tag.slug === 'seen');
   const seenCount = seenByUsers.length;
   const seenNames = seenByUsers.map((t) => t.user.display_name || t.user.username);
+  const seenLabel = isSeen ? `Remove "Seen it" from ${movie.title}` : `Mark ${movie.title} as seen`;
+  const seenTooltip =
+    seenCount > 0
+      ? `Seen by: ${seenNames.join(', ')}`
+      : isSeen
+        ? 'Remove "Seen it"'
+        : "I've seen this";
 
   return (
-    <tr
-      style={
-        isRecentlyAdded
-          ? {
-              background: 'rgba(var(--joy-palette-primary-mainChannel) / 0.06)',
-              boxShadow: 'inset 3px 0 0 var(--joy-palette-primary-400)',
-            }
-          : undefined
-      }
-    >
+    <tr style={isRecentlyAdded ? recentlyAddedRowStyle : undefined}>
       {/* Title */}
-      <td style={{ verticalAlign: 'middle', padding: '8px 16px' }}>
+      <td style={cellStyle}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <Poster url={movie.poster_url} size="xs" />
           <Typography level="body-sm" sx={{ fontWeight: 600, color: 'text.primary' }}>
@@ -51,14 +88,14 @@ const MovieRow: React.FC<MovieRowProps> = ({
       </td>
 
       {/* Suggested by */}
-      <td style={{ verticalAlign: 'middle', padding: '12px 16px' }}>
+      <td style={cellStyleNarrow}>
         <Chip size="sm" variant="soft" color="neutral" sx={{ fontWeight: 500 }}>
           {movie.requester}
         </Chip>
       </td>
 
       {/* Date */}
-      <td style={{ verticalAlign: 'middle', padding: '12px 16px', whiteSpace: 'nowrap' }}>
+      <td style={cellStyleNoWrap}>
         <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
           {new Date(movie.date_submitted).toLocaleDateString(undefined, {
             year: 'numeric',
@@ -69,12 +106,13 @@ const MovieRow: React.FC<MovieRowProps> = ({
       </td>
 
       {/* TMDB */}
-      <td style={{ verticalAlign: 'middle', padding: '12px 8px', textAlign: 'center' }}>
+      <td style={cellStyleCenter}>
         {movie.tmdb_id ? (
           <a
             href={`https://www.themoviedb.org/movie/${movie.tmdb_id}`}
             target="_blank"
             rel="noopener noreferrer"
+            aria-label={`View ${movie.title} on TMDB (opens in new tab)`}
             style={{ color: 'var(--joy-palette-primary-500)', fontSize: '0.75rem' }}
           >
             ↗
@@ -84,36 +122,29 @@ const MovieRow: React.FC<MovieRowProps> = ({
 
       {/* Seen it */}
       {isAuthenticated && (
-        <td style={{ verticalAlign: 'middle', padding: '0 4px', textAlign: 'center' }}>
-          <Tooltip
-            title={
-              seenCount > 0
-                ? `Seen by: ${seenNames.join(', ')}`
-                : isSeen
-                  ? 'Remove "Seen it"'
-                  : "I've seen this"
-            }
-            placement="top"
-            arrow
-          >
+        <td style={cellStyleSeen}>
+          <Tooltip title={seenTooltip} placement="top" arrow>
             <IconButton
               size="sm"
-              variant="plain"
+              variant={isSeen ? 'soft' : 'plain'}
               color={isSeen ? 'warning' : 'neutral'}
               onClick={() => onToggleSeen(movie.id, isSeen)}
+              aria-label={seenLabel}
+              aria-pressed={isSeen}
               sx={{
-                opacity: isSeen ? 0.9 : 0.35,
+                opacity: isSeen ? 0.95 : 0.5,
                 transition: 'opacity 0.15s',
                 '&:hover': { opacity: 1 },
                 fontSize: '0.85rem',
               }}
             >
-              {isSeen ? '👁' : '👁‍🗨'}
+              <span aria-hidden="true">{isSeen ? '👁' : '👁‍🗨'}</span>
               {seenCount > 0 && (
                 <Typography
                   component="span"
                   level="body-xs"
                   sx={{ ml: 0.25, fontWeight: 700, fontSize: '0.6rem' }}
+                  aria-label={`Seen by ${seenCount}`}
                 >
                   {seenCount}
                 </Typography>
@@ -125,20 +156,14 @@ const MovieRow: React.FC<MovieRowProps> = ({
 
       {/* Actions */}
       {(canMarkWatched || isAdmin) && (
-        <td
-          style={{
-            verticalAlign: 'middle',
-            padding: '0 12px',
-            textAlign: 'right',
-            whiteSpace: 'nowrap',
-          }}
-        >
+        <td style={cellStyleActions}>
           {canMarkWatched && (
             <IconButton
               size="sm"
               color="success"
               variant="plain"
               onClick={() => onMarkWatched(movie.id, movie.title)}
+              aria-label={`Mark "${movie.title}" as done`}
               title={`Mark "${movie.title}" as done`}
               sx={{
                 opacity: 0.5,
@@ -147,7 +172,7 @@ const MovieRow: React.FC<MovieRowProps> = ({
                 mr: isAdmin ? 0.5 : 0,
               }}
             >
-              ✓
+              <span aria-hidden="true">✓</span>
             </IconButton>
           )}
           {isAdmin && (
@@ -156,6 +181,7 @@ const MovieRow: React.FC<MovieRowProps> = ({
               color="danger"
               variant="plain"
               onClick={() => onDelete(movie.id, movie.title)}
+              aria-label={`Remove "${movie.title}"`}
               title={`Remove "${movie.title}"`}
               sx={{
                 opacity: 0.5,
@@ -163,7 +189,7 @@ const MovieRow: React.FC<MovieRowProps> = ({
                 '&:hover': { opacity: 1 },
               }}
             >
-              ✕
+              <span aria-hidden="true">✕</span>
             </IconButton>
           )}
         </td>

--- a/src/components/home/TmdbMatchFlow.tsx
+++ b/src/components/home/TmdbMatchFlow.tsx
@@ -70,7 +70,7 @@ const TmdbMatchFlow: React.FC<Props> = ({ movies, onClose }) => {
   return (
     <Modal open onClose={onClose}>
       <ModalDialog sx={{ maxWidth: 460, width: '100%', p: 3 }}>
-        <ModalClose />
+        <ModalClose aria-label="Close TMDB match flow" />
 
         {!current ? (
           <>

--- a/src/components/home/WatchHistory.tsx
+++ b/src/components/home/WatchHistory.tsx
@@ -45,7 +45,7 @@ const WatchHistory: React.FC = () => {
     const ok = await confirm({
       title: 'Watch again?',
       message: `"${title}" will go back to the end of the queue.`,
-      confirmText: 'Requeue',
+      confirmText: 'Watch again',
       confirmColor: 'primary',
     });
     if (!ok) return;
@@ -102,6 +102,7 @@ const WatchHistory: React.FC = () => {
               >
                 <Box sx={{ overflowX: 'auto' }}>
                   <table
+                    aria-label="Watched movies history"
                     style={{
                       width: '100%',
                       minWidth: 480,
@@ -119,6 +120,7 @@ const WatchHistory: React.FC = () => {
                         {['Title', 'Suggested by', 'Watched'].map((label) => (
                           <th
                             key={label}
+                            scope="col"
                             style={{
                               padding: '10px 16px',
                               textAlign: 'left',
@@ -133,6 +135,8 @@ const WatchHistory: React.FC = () => {
                           </th>
                         ))}
                         <th
+                          scope="col"
+                          aria-label="Actions"
                           style={{
                             padding: '10px 12px',
                             textAlign: 'right',
@@ -165,6 +169,7 @@ const WatchHistory: React.FC = () => {
                                     href={`https://www.themoviedb.org/movie/${movie.tmdb_id}`}
                                     target="_blank"
                                     rel="noopener noreferrer"
+                                    aria-label={`View ${movie.title} on TMDB (opens in new tab)`}
                                     style={{
                                       color: 'var(--joy-palette-primary-500)',
                                       fontSize: '0.75rem',
@@ -216,6 +221,7 @@ const WatchHistory: React.FC = () => {
                                     color="primary"
                                     variant="plain"
                                     onClick={() => handleUnwatch(movie.id, movie.title)}
+                                    aria-label={`Watch "${movie.title}" again`}
                                     sx={{
                                       opacity: 0.5,
                                       transition: 'opacity 0.15s',
@@ -223,7 +229,7 @@ const WatchHistory: React.FC = () => {
                                       fontSize: '0.8rem',
                                     }}
                                   >
-                                    ↩
+                                    <span aria-hidden="true">↩</span>
                                   </IconButton>
                                 </Tooltip>
                               )}

--- a/src/components/home/WatchHistoryCard.tsx
+++ b/src/components/home/WatchHistoryCard.tsx
@@ -31,6 +31,7 @@ const WatchHistoryCard: React.FC<WatchHistoryCardProps> = ({ movie, canUnwatch, 
               href={`https://www.themoviedb.org/movie/${movie.tmdb_id}`}
               target="_blank"
               rel="noopener noreferrer"
+              aria-label={`View ${movie.title} on TMDB (opens in new tab)`}
               style={{
                 color: 'var(--joy-palette-primary-500)',
                 fontSize: '0.7rem',
@@ -70,9 +71,10 @@ const WatchHistoryCard: React.FC<WatchHistoryCardProps> = ({ movie, canUnwatch, 
               color="primary"
               variant="soft"
               onClick={() => onUnwatch(movie.id, movie.title)}
+              aria-label={`Watch "${movie.title}" again`}
               sx={{ minWidth: 36, minHeight: 36 }}
             >
-              ↩
+              <span aria-hidden="true">↩</span>
             </IconButton>
           </Tooltip>
         </Box>

--- a/src/index.css
+++ b/src/index.css
@@ -64,3 +64,18 @@ code {
   background: rgba(245, 197, 24, 0.25);
   color: var(--mn-text-primary);
 }
+
+/* ── Focus visibility for native HTML controls ────────────────────────────
+   Joy components handle their own focus styles via `--joy-focusVisible`.
+   This rule covers raw <a>, <button>, <input>, <select>, <textarea> elements
+   so keyboard users always get a clear focus indicator. */
+a:focus-visible,
+button:focus-visible,
+[role='button']:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--mn-gold);
+  outline-offset: 2px;
+  border-radius: 2px;
+}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -124,6 +124,21 @@ const theme = extendTheme({
         root: {
           borderRadius: '6px',
           fontWeight: 600,
+          '&:focus-visible': {
+            outline: '2px solid var(--joy-palette-focusVisible)',
+            outlineOffset: '2px',
+          },
+        },
+      },
+    },
+    JoyIconButton: {
+      styleOverrides: {
+        root: {
+          '&:focus-visible': {
+            outline: '2px solid var(--joy-palette-focusVisible)',
+            outlineOffset: '2px',
+            opacity: 1,
+          },
         },
       },
     },


### PR DESCRIPTION
## Summary

Grouped UX-quality fixes that don't block core flows but improve baseline experience.

**Accessibility**
- `aria-label` / `aria-pressed` / `aria-hidden` added across icon buttons (seen toggle, mark-done, delete, watch-again, TMDB links).
- Tables in Homepage / WatchHistory / UserManagement get `aria-label` and `scope="col"` on headers.
- `ModalClose` buttons in TmdbMatchFlow, ConnectionInboxModal, and OnboardingGuide get `aria-label`.
- Non-color cue for the "seen" state — uses filled `soft` vs `plain` IconButton variant in addition to gold/gray.
- Global `:focus-visible` outline for native HTML controls in `index.css` + theme overrides for Joy `Button` / `IconButton`.
- `ConfirmDialog` now uses `role="alertdialog"` with labelled title/message ids.

**Confirmation severity**
- `ConfirmDialog` renders a leading severity badge (⚠ / ✓ / ⓘ) for danger and warning levels.
- Seed-data action bumped `warning` → `danger` to reflect that it deletes existing data.

**Terminology**
- History confirm button "Requeue" → "Watch again", aligning with the tooltip and matching the standard.
- New "UI style guide" section in `CLAUDE.md` documents action terminology and confirmation severity tiers.

**Styling**
- `MovieRow` inline `<tr>` / `<td>` styles extracted to module-level `React.CSSProperties` constants.
- Unused CRA boilerplate (`.App-logo`, `.App-header`, keyframes) removed from `App.css`.

## Test plan

- [x] `npm test -- --watchAll=false` — 23/23 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx prettier --check` — clean
- [ ] Manual: keyboard-tab through movie list, watch history, user admin to verify focus rings appear on icon buttons and links
- [ ] Manual: open delete-movie / delete-user / seed dialogs and confirm danger badge renders; mark-done dialog still uses success styling without badge
- [ ] Manual: screen reader announces seen-toggle state changes via `aria-pressed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)