### PR TITLE
feat: mark-as-watched action on combined view

### DIFF
--- a/backend/src/__tests__/resolvers/movie-resolvers.test.ts
+++ b/backend/src/__tests__/resolvers/movie-resolvers.test.ts
@@ -146,11 +146,26 @@ describe('Mutation.markWatched', () => {
     await markWatched(null, { id: '1' }, adminContext());
   });
 
-  it('non-owner non-admin throws FORBIDDEN', async () => {
-    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1, requested_by: 99 }] });
+  it('non-owner without connection throws FORBIDDEN', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1, requested_by: 99 }] }) // SELECT movie
+      .mockResolvedValueOnce({ rows: [] }); // connection lookup → none
     await expect(markWatched(null, { id: '1' }, authContext({ userId: 2 }))).rejects.toThrow(
       'Not authorized',
     );
+  });
+
+  it('non-owner with accepted connection to owner can mark watched', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1, requested_by: 99 }] }) // SELECT movie
+      .mockResolvedValueOnce({ rows: [{ '?column?': 1 }] }) // connection lookup → exists
+      .mockResolvedValueOnce({
+        rows: [{ id: 1, title: 'M', requested_by: 99, watched_at: new Date() }],
+      }) // UPDATE
+      .mockResolvedValueOnce({ rows: [{ username: 'x', display_name: null }] }) // user lookup
+      .mockResolvedValueOnce({ rows: [] }); // logAudit
+    const result = await markWatched(null, { id: '1' }, authContext({ userId: 2 }));
+    expect(result.watched_at).toBeTruthy();
   });
 
   it('nonexistent movie throws NOT_FOUND', async () => {

--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -826,9 +826,20 @@ export const resolvers = {
         });
       }
       if (!context.user.isAdmin && movieResult.rows[0].requested_by !== context.user.userId) {
-        throw new GraphQLError('Not authorized', {
-          extensions: { code: 'FORBIDDEN' },
-        });
+        const ownerId = movieResult.rows[0].requested_by;
+        const conn = await pool.query(
+          `SELECT 1 FROM user_connections
+             WHERE status = 'accepted'
+               AND ((requester_id = $1 AND addressee_id = $2)
+                    OR (addressee_id = $1 AND requester_id = $2))
+             LIMIT 1`,
+          [context.user.userId, ownerId],
+        );
+        if (conn.rows.length === 0) {
+          throw new GraphQLError('Not authorized', {
+            extensions: { code: 'FORBIDDEN' },
+          });
+        }
       }
       const result = await pool.query(
         `UPDATE movies SET watched_at = NOW() WHERE id = $1

--- a/src/components/home/Homepage.tsx
+++ b/src/components/home/Homepage.tsx
@@ -138,7 +138,12 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
   const { data, loading: moviesLoading } = useQuery(GET_MOVIES, { pollInterval: 5000 });
 
   const [markWatched] = useMutation(MARK_WATCHED, {
-    refetchQueries: [{ query: GET_MOVIES }],
+    refetchQueries: [
+      { query: GET_MOVIES },
+      ...(selectedConnectionId && selectedConnectionId !== 'solo'
+        ? [{ query: COMBINED_LIST, variables: { connectionId: selectedConnectionId } }]
+        : []),
+    ],
   });
   const [deleteMovie] = useMutation(DELETE_MOVIE, {
     refetchQueries: [{ query: GET_MOVIES }],
@@ -185,6 +190,21 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
     const ok = await confirm({
       title: 'Mark as done?',
       message: `"${movieTitle}" will move to your watch history.`,
+      confirmText: 'Done',
+      confirmColor: 'success',
+    });
+    if (!ok) return;
+    try {
+      await markWatched({ variables: { id } });
+    } catch (err: any) {
+      showError(`Error marking movie as done: ${err.message}`);
+    }
+  };
+
+  const handleMarkWatchedCombined = async (id: string, movieTitle: string, friendName: string) => {
+    const ok = await confirm({
+      title: 'Watched together?',
+      message: `"${movieTitle}" will move to both your and ${friendName}'s watch history, and disappear from your queues.`,
       confirmText: 'Done',
       confirmColor: 'success',
     });
@@ -657,13 +677,14 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
                                     combinedData.combinedList.connection.user.username}
                                 </th>
                                 <th style={combinedThStyle}>Combined</th>
+                                <th style={combinedThStyle} aria-label="Actions"></th>
                               </tr>
                             </thead>
                             <tbody>
                               {filteredRankings.length === 0 ? (
                                 <tr>
                                   <td
-                                    colSpan={5}
+                                    colSpan={6}
                                     style={{
                                       ...combinedTdStyle,
                                       textAlign: 'center',
@@ -746,6 +767,44 @@ const HomePage: React.FC<HomePageProps> = ({ onShowThisOrThat, onShowConnections
                                       <Chip size="sm" variant="solid" color="primary">
                                         {Math.round(r.combinedElo)}
                                       </Chip>
+                                    </td>
+                                    <td
+                                      style={{
+                                        ...combinedTdStyle,
+                                        textAlign: 'right',
+                                        whiteSpace: 'nowrap',
+                                      }}
+                                    >
+                                      {isAuthenticated && (
+                                        <Tooltip
+                                          title={`Mark "${r.movie.title}" as watched together`}
+                                          arrow
+                                        >
+                                          <IconButton
+                                            size="sm"
+                                            color="success"
+                                            variant="plain"
+                                            onClick={() =>
+                                              handleMarkWatchedCombined(
+                                                r.movie.id,
+                                                r.movie.title,
+                                                combinedData.combinedList.connection.user
+                                                  .display_name ||
+                                                  combinedData.combinedList.connection.user
+                                                    .username,
+                                              )
+                                            }
+                                            aria-label={`Mark "${r.movie.title}" as watched together`}
+                                            sx={{
+                                              opacity: 0.5,
+                                              transition: 'opacity 0.15s',
+                                              '&:hover': { opacity: 1 },
+                                            }}
+                                          >
+                                            <span aria-hidden="true">✓</span>
+                                          </IconButton>
+                                        </Tooltip>
+                                      )}
                                     </td>
                                   </tr>
                                 ))


### PR DESCRIPTION
## Summary
- Adds a "Done" (✓) action column to the Combined rankings table so either user in a connection can mark a movie watched together — clearing it from both queues immediately (since `watched_at` is global).
- Loosens `markWatched` authorization: non-owner, non-admin users may mark a movie watched if they have an `accepted` connection with the movie's requester.
- Friend-aware confirm copy: "'{title}' will move to both your and {friend}'s watch history, and disappear from your queues."
- `MARK_WATCHED` mutation also refetches `COMBINED_LIST` while on a combined view so the row vanishes immediately.

## Test plan
- [x] `backend && npx jest` — 273 tests pass (includes new connected-user authz test + updated FORBIDDEN-without-connection case)
- [x] `npm test -- --watchAll=false` — 23 frontend tests pass
- [x] `npx tsc --noEmit` — clean
- [x] Prettier clean
- [ ] Manual: open a Combined view, click ✓, confirm dialog shows friend's name, row disappears from both users' queues
- [ ] Manual: user not connected to the requester gets FORBIDDEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)